### PR TITLE
Potential fix for code scanning alert no. 6: Insecure randomness

### DIFF
--- a/src/search/ProductSearcher.ts
+++ b/src/search/ProductSearcher.ts
@@ -5,6 +5,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import crypto from 'crypto';
 import { PAAPIClient } from '../api/PAAPIClient';
 import { ConfigManager } from '../config/ConfigManager';
 import {
@@ -382,7 +383,8 @@ export class ProductSearcher {
 
   private generateSessionId(): string {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const random = Math.random().toString(36).substring(2, 8);
+    // Use cryptographically secure random bytes for the session suffix
+    const random = crypto.randomBytes(4).toString('hex');
     return `${timestamp}_${random}`;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/6](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/6)

In general, to fix insecure randomness you must replace uses of `Math.random()` (or similar weak PRNGs) in any security‑sensitive context with a cryptographically secure source, such as Node’s `crypto.randomBytes` or browser `crypto.getRandomValues`. When generating identifiers as strings, use secure bytes and encode them (hex, base64, or base36) instead of relying on `Math.random()`.

For this specific case, the best fix is to update `generateSessionId()` to derive its random suffix from Node’s `crypto` module instead of `Math.random()`. We can import `randomBytes` from the built‑in `crypto` module and use it to generate a small buffer of random bytes, then encode them into a compact string. This preserves the existing interface (still returns a string of the form `<timestamp>_<random>`) and behavior (timestamp + short random token) while making the random part cryptographically secure. Concretely:
- Add an import for `crypto` (or `randomBytes`) at the top of `src/search/ProductSearcher.ts`, without altering existing imports.
- Replace the body of `generateSessionId()` so that:
  - It still computes the timestamp as before.
  - It uses `randomBytes(4)` (or similar) and converts it to a base‑36 string to keep it short, trimming/padding if needed, instead of using `Math.random()`.

No other files or methods need to change, and all call sites continue to work as before.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
