### PR TITLE
Add investigation data for B0BX98V578

### DIFF
--- a/data/investigations/B0BX98V578.json
+++ b/data/investigations/B0BX98V578.json
@@ -1,0 +1,126 @@
+{
+  "analysis": {
+    "productName": "LINSOUL KZ ZVX 1DDインナーイヤーイヤホン",
+    "parentAsin": "B0BX986HXV",
+    "productDescription": "10mm複合磁気ダイナミックドライバーを搭載し、亜鉛合金製の金属筐体を採用した、低価格ながら高級感のある中華イヤホン。",
+    "productUsage": [
+      "スマートフォンやDAPでの音楽鑑賞",
+      "リケーブルによる音質のカスタマイズ",
+      "PCでのゲームや動画視聴"
+    ],
+    "positivePoints": [
+      "価格を超えた高級感のある金属筐体（亜鉛合金製）",
+      "リケーブル対応で好みのケーブルに交換可能",
+      "パワフルな重低音とクリアなボーカル",
+      "人間工学に基づいたフィット感の良い形状",
+      "スマートフォンでも鳴らしやすい低インピーダンス設計"
+    ],
+    "negativePoints": [
+      "金属筐体のため冬場は装着時に冷たく感じる",
+      "高音が人によっては刺さると感じることがある",
+      "付属ケーブルの質は簡易的なもので、タッチノイズが気になる場合がある"
+    ],
+    "useCases": [
+      "通勤・通学時のリスニング",
+      "初めてのリケーブル対応イヤホンとして",
+      "手軽に持ち運べるサブ機として"
+    ],
+    "userStories": [
+      {
+        "userType": "20代学生",
+        "scenario": "通学中の電車内",
+        "experience": "スマホ直挿しで使用しているが、以前使っていた付属イヤホンとは比べ物にならないほど音が良く、遮音性も高いので音楽に没頭できる。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "30代会社員",
+        "scenario": "デスクワーク中のBGM",
+        "experience": "金属製の質感が素晴らしく、デスクに置いているだけでも様になる。音質も元気があり、仕事の合間の気分転換に最適。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "1000円台という価格からは信じられないほどのビルドクオリティと、KZらしい元気なドンシャリサウンドで、コスパ最強の一角として高く評価されている。",
+    "sources": [
+      {
+        "name": "Amazon.co.jp 商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0BX98V578",
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-27",
+    "competitiveAnalysis": [
+      {
+        "name": "KZ EDX Lite",
+        "asin": "B0D87LKTXN",
+        "priceComparison": "ZVXよりさらに安価（約100円〜200円差）",
+        "featureComparison": [
+          "樹脂製筐体で軽量",
+          "同じく1DD構成",
+          "リケーブル対応"
+        ],
+        "differentiators": [
+          "ZVXは金属筐体で高級感があるのに対し、EDX Liteはプラスチックでチープさがある",
+          "音質はZVXの方が解像感が高い傾向"
+        ]
+      },
+      {
+        "name": "KZ EDX Pro",
+        "asin": "B09F34DKQP",
+        "priceComparison": "ZVXより数百円高い場合が多い",
+        "featureComparison": [
+          "KZの定番エントリーモデル",
+          "樹脂製筐体に金属プレート",
+          "強力なドンシャリサウンド"
+        ],
+        "differentiators": [
+          "ZVXの方が筐体全体の剛性が高く、音の響きが引き締まっている",
+          "EDX Proの方が低音の量がより多い"
+        ]
+      },
+      {
+        "name": "KBEAR Flash",
+        "asin": "B0D45L71V8",
+        "priceComparison": "ZVXより数百円高い（約1,449円）",
+        "featureComparison": [
+          "1DD+1BAのハイブリッド構成",
+          "合金製カバー",
+          "リケーブル対応"
+        ],
+        "differentiators": [
+          "KBEAR Flashはハイブリッド構成で高域の煌びやかさが特徴",
+          "ZVXはシングルダイナミックならではの自然な繋がりがある"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "コストパフォーマンスを最優先する人",
+        "金属筐体の質感が好きな人",
+        "リケーブルを試してみたいイヤホン初心者"
+      ],
+      "pros": [
+        "圧倒的なコストパフォーマンス",
+        "価格破壊級のビルドクオリティ（金属筐体）",
+        "楽しく聴けるドンシャリサウンド"
+      ],
+      "cons": [
+        "冬場の装着時の冷たさ",
+        "リケーブル沼への入り口となる危険性"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +15] (1000円台前半で金属筐体かつリケーブル可能という圧倒的なコストパフォーマンス)\n[加点: +5] (ビルドクオリティが高く、デザインもシンプルで良い)\n[減点: -5] (高域の粗さや付属ケーブルの質など、価格なりの妥協点は存在する)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "driver": "10mm 複合磁気ダイナミックドライバー",
+      "codec": null,
+      "battery": null,
+      "connectivity": [
+        "3.5mmプラグ",
+        "0.75mm 2pin リケーブル対応"
+      ],
+      "noiseCancel": "パッシブノイズキャンセリング（遮音性）",
+      "impedance": "35Ω",
+      "sensitivity": "95dB"
+    }
+  }
+}


### PR DESCRIPTION
Added detailed market analysis and product investigation for LINSOUL KZ ZVX earphones (ASIN: B0BX98V578). Includes competitive analysis, user stories, and technical specifications.

---
*PR created automatically by Jules for task [1067320669078322968](https://jules.google.com/task/1067320669078322968) started by @aegisfleet*