### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/category-dropdown.js
+++ b/static/js/category-dropdown.js
@@ -186,6 +186,19 @@
         }
     }
 
+    function safeNavigate(url) {
+        if (!url) return;
+        try {
+            const targetUrl = new URL(url, window.location.origin);
+            if (targetUrl.origin === window.location.origin &&
+                (targetUrl.protocol === 'http:' || targetUrl.protocol === 'https:')) {
+                window.location.href = targetUrl.toString();
+            }
+        } catch (e) {
+            // Invalid URL; do not navigate
+        }
+    }
+
     function handleSubChange(e) {
         if (e.target.id !== 'category-sub-select') return;
 
@@ -198,12 +211,12 @@
             // Build parent category URL
             const basePathMatch = window.location.pathname.match(/^(\/[^/]+\/)?/);
             const basePath = basePathMatch ? basePathMatch[0] : '/';
-            window.location.href = `${basePath}parent-category/${slug}/`;
+            safeNavigate(`${basePath}parent-category/${slug}/`);
             return;
         }
 
         if (selectedCategory && urls[selectedCategory]) {
-            window.location.href = urls[selectedCategory];
+            safeNavigate(urls[selectedCategory]);
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/9](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/9)

In general, to fix this problem you either (1) ensure that the tainted data (`urlDataScript.textContent`) is never attacker-controlled, or (2) treat it as untrusted and validate/sanitize it before using it in a sensitive sink. Here the sink is `window.location.href`, so the safest approach is to validate that the URL we navigate to is of an expected form (e.g., same-origin relative path, or an allowed absolute URL scheme/host), and reject or neutralize anything else. This removes the risk of an attacker injecting a `javascript:` URL or an arbitrary external URL via the JSON payload.

The best way to fix this without changing the observable functionality is:

1. Introduce a small helper function, e.g. `safeNavigate(url)`, inside `static/js/category-dropdown.js`.
2. In `safeNavigate`, construct a `URL` object from the candidate URL and the current page’s origin (`window.location.origin`) so that relative URLs are resolved correctly.
3. Check that:
   - The scheme is `http:` or `https:`, and
   - The origin (protocol + host + port) matches `window.location.origin` (assuming navigation is intended to stay on the same site).  
   If you want to allow same-origin paths only (which fits this use case), this is sufficient.
4. Only if the URL passes validation, assign it to `window.location.href`; otherwise, either do nothing or fall back to a safe default (here, we’ll just `return` early to avoid navigation).

Then, replace the direct `window.location.href = ...` assignments in `handleSubChange` with calls to `safeNavigate(...)`. This confines navigation to safe URLs while keeping behavior unchanged for valid data.

Concretely:

- Add `function safeNavigate(url) { ... }` somewhere above `handleSubChange` in `static/js/category-dropdown.js`.
- At line 201, change `window.location.href = ...` to `safeNavigate(...)`.
- At line 206, change `window.location.href = urls[selectedCategory];` to `safeNavigate(urls[selectedCategory]);`.

No external libraries are required; we can use the standard `URL` API available in modern browsers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
