### PR TITLE
Investigate Turtle Beach Vulcan II TKL Pro

### DIFF
--- a/data/investigations/B0D7928XR4.json
+++ b/data/investigations/B0D7928XR4.json
@@ -1,0 +1,108 @@
+{
+  "analysis": {
+    "productName": "Turtle Beach Vulcan II TKL Pro",
+    "parentAsin": "B0FX9RBSCZ",
+    "productDescription": "磁気ホールエフェクトスイッチを採用し、ラピッドトリガーやSOCD（リアクタップ）機能を搭載したテンキーレスゲーミングキーボード。ROCCATのデザイン哲学を継承したスタイリッシュな外観と、競合を圧倒するコストパフォーマンスが特徴。",
+    "productUsage": [
+      "FPS/TPSタイトルでの精密なキャラクターコントロール（ストッピング）",
+      "ラピッドトリガー機能による高速な連打入力",
+      "専用ソフトウェアによるアクチュエーションポイントのカスタマイズ",
+      "AIMOライティングシステムによるデスク環境の演出"
+    ],
+    "positivePoints": [
+      "ラピッドトリガー搭載機としては破格の安さ（約1.4万円）",
+      "SOCDクリーナー（リアクタップ）とラピッドトリガーの同時利用が可能",
+      "サンドブラスト処理されたアルミトッププレートによる高い質感",
+      "ホールエフェクト（磁気）スイッチによる高耐久性（1.5億回）と滑らかな打鍵感",
+      "国内正規品としての2年保証と日本語配列対応"
+    ],
+    "negativePoints": [
+      "製品情報やユーザーレビューが少なく、実際の使用感に関する情報が不足している",
+      "統合ソフトウェア（Swarm II）の使い勝手や安定性が未知数"
+    ],
+    "useCases": [
+      "予算を抑えつつ本格的なラピッドトリガーキーボードを導入したい場合",
+      "ValorantやOverwatch 2などのストッピングが重要なFPSゲーム",
+      "ホワイトカラーで統一されたデスクセットアップ"
+    ],
+    "userStories": [],
+    "userImpression": "ユーザーレビューが現状見当たらないため詳細は不明だが、スペックと価格のバランスから、コストパフォーマンスを重視するゲーマーにとって非常に魅力的な選択肢となると予測される。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B0D7928XR4",
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-29",
+    "competitiveAnalysis": [
+      {
+        "name": "Logicool G PRO X TKL RAPID",
+        "asin": "B0DFBWQZDL",
+        "priceComparison": "本製品より約1.1万円高い（約25,000円）",
+        "featureComparison": [
+          "LIGHTSYNC RGB対応",
+          "キー優先設定（SOCD相当）あり",
+          "Logicool G HUBでの管理"
+        ],
+        "differentiators": [
+          "圧倒的なブランド信頼性とユーザー数",
+          "周辺機器との統合管理（G HUB）"
+        ]
+      },
+      {
+        "name": "DrunkDeer A75",
+        "asin": "B0C5HC7145",
+        "priceComparison": "本製品より約5,000円高い（約19,000円）",
+        "featureComparison": [
+          "75%レイアウト（コンパクト）",
+          "Webドライバーでの設定が可能"
+        ],
+        "differentiators": [
+          "ラピッドトリガー普及の立役者としての実績",
+          "コンパクトなサイズ感"
+        ]
+      },
+      {
+        "name": "CORSAIR K70 PRO TKL MGX",
+        "asin": "B0D7VW5SMC",
+        "priceComparison": "本製品より約8,000円高い（約22,000円）",
+        "featureComparison": [
+          "ポーリングレート8000Hz対応",
+          "脱着可能なパームレスト付属"
+        ],
+        "differentiators": [
+          "より高速なポーリングレート",
+          "iCUEソフトウェアによる高度な制御"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めてラピッドトリガーキーボードを購入するユーザー",
+        "コストパフォーマンスを最優先するFPSゲーマー",
+        "ROCCATのデザイン（Vulcanシリーズ）が好きなユーザー"
+      ],
+      "pros": [
+        "市場最安クラスの価格でフル機能（ラピトリ/SOCD）を搭載",
+        "信頼できるメーカー（Turtle Beach）の保証と品質",
+        "日本語配列で普段使いもしやすい"
+      ],
+      "cons": [
+        "発売直後で不具合情報や設定ノウハウが少ない可能性がある",
+        "高級機（3万円〜）と比較すると質感や打鍵音が劣る可能性がある"
+      ],
+      "score": 95,
+      "scoreRationale": "[基本点: 70]\n[加点: +8] (ラピッドトリガー、SOCD、ホールエフェクトなど最新機能を網羅)\n[加点: +15] (競合製品と比較して圧倒的に安価であり、市場破壊的な価格設定)\n[加点: +4] (ROCCATの定評あるデザインとアルミプレートの質感)\n[加点: +2] (SOCDとラピトリの同時使用を明記)\n[減点: -4] (実機レビュー不足による信頼性の不透明さ)\n[合計: 95]"
+    },
+    "technicalSpecs": {
+      "switchType": "磁気ホールエフェクトスイッチ",
+      "layout": "日本語配列 TKL (テンキーレス)",
+      "connectivity": "有線 (USB)",
+      "features": ["ラピッドトリガー", "SOCDクリーナー(リアクタップ)", "可変アクチュエーション", "AIMO RGBライティング"],
+      "dimensions": null,
+      "weight": null,
+      "warranty": "2年間"
+    }
+  }
+}


### PR DESCRIPTION
Investigation report for Turtle Beach Vulcan II TKL Pro. The product features magnetic switches with rapid trigger and SOCD capabilities at a very competitive price point (~13,800 JPY). Analysis highlights the cost advantage over competitors like Logicool and DrunkDeer.

---
*PR created automatically by Jules for task [9095662148473445976](https://jules.google.com/task/9095662148473445976) started by @aegisfleet*