### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/src/article/ArticleGenerator.ts
+++ b/src/article/ArticleGenerator.ts
@@ -620,9 +620,23 @@ export class ArticleGenerator {
     const sourcesList = validSources
       .map(source => {
         const credibility = source.credibility ? ` (${source.credibility})` : '';
-        const paapiBaseUrl = 'https://webservices.amazon.co.jp/paapi5';
+        const paapiHost = 'webservices.amazon.co.jp';
+        const paapiPathPrefix = '/paapi5';
 
-        if (source.url && !source.url.includes(paapiBaseUrl)) {
+        const isPaapiUrl = (urlString: string): boolean => {
+          try {
+            const parsed = new URL(urlString);
+            return (
+              parsed.hostname === paapiHost &&
+              parsed.pathname.startsWith(paapiPathPrefix)
+            );
+          } catch {
+            // URLとして解釈できない場合はPAAPIとはみなさない（従来動作に近づける）
+            return false;
+          }
+        };
+
+        if (source.url && !isPaapiUrl(source.url)) {
           return `- [${source.name}](${source.url})${credibility}`;
         }
         return `- ${source.name}${credibility}`;


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/12](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/12)

In general, the fix is to avoid substring checks on the whole URL string and instead parse the URL, then compare the relevant structured parts (host, pathname) to a whitelist or exact value. This ensures that `https://webservices.amazon.co.jp/paapi5` is recognized only when it is actually the origin/path of the URL, not merely present anywhere in the string.

For this specific case, we want to detect URLs that point to the PAAPI endpoint so we can suppress links for them. The best way to do this without changing existing functionality is:

1. Parse `source.url` using the standard `URL` class.
2. Check that:
   - `url.hostname` exactly matches `webservices.amazon.co.jp`, and
   - `url.pathname` starts with `/paapi5`.
3. Treat parsing failures (invalid URLs) conservatively as non‑PAAPI (or as non‑linkable, but that would be a larger behavior change). To preserve current behavior as closely as possible, we should only suppress links when we are confident it is a PAAPI URL; if parsing fails, fall back to allowing the link.

Concretely, in `src/article/ArticleGenerator.ts`, within `generateSourcesSection`, we will:

- Replace `const paapiBaseUrl = 'https://webservices.amazon.co.jp/paapi5';` with a host and path prefix constant, e.g. `PAAPI_HOST` and `PAAPI_PATH_PREFIX`.
- Replace `source.url.includes(paapiBaseUrl)` with a small helper that:
  - Attempts `new URL(source.url)`;
  - Returns `true` if `hostname` and `pathname` match the PAAPI patterns; otherwise `false`.
- Implement that helper as a local function inside `generateSourcesSection` so we don’t modify other file regions or imports.

This keeps behavior aligned with the original intent (“don’t link PAAPI URLs”) while avoiding incomplete substring sanitization.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
