### PR TITLE
Add investigation data for TANGZU Wan'er S.G 2

### DIFF
--- a/data/investigations/B0FDJXTC7K.json
+++ b/data/investigations/B0FDJXTC7K.json
@@ -1,0 +1,121 @@
+{
+  "analysis": {
+    "productName": "TANGZU Wan'er S.G 2",
+    "parentAsin": "B0FDWC9MRC",
+    "productDescription": "コストパフォーマンス最強と謳われた名機「Wan'er S.G」の正統進化モデル。ドライバーの改良による音質向上に加え、高級イヤーピース「Tang Sancai」を標準付属するなど、付属品も大幅にグレードアップしています。",
+    "productUsage": [
+      "高音質な音楽鑑賞（特にボーカル曲）",
+      "FPSなどのゲーミング用途（正確な定位感）",
+      "初めてのIEM（インイヤーモニター）としての入門機",
+      "外出時のリスニング（絡まりにくいケーブル）"
+    ],
+    "positivePoints": [
+      "名機をベースに改良された10mm PETダイヤフラムドライバーによるクリアなサウンド",
+      "単体で購入すると高価な「Tang Sancai」イヤーピースが標準付属する破格のコストパフォーマンス",
+      "取り回しが良く絡まりにくい、アップグレードされた銀メッキOFCケーブル",
+      "人間工学に基づいた疲れにくい装着感と美しいフェイスプレートデザイン"
+    ],
+    "negativePoints": [
+      "競合機種（Moondrop Chu IIなど）と比較すると筐体がプラスチック製であり、質感で劣る場合がある",
+      "発売直後のため、長期的な耐久性に関するユーザーレビューがまだ少ない"
+    ],
+    "useCases": [
+      "通勤・通学時の音楽リスニング",
+      "PCやスマートフォンでのゲームプレイ",
+      "カフェなどでの作業用BGM再生"
+    ],
+    "userStories": [
+      {
+        "userType": "オーディオ初心者（学生）",
+        "scenario": "初めての本格的な有線イヤホン選び",
+        "experience": "スマホ付属のイヤホンから卒業したくて購入。3000円台とは思えないほど音がクリアで、特に女性ボーカルが綺麗に聞こえる。付属のイヤーピースがカラフルで可愛く、装着感も抜群だった。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "初代Wan'er S.Gユーザー",
+        "scenario": "サブ機の買い替え",
+        "experience": "初代を持っていたが、ケーブルの質感がチープだったのが不満だった。このS.G 2はケーブルが大幅に改善されており、絡まりにくくて使いやすい。音質も低域の解像度が上がっているように感じる。（推測）",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "「価格破壊」と呼ばれた初代の良さをそのままに、弱点だったケーブルや付属品を強化した「完全版」。特にTang Sancaiイヤーピースの付属はユーザーにとって大きなサプライズであり、この価格帯では頭一つ抜けた満足度を提供している。",
+    "sources": [
+      {
+        "name": "Amazon Product Page Details",
+        "url": "https://www.amazon.co.jp/dp/B0FDJXTC7K",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-27",
+    "competitiveAnalysis": [
+      {
+        "name": "Moondrop Chu II",
+        "asin": "B0CB8HHS8V",
+        "priceComparison": "約3,900円（Wan'er S.G 2より約400円高い）",
+        "featureComparison": [
+          "アルミニウムマグネシウム合金ドーム振動板",
+          "堅牢な金属筐体",
+          "ノズル交換ギミック搭載"
+        ],
+        "differentiators": [
+          "Chu IIは金属筐体で高級感があるが、Wan'er S.G 2は高級イヤーピース付属で装着感とコスパで勝負",
+          "Wan'er S.G 2の方がケーブルの質が良い（Chu 2のケーブルはゴム被膜で癖がつきやすい）"
+        ]
+      },
+      {
+        "name": "7Hz Salnotes Zero 2",
+        "asin": "B0CN2T4G4L",
+        "priceComparison": "約3,200円（Wan'er S.G 2より約300円安い）",
+        "featureComparison": [
+          "10mmダイナミックドライバー",
+          "より低音を強調したチューニング",
+          "プラスチック筐体"
+        ],
+        "differentiators": [
+          "Zero 2は低音重視のパワフルな音、Wan'er S.G 2はボーカル重視のバランス型",
+          "付属品の豪華さではWan'er S.G 2が圧倒的に有利"
+        ]
+      },
+      {
+        "name": "Linsoul Tripowin Ruta10",
+        "asin": "B0F4QYH46B",
+        "priceComparison": "約2,640円（Wan'er S.G 2より約900円安い）",
+        "featureComparison": [
+          "LCPダイナミックドライバー",
+          "シンプルな構成"
+        ],
+        "differentiators": [
+          "価格は安いが、付属品やビルドクオリティはWan'er S.G 2の方が価格差以上に高い"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めて中華イヤホンを買う人",
+        "コスパ重視で音質と装着感を両立させたい人",
+        "女性ボーカル曲をよく聴く人"
+      ],
+      "pros": [
+        "高級イヤーピース「Tang Sancai」が標準付属（これだけで元が取れるレベル）",
+        "取り回しの良い高品質なケーブル",
+        "全帯域バランスの取れた聴き疲れしないサウンド"
+      ],
+      "cons": [
+        "金属筐体のライバル機に比べると高級感は劣る",
+        "リケーブル端子（2pin）の耐久性は扱い方による"
+      ],
+      "score": 96,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (高級イヤーピース付属による圧倒的なコストパフォーマンス)\n[加点: +5] (名機をベースに改良された確かな音質性能)\n[加点: +3] (デザインは良いがプラ筐体のため控えめに評価)\n[加点: +3] (初代の実績はあるが新製品のため控えめに評価)\n[加点: +5] (Tang Sancaiイヤーピースという独自の強力な武器)\n[合計: 96]"
+    },
+    "technicalSpecs": {
+      "driver": "10mm PETダイヤフラム ダイナミックドライバー",
+      "codec": null,
+      "battery": null,
+      "connectivity": "有線 (3.5mmプラグ / 0.78mm 2pinコネクタ)",
+      "noiseCancel": null,
+      "impedance": "19Ω",
+      "sensitivity": "105dB (推測値)",
+      "cable": "1.2m 銀メッキOFCケーブル (絡まり防止設計)"
+    }
+  }
+}


### PR DESCRIPTION
TANGZU Wan'er S.G 2 (B0FDJXTC7K) の調査データを追加しました。
PA-APIによる商品情報取得、および競合商品（Moondrop Chu IIなど）との比較分析を行いました。
レビュースコアは、価格に対する付属品の豪華さ（Tang Sancaiイヤーピース付属）とドライバーの改良を高く評価し、96点としています。

---
*PR created automatically by Jules for task [10017520283978018518](https://jules.google.com/task/10017520283978018518) started by @aegisfleet*