### PR TITLE
Add investigation for UGREEN B0FG7DVV62

### DIFF
--- a/data/investigations/B0FG7DVV62.json
+++ b/data/investigations/B0FG7DVV62.json
@@ -1,0 +1,138 @@
+{
+  "analysis": {
+    "productName": "UGREEN RGBゲーミングマイク 96kHz/24bit (モデル 65629)",
+    "parentAsin": "B0FG7DVV62",
+    "productDescription": "最大96kHz/24bitのハイレゾ音質に対応し、鮮やかなRGBライティングとノイズ抑制機能を搭載した高コストパフォーマンスなUSBコンデンサーマイク。",
+    "productUsage": [
+      "ゲーム実況・ライブ配信（YouTube, Twitch, OBS）",
+      "ボイスチャット（Discord, Skype, LINE）",
+      "Web会議・テレワーク（Zoom, Teams, Google Meet）",
+      "PS4/PS5でのゲーム内ボイスチャット"
+    ],
+    "positivePoints": [
+      "3,000円以下の価格帯で最大96kHz/24bitの高解像度録音に対応",
+      "ワンタッチで操作できるミュートボタンとRGBライティング切り替え",
+      "ポップフィルター、ショックマウント、スタンドがすべて揃ったオールインワンセット",
+      "DSPチップ内蔵による環境ノイズ抑制機能",
+      "遅延ゼロで自分の声を確認できる3.5mmモニタリングジャック搭載"
+    ],
+    "negativePoints": [
+      "マイク本体に物理的なマイクゲイン（入力音量）調整ノブがない（PC/ソフト側での調整が必要）",
+      "Xboxシリーズには非対応",
+      "高感度ゆえに、スピーカーからの音を拾いやすくハウリングの注意が必要"
+    ],
+    "useCases": [
+      "初めてのゲーム実況環境構築",
+      "テレワークでの通話品質向上",
+      "PS5での友人とのボイスチャット"
+    ],
+    "userStories": [
+      {
+        "userType": "ゲーム配信初心者（学生）",
+        "scenario": "初めての実況動画作成",
+        "experience": "（推測）限られた予算の中で、見た目も良く音質も妥協したくないと思い購入。RGBライトがデスクの雰囲気を盛り上げてくれ、ポップフィルターも付属しているのですぐに本格的な録音が始められた。ノイズキャンセリングのおかげでキーボードの打鍵音が入りにくく、視聴者からも「声がクリア」と好評だった。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "在宅勤務の会社員",
+        "scenario": "Zoom会議での使用",
+        "experience": "（推測）PC内蔵マイクの音質が悪かったため導入。ワンタッチでミュートできる機能が会議中に非常に便利。相手に「声が聞き取りやすくなった」と言われ、仕事の効率も上がった気がする。ただ、本体で入力レベルを調整できないので、初期設定でWindowsの設定を開く必要があったのが少し手間だった。",
+        "sentiment": "mixed"
+      }
+    ],
+    "userImpression": "3,000円を切る価格ながら、配信や通話に必要な機能（高音質、ミュート、RGB、付属品）が全て揃っており、コストパフォーマンスが非常に高い製品。初心者や予算を抑えたいユーザーにとって強力な選択肢となる。",
+    "sources": [
+      {
+        "name": "UGREEN Official Site (General Product Info)",
+        "url": "https://www.ugreen.com/",
+        "credibility": "High"
+      },
+      {
+        "name": "Amazon Product Page Specifications",
+        "url": "https://www.amazon.co.jp/dp/B0FG7DVV62",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-28",
+    "competitiveAnalysis": [
+      {
+        "name": "TKGOU ArctisX USBマイク",
+        "asin": "B0B1CWKWZR",
+        "priceComparison": "ほぼ同価格帯（約3,100円）",
+        "featureComparison": [
+          "192kHz/24bit対応（UGREENは96kHz）",
+          "同じくワンタッチミュート搭載"
+        ],
+        "differentiators": [
+          "TKGOUはさらに高いサンプリングレートを謳うが、UGREENはDSPノイズ抑制を強調",
+          "デザインの好みで分かれる"
+        ]
+      },
+      {
+        "name": "ZealSound USBマイク",
+        "asin": "B092JB6XR3",
+        "priceComparison": "少し高い（約3,600円）",
+        "featureComparison": [
+          "エコー機能搭載",
+          "ボリュームノブ搭載"
+        ],
+        "differentiators": [
+          "ZealSoundは本体で音量調整とエコー調整が可能",
+          "UGREENはRGBライティングがあり、ゲーミング用途に特化"
+        ]
+      },
+      {
+        "name": "エレコム ゲーミングマイク HS-MC14UBK",
+        "asin": "B0BTGLP2G5",
+        "priceComparison": "同価格帯（約3,300円）",
+        "featureComparison": [
+          "タッチミュート、LED搭載",
+          "国内メーカー製"
+        ],
+        "differentiators": [
+          "エレコムは安心の国内サポート",
+          "UGREENはスペック（96kHz/24bit）で勝る可能性がある（エレコムは詳細スペック非公表の場合が多い）"
+        ]
+      },
+      {
+        "name": "Faunow USBコンデンサーマイク",
+        "asin": "B09LHKBPSN",
+        "priceComparison": "非常に安い（約1,800円）",
+        "featureComparison": [
+          "基本的な録音機能のみ",
+          "ミュートボタンなしのモデルもあり"
+        ],
+        "differentiators": [
+          "価格最優先ならFaunow",
+          "機能と使い勝手、音質を求めるならUGREEN"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "予算3,000円以下で高音質なマイクを探している人",
+        "初めてゲーム実況や配信を始める初心者",
+        "デスクをRGBライティングで飾りたいゲーマー",
+        "PS4/PS5で手軽にボイスチャットを楽しみたい人"
+      ],
+      "pros": [
+        "価格以上の高スペック（96kHz/24bit, DSP内蔵）",
+        "必要なアクセサリー（ポップガード、スタンド）が全て付属",
+        "ワンタッチミュートとモニタリング機能が便利"
+      ],
+      "cons": [
+        "マイク本体で入力ゲイン（音量）を調整できない",
+        "Xboxシリーズでは使用不可"
+      ],
+      "score": 90,
+      "scoreRationale": "[基本点: 70]\n[加点: +12] (3000円以下で96kHz/24bit、DSP、全部入りセットという圧倒的なコストパフォーマンス)\n[加点: +5] (ワンタッチミュート、RGB、遅延なしモニタリングなど実用的な機能が充実)\n[加点: +2] (UGREENブランドの信頼性とビルドクオリティへの期待)\n[加点: +3] (この価格帯でRGBとハイレゾを両立させた独自性)\n[減点: -2] (本体にゲイン調整ノブがないため、微調整にはPC操作が必要)\n[合計: 90]"
+    },
+    "technicalSpecs": {
+      "driver": "Condenser (Cardioid)",
+      "connectivity": ["USB Type-C", "3.5mm Headphone Jack"],
+      "noiseCancel": "DSP Noise Reduction",
+      "dimensions": null,
+      "other": ["96kHz/24bit Sampling Rate", "RGB Lighting", "Touch Mute", "Plug & Play"]
+    }
+  }
+}


### PR DESCRIPTION
UGREEN コンデンサーマイク ゲーミングマイク (B0FG7DVV62) の市場調査データを追加しました。
PA-APIによる情報取得と、競合商品（ZealSound, TKGOU, Elecom等）との比較を行い、96kHz/24bit対応などの高スペックと低価格を評価してスコア90点を算出しました。
レビュー情報が少ないため、一般的なユースケースに基づく推測としてユーザーストーリーを記述しています。

---
*PR created automatically by Jules for task [16895417843040290257](https://jules.google.com/task/16895417843040290257) started by @aegisfleet*