### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/category-dropdown.js
+++ b/static/js/category-dropdown.js
@@ -97,6 +97,23 @@
         return categoryUrls;
     }
 
+    function safeCategoryUrl(rawUrl) {
+        if (!rawUrl || typeof rawUrl !== 'string') {
+            return '#';
+        }
+        try {
+            var parsed = new URL(rawUrl, window.location.origin);
+            // Allow only HTTP(S) URLs and enforce same-origin paths
+            if ((parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+                parsed.origin === window.location.origin) {
+                return parsed.href;
+            }
+        } catch (e) {
+            // fall through to safe default
+        }
+        return '#';
+    }
+
     function getFilteredGroups() {
         if (Object.keys(filteredGroups).length === 0) {
             const urls = getCategoryUrls();
@@ -271,7 +288,7 @@
 
             categories.forEach(category => {
                 const tag = document.createElement('a');
-                tag.href = urls[category];
+                tag.href = safeCategoryUrl(urls[category]);
                 tag.className = 'category-tag-link';
                 tag.textContent = category;
                 tagsContainer.appendChild(tag);


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/10](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/10)

In general, the fix is to treat the values loaded from `#category-url-data` as untrusted and validate/sanitize them before assigning them to `tag.href`. The main risk is not HTML re‑interpretation but allowing arbitrary URL schemes such as `javascript:`, `data:`, or external domains when only same‑origin HTTP(S) paths are expected. The safest approach is to implement a small helper (within this file) that parses a URL and only returns it if it uses an allowed scheme and, optionally, same origin; otherwise it falls back to a safe default (e.g., `'#'`).

Concretely, within `static/js/category-dropdown.js`:

1. Add a helper function, e.g. `safeCategoryUrl(url)`, near the other helper functions. This function should:
   - Return `'#'` if the input is falsy or not a string.
   - Use the `URL` constructor with `window.location.origin` as base to parse the URL.
   - Check that the resulting protocol is `http:` or `https:`.
   - Optionally, enforce `parsed.origin === window.location.origin` if you only want same‑origin URLs.
   - On any parsing error, return `'#'`.

2. Update the line where `tag.href` is set (line 274) to use this sanitization function: `tag.href = safeCategoryUrl(urls[category]);`.

No external dependencies are required; we use the standard `URL` API, which is widely supported in modern browsers. Existing functionality is preserved for valid, expected URLs, while unsafe or malformed values are neutralized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
