### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/affiliate/AffiliateLinkManager.ts
+++ b/src/affiliate/AffiliateLinkManager.ts
@@ -280,14 +280,26 @@ export class AffiliateLinkManager {
     }
 
     /**
+     * ホスト名が指定のマーケットプレイスに該当するかを判定
+     * 完全一致、またはサブドメインとしての一致のみ許可する
+     * 例: "amazon.co.jp" または "www.amazon.co.jp" は OK
+     *     "evil-amazon.co.jp.example.com" は NG
+     */
+    private isMarketplaceHost(hostname: string, domain: AmazonMarketplace): boolean {
+        const lowerHost = hostname.toLowerCase();
+        const lowerDomain = domain.toLowerCase();
+        return lowerHost === lowerDomain || lowerHost.endsWith('.' + lowerDomain);
+    }
+
+    /**
      * ホスト名からマーケットプレイスを特定
      */
     private identifyMarketplace(hostname: string): AmazonMarketplace {
-        if (hostname.includes('amazon.co.jp')) return 'amazon.co.jp';
-        if (hostname.includes('amazon.com')) return 'amazon.com';
-        if (hostname.includes('amazon.co.uk')) return 'amazon.co.uk';
-        if (hostname.includes('amazon.de')) return 'amazon.de';
-        if (hostname.includes('amazon.fr')) return 'amazon.fr';
+        if (this.isMarketplaceHost(hostname, 'amazon.co.jp')) return 'amazon.co.jp';
+        if (this.isMarketplaceHost(hostname, 'amazon.com')) return 'amazon.com';
+        if (this.isMarketplaceHost(hostname, 'amazon.co.uk')) return 'amazon.co.uk';
+        if (this.isMarketplaceHost(hostname, 'amazon.de')) return 'amazon.de';
+        if (this.isMarketplaceHost(hostname, 'amazon.fr')) return 'amazon.fr';
         return 'amazon.co.jp'; // デフォルト
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/4](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/4)

In general, this kind of problem is fixed by avoiding substring checks on hostnames and instead performing exact or carefully bounded comparisons on parsed host values. Instead of `hostname.includes('amazon.com')`, we should either (a) compare for equality with the expected host, or (b) allow specific subdomains via suffix checks that enforce a dot boundary before the expected domain.

The single best minimal-change fix here is to replace each `includes` call with an exact comparison to the expected marketplace host, since the codebase already defines the set of valid marketplaces precisely (`'amazon.co.jp'`, `'amazon.com'`, `'amazon.co.uk'`, `'amazon.de'`, `'amazon.fr'`). If subdomains such as `www.amazon.com` must be supported, we can perform a suffix check that ensures the hostname is either exactly the domain or ends with `.` + domain. To keep functionality flexible while still secure, we can implement such a bounded suffix check once and reuse it.

Concretely, in `src/affiliate/AffiliateLinkManager.ts` inside `identifyMarketplace`, we will:  
1. Add a small private helper method `isMarketplaceHost(hostname: string, domain: AmazonMarketplace): boolean` just above `identifyMarketplace`. This method will normalize the hostname to lower case and then return true if the hostname is exactly `domain` or ends with `.` + `domain`.  
2. Rewrite the `if (hostname.includes(...))` lines to call `this.isMarketplaceHost(hostname, 'amazon.co.jp')`, etc.  

No external libraries are needed; we rely only on standard string operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
