### PR TITLE
Enable auto-merge for PRs from aegisfleet

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   auto-merge:
     # JulesボットまたはJules関連のユーザーからのPRのみ処理
-    if: github.actor == 'jules[bot]' || contains(github.actor, 'jules')
+    if: github.actor == 'jules[bot]' || contains(github.actor, 'jules') || github.actor == 'aegisfleet'
     runs-on: ubuntu-latest
 
     permissions:

--- a/src/github/AutoMergeManager.ts
+++ b/src/github/AutoMergeManager.ts
@@ -108,7 +108,8 @@ export class AutoMergeManager {
     verifyJulesAuthor(pr: PullRequest): boolean {
         const isJules = pr.author === this.conditions.requiredAuthor ||
             pr.author.toLowerCase().includes('jules') ||
-            pr.author === 'jules[bot]';
+            pr.author === 'jules[bot]' ||
+            pr.author === 'aegisfleet';
 
         if (isJules) {
             this.logger.info(`PR author ${pr.author} is verified as Jules`);

--- a/src/github/__tests__/AutoMergeManager.test.ts
+++ b/src/github/__tests__/AutoMergeManager.test.ts
@@ -1,0 +1,45 @@
+import { AutoMergeManager } from '../AutoMergeManager';
+import { PullRequest } from '../../types/GitHubTypes';
+
+describe('AutoMergeManager', () => {
+    let autoMergeManager: AutoMergeManager;
+
+    beforeEach(() => {
+        autoMergeManager = new AutoMergeManager();
+    });
+
+    const createMockPr = (author: string): PullRequest => ({
+        number: 1,
+        title: 'Test PR',
+        body: 'Test Body',
+        head: 'feature-branch',
+        base: 'main',
+        author: author,
+        state: 'open',
+        draft: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        labels: [],
+        changedFiles: ['data/test.json']
+    });
+
+    test('verifyJulesAuthor should return true for jules[bot]', () => {
+        const pr = createMockPr('jules[bot]');
+        expect(autoMergeManager.verifyJulesAuthor(pr)).toBe(true);
+    });
+
+    test('verifyJulesAuthor should return true for author containing jules', () => {
+        const pr = createMockPr('some-jules-user');
+        expect(autoMergeManager.verifyJulesAuthor(pr)).toBe(true);
+    });
+
+    test('verifyJulesAuthor should return true for aegisfleet', () => {
+        const pr = createMockPr('aegisfleet');
+        expect(autoMergeManager.verifyJulesAuthor(pr)).toBe(true);
+    });
+
+    test('verifyJulesAuthor should return false for other authors', () => {
+        const pr = createMockPr('random-user');
+        expect(autoMergeManager.verifyJulesAuthor(pr)).toBe(false);
+    });
+});


### PR DESCRIPTION
Updated the auto-merge workflow and AutoMergeManager to include 'aegisfleet' as an authorized author for automatic merging. Added unit tests for AutoMergeManager.

---
*PR created automatically by Jules for task [3530917650256574953](https://jules.google.com/task/3530917650256574953) started by @aegisfleet*