### PR TITLE
Potential fix for code scanning alert no. 15: Incomplete string escaping or encoding

### DIFF
--- a/src/article/ArticleGenerator.ts
+++ b/src/article/ArticleGenerator.ts
@@ -1134,6 +1134,12 @@ ${score >= 80 ? '自信を持っておすすめできる商品です。' :
   /**
    * フロントマターを生成
    */
+  private escapeForFrontMatter(value: string): string {
+    return value
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+  }
+
   private generateFrontMatter(metadata: ArticleMetadata): string {
     const lines = [
       '---',
@@ -1312,21 +1318,21 @@ ${score >= 80 ? '自信を持っておすすめできる商品です。' :
         if (metadata.hero.score_rationale.top_plus) {
           lines.push('    top_plus:');
           lines.push(`      points: ${metadata.hero.score_rationale.top_plus.points}`);
-          lines.push(`      desc: "${metadata.hero.score_rationale.top_plus.desc.replace(/"/g, '\\"')}"`);
+          lines.push(`      desc: "${this.escapeForFrontMatter(metadata.hero.score_rationale.top_plus.desc)}"`);
         }
         if (metadata.hero.score_rationale.top_minus) {
           lines.push('    top_minus:');
           lines.push(`      points: ${metadata.hero.score_rationale.top_minus.points}`);
-          lines.push(`      desc: "${metadata.hero.score_rationale.top_minus.desc.replace(/"/g, '\\"')}"`);
+          lines.push(`      desc: "${this.escapeForFrontMatter(metadata.hero.score_rationale.top_minus.desc)}"`);
         }
       }
 
       if (metadata.hero.target_users && metadata.hero.target_users.length > 0) {
-        lines.push(`  target_users: [${metadata.hero.target_users.map(u => `"${u.replace(/"/g, '\\"')}"`).join(', ')}]`);
+        lines.push(`  target_users: [${metadata.hero.target_users.map(u => `"${this.escapeForFrontMatter(u)}"`).join(', ')}]`);
       }
 
       if (metadata.hero.warnings && metadata.hero.warnings.length > 0) {
-        lines.push(`  warnings: [${metadata.hero.warnings.map(w => `"${w.replace(/"/g, '\\"')}"`).join(', ')}]`);
+        lines.push(`  warnings: [${metadata.hero.warnings.map(w => `"${this.escapeForFrontMatter(w)}"`).join(', ')}]`);
       }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/15](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/15)

In general, the problem should be fixed by centralizing string escaping into a helper that consistently escapes all characters that are significant in the target format, instead of ad-hoc `.replace` calls. For double-quoted YAML/JSON-like strings, the minimum is to escape backslashes (`\` → `\\`) and double quotes (`"` → `\"`) in that order, so pre-existing backslashes cannot alter how subsequent characters (including quotes) are parsed.

For this file, the best fix without changing functionality is:

1. Add a small helper method inside `ArticleGenerator` (or near `generateFrontMatter`) such as `private escapeForFrontMatter(value: string): string` that:
   - First replaces all backslashes: `value.replace(/\\/g, '\\\\')`
   - Then replaces all double quotes: `.replace(/"/g, '\\"')`
2. Replace the inline `.replace(/"/g, '\\"')` calls in `generateFrontMatter` with calls to this helper.
   - Line 1315: wrap `metadata.hero.score_rationale.top_plus.desc` with the helper.
   - Line 1320: same for `top_minus.desc`.
   - Line 1325: in the `target_users` mapping, call the helper on `u` instead of directly calling `.replace(/"/g, '\\"')`.
   - Line 1329: in the `warnings` mapping, call the helper on `w` instead of the inline replace.
3. No new imports are required; we use only built-in string methods.

This preserves current behavior with respect to quotes while adding correct handling of backslashes across all relevant fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
