### PR TITLE
Add investigation for B08P4CN4YC (SanDisk Extreme Portable SSD V2)

### DIFF
--- a/data/investigations/B08P4CN4YC.json
+++ b/data/investigations/B08P4CN4YC.json
@@ -1,0 +1,125 @@
+{
+  "analysis": {
+    "productName": "SanDisk Extreme Portable SSD V2 1TB (SDSSDE61)",
+    "parentAsin": "B0CL8HSYF3",
+    "productDescription": "最大読出し1050MB/秒の高速転送とIP65防滴・防塵性能を備えた、プロフェッショナル向けポータブルSSD。",
+    "productUsage": [
+      "写真や動画の高速バックアップ・編集作業",
+      "Win/Mac/PS4/PS5/iPhone 15シリーズへのデータ保存",
+      "外出先や過酷な環境でのデータ持ち運び"
+    ],
+    "positivePoints": [
+      "最大1050MB/秒の高速読出し速度により大容量ファイルの転送がスムーズ。",
+      "IP65の防滴・防塵性能と最大3mからの落下に耐える高耐久設計。",
+      "カラビナを通せるホールがあり、持ち運びに便利。",
+      "AES 256ビットハードウェア暗号化によるパスワード保護対応。",
+      "iPhone 15 ProのProRes動画直接録画に対応。"
+    ],
+    "negativePoints": [
+      "付属のUSBケーブルが短い場合があり、デスクトップPC接続時に不便を感じることがある。",
+      "長時間の高速転送時に本体が熱を持つことがある（SSDの一般的特性）。",
+      "過去のファームウェア問題に関する報道があったため、使用前に最新ファームウェアの確認が推奨される。"
+    ],
+    "useCases": [
+      "フォトグラファーやビデオグラファーのロケ撮影データのバックアップ",
+      "PS5やXbox Series X/Sのゲームデータの保存・持ち運び",
+      "ビジネスデータの安全な持ち運び（暗号化機能活用）"
+    ],
+    "userStories": [
+      {
+        "userType": "30代フォトグラファー",
+        "scenario": "ロケ先での撮影データのバックアップに使用",
+        "experience": "IP65防水防塵なので、屋外でも安心して使えるのが心強い。転送速度も速く、作業効率が上がった。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "40代動画クリエイター",
+        "scenario": "4K動画編集の素材置き場として活用",
+        "experience": "内蔵SSDと遜色ない速度で編集でき、コンパクトなので持ち運びも苦にならない。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "高速転送と高い耐久性を兼ね備え、多くのクリエイターから支持されている。特に屋外での使用や持ち運びが多いユーザーにとって、防滴・防塵性能と耐衝撃性は大きな安心材料となっている。",
+    "sources": [
+      {
+        "name": "SanDisk公式サイト",
+        "url": "https://www.westerndigital.com/ja-jp/products/portable-drives/sandisk-extreme-usb-3-2-ssd",
+        "credibility": "公式情報"
+      }
+    ],
+    "lastInvestigated": "2026-01-27",
+    "competitiveAnalysis": [
+      {
+        "name": "Samsung T7 Shield",
+        "asin": "B0BSQSNKYF",
+        "priceComparison": "同価格帯だが、セール時はSamsungの方が安くなる傾向がある。",
+        "featureComparison": [
+          "SanDiskと同様にIP65防滴防塵に対応。",
+          "ラバー素材のボディで衝撃吸収性が高い。"
+        ],
+        "differentiators": [
+          "SanDiskの方がスリムで軽量。",
+          "Samsung T7 Shieldはより厚みがあり、堅牢性が高い印象。"
+        ]
+      },
+      {
+        "name": "Crucial X9 Pro",
+        "asin": "B0CGW18S6Y",
+        "priceComparison": "SanDiskと比較して若干安価な場合が多い。",
+        "featureComparison": [
+          "IP55防滴防塵（SanDiskはIP65）。",
+          "非常にコンパクトなサイズ。"
+        ],
+        "differentiators": [
+          "Crucialの方が一回り小さく、携帯性に優れる。",
+          "SanDiskはIP65等級で防塵性能が高い（CrucialはIP55）。"
+        ]
+      },
+      {
+        "name": "Buffalo SSD-PHE",
+        "asin": "B093H3PRRP",
+        "priceComparison": "SanDiskよりも高価なハイエンドモデル。",
+        "featureComparison": [
+          "USB 3.2 Gen 2x2対応で最大2000MB/秒の転送速度。",
+          "IP55防滴防塵。"
+        ],
+        "differentiators": [
+          "Buffaloの方が転送速度が速い（Gen 2x2環境が必要）。",
+          "SanDiskは汎用性の高いUSB 3.2 Gen 2でのバランスが良い。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "高速転送と堅牢性を重視するクリエイター",
+        "屋外での撮影やデータ持ち運びが多いユーザー",
+        "PS5/PS4のストレージ拡張を検討しているゲーマー"
+      ],
+      "pros": [
+        "最大1050MB/秒の高速転送",
+        "IP65防滴防塵の高耐久仕様",
+        "コンパクトでカラビナホール付きのデザイン"
+      ],
+      "cons": [
+        "長時間の使用で熱を持つ場合がある",
+        "最新ファームウェアの確認が必要"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (最大1050MB/秒の高速転送とIP65防滴防塵の実用性)\n[加点: +5] (コンパクトで持ち運びに適したデザインとカラビナホール)\n[減点: 0] (価格は標準的だが、競合と比較しても妥当な範囲)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "interface": "USB 3.2 Gen 2",
+      "speed": "読出し1050MB/秒, 書込み1000MB/秒",
+      "capacity": "1TB",
+      "durability": "IP65, 最大3mからの落下耐性",
+      "dimensions": {
+        "height": "100.54mm",
+        "width": "52.42mm",
+        "depth": "8.95mm",
+        "weight": "52g"
+      },
+      "warranty": "5年間",
+      "security": "AES 256ビットハードウェア暗号化"
+    }
+  }
+}


### PR DESCRIPTION
Added investigation data for SanDisk Extreme Portable SSD V2 1TB, including product details, competitor analysis, and scoring.

---
*PR created automatically by Jules for task [15204480041235942831](https://jules.google.com/task/15204480041235942831) started by @aegisfleet*