### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/product-research.yml
+++ b/.github/workflows/product-research.yml
@@ -1,5 +1,8 @@
 name: Product Research Pipeline
 
+permissions:
+  contents: read
+
 on:
   # schedule:
     # Run daily at 2 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/2](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/2)

In general, the fix is to define an explicit `permissions` block to restrict the `GITHUB_TOKEN` to the least privileges needed. This can be added at the top level of the workflow (applies to all jobs) or per job. Since both jobs in this workflow only need to read repository contents and interact with artifacts (which do not require broader repo write scopes), we can safely set `contents: read` at the workflow level.

The best minimal fix without changing functionality is to add a workflow-level `permissions` section right after the `name:` line and before the `on:` block:

```yaml
name: Product Research Pipeline

permissions:
  contents: read

on:
  ...
```

This sets `GITHUB_TOKEN` to read-only for repository contents for all jobs (`product-search` and `jules-investigation`). The standard actions used (`checkout`, `setup-node`, artifact upload/download) all work with `contents: read` or do not rely on repository write permissions, so no additional scopes are required based on the provided snippet. No imports or other code changes are needed, only this YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
