### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/1](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` for the workflow or for the `test` job so that the `GITHUB_TOKEN` has only the minimal privileges required. Since this workflow only checks out code and runs Node.js build/test commands without pushing changes, creating releases, or modifying issues/PRs, `contents: read` is sufficient.

The best minimal, non-functional-change fix is:
- Add a top-level `permissions` block right under the `name` (or `on`) key in `.github/workflows/build-and-test.yml`.
- Set `contents: read` so all jobs inherit read-only repository contents access.
- Do not change any steps or add other permissions, since nothing in the provided snippet requires write access or other scopes.

This requires no imports or additional methods; it is purely a YAML configuration change at the top of `.github/workflows/build-and-test.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
