### PR TITLE
Add investigation for Crucial X9 SSD 2TB

### DIFF
--- a/data/investigations/B0CGW18S6Y.json
+++ b/data/investigations/B0CGW18S6Y.json
@@ -1,0 +1,135 @@
+{
+  "analysis": {
+    "productName": "Crucial X9 外付け SSD 2TB",
+    "parentAsin": "B0DKNC4YKG",
+    "productDescription": "手のひらに収まる65mm角の超小型ボディに、最大1050MB/秒の高速転送性能を凝縮したポータブルSSD。持ち運びのストレスを最小限に抑えつつ、大容量データの高速処理を実現します。",
+    "productUsage": [
+      "PC/Macのストレージ容量拡張とバックアップ",
+      "PS5/PS4やXboxのゲームデータ保存・ロード時間短縮",
+      "iPad ProやAndroid端末でのデータ持ち運び"
+    ],
+    "positivePoints": [
+      "圧倒的なコンパクトサイズ（65 x 50 mm）で携帯性が抜群",
+      "最大1050MB/秒の高速読み込みで、大容量ファイルも快適に扱える",
+      "SanDiskなどの競合ハイエンドモデルと比較して安価",
+      "USB-C to Cケーブルが付属し、最近のデバイスとすぐに接続可能"
+    ],
+    "negativePoints": [
+      "保証期間が3年と、競合（SanDisk Extreme等は5年）に比べて短い",
+      "防水・防塵性能（IP等級）の記載がなく、アウトドアでの使用には注意が必要（上位モデルX9 Proとの差別化点）",
+      "付属ケーブルが短いため、デスクトップPCの背面ポート等への接続には不便な場合がある"
+    ],
+    "useCases": [
+      "カフェや出張先で作業するノマドワーカーのデータ持ち運び",
+      "容量不足に悩むノートPCユーザーの常時接続用ストレージ",
+      "ゲームコンソールのロード時間短縮とライブラリ拡張"
+    ],
+    "userStories": [
+      {
+        "userType": "30代フリーランスフォトグラファー",
+        "scenario": "出先での写真編集データのバックアップ",
+        "experience": "以前使っていたHDDとは比べ物にならない転送速度で、撮影後のデータ退避があっという間に終わる。何よりポケットに入れても存在を感じさせないサイズ感が最高。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "大学生",
+        "scenario": "MacBook Airの容量拡張",
+        "experience": "MacBookのストレージが一杯になったので購入。本体が小さいのでカフェの狭いテーブルでも邪魔にならず、動画編集の素材置き場として重宝している。（推測）",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "「小ささは正義」を体現したモデル。上位モデルのProと比較すると保証や耐久性スペックで劣るものの、日常的な屋内使用や持ち運びには十分すぎる性能と携帯性を備えており、コストパフォーマンスに優れた選択肢として評価されるだろう。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B0CGW18S6Y",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-27",
+    "competitiveAnalysis": [
+      {
+        "name": "SanDisk Extreme Portable SSD V2 2TB",
+        "asin": "B08P45YTTL",
+        "priceComparison": "約35,800円（Crucial X9より約6,000円高い）",
+        "featureComparison": [
+          "最大1050MB/秒（同等）",
+          "IP55防滴防塵対応",
+          "5年保証"
+        ],
+        "differentiators": [
+          "高い耐久性と長い保証期間",
+          "カラビナホール一体型のデザイン"
+        ]
+      },
+      {
+        "name": "WD Elements SE SSD 2TB",
+        "asin": "B097TSN41S",
+        "priceComparison": "約26,000円（Crucial X9より約4,000円安い）",
+        "featureComparison": [
+          "最大400MB/秒（X9の半分以下の速度）",
+          "3年保証"
+        ],
+        "differentiators": [
+          "価格の安さ",
+          "速度はSATA SSD並みで遅い"
+        ]
+      },
+      {
+        "name": "Buffalo SSD-SCT2.0U3BA/N",
+        "asin": "B099214J49",
+        "priceComparison": "約29,500円（同等）",
+        "featureComparison": [
+          "最大600MB/秒",
+          "ケーブルレスのスティック型"
+        ],
+        "differentiators": [
+          "ケーブル不要でPCに直挿し可能",
+          "速度はX9より遅い"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "携帯性を最優先するノートPCユーザー",
+        "高速な外付けストレージを安価に手に入れたいユーザー",
+        "iPadやスマホとデータをやり取りしたい人"
+      ],
+      "pros": [
+        "市場最小クラスのコンパクトボディ",
+        "1050MB/sの高速転送による快適なレスポンス",
+        "1GBあたり約15円という良好なコストパフォーマンス"
+      ],
+      "cons": [
+        "過酷な環境（水濡れ、粉塵）での使用には向かない",
+        "長期保証を求めるなら他社製品や上位モデルが良い"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[性能: +5] (USB 3.2 Gen2対応で1050MB/sの高速転送、実用性十分)\n[コストパフォーマンス: +5] (競合のSanDiskより安く、性能は同等でコスパ良好)\n[独自性: +5] (65x50mmという極小サイズは他社にない強み)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "interface": "USB 3.2 Gen 2 (10Gbps)",
+      "capacity": "2TB",
+      "maxReadSpeed": "1050 MB/s",
+      "dimensions": {
+        "width": "50mm",
+        "height": "65mm",
+        "depth": "10mm",
+        "weight": "32g"
+      },
+      "compatibility": [
+        "Windows",
+        "Mac",
+        "Android",
+        "iPad Pro",
+        "PS4/PS5",
+        "Xbox"
+      ],
+      "warranty": "3年間",
+      "included": [
+        "USB Type-C to Cケーブル",
+        "クイックスタートガイド"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added investigation data for Crucial X9 Portable SSD 2TB (B0CGW18S6Y).
Data includes product overview, competitive analysis against SanDisk, WD, and Buffalo, and a recommendation score based on the standardized rubric.
Information was gathered using PA-API and inferred from product specifications due to limited external review access.

---
*PR created automatically by Jules for task [8246445084594173102](https://jules.google.com/task/8246445084594173102) started by @aegisfleet*