### PR TITLE
Investigate Nothing Headphone (1)

### DIFF
--- a/data/investigations/B0F66XD5LF.json
+++ b/data/investigations/B0F66XD5LF.json
@@ -1,0 +1,134 @@
+{
+  "analysis": {
+    "productName": "Nothing Headphone (1)",
+    "parentAsin": "B0F9JQRYNG",
+    "productDescription": "Nothingブランド初となるオーバーイヤー型ワイヤレスヘッドホン。アイコニックな透明デザインに加え、英国の名門オーディオブランドKEFによるサウンドチューニング、回転式ダイヤル操作、最大80時間の長時間再生を実現。",
+    "productUsage": [
+      "高音質での音楽鑑賞（KEFチューニング・LDAC対応）",
+      "長時間の移動・旅行（最大80時間バッテリー）",
+      "ファッションアイテムとしての活用（透明デザイン）",
+      "Nothingエコシステムとの連携（ChatGPT呼び出しなど）"
+    ],
+    "positivePoints": [
+      "Nothingらしい独創的な透明（スケルトン）デザイン",
+      "ANCオフ時最大80時間、オン時35時間の長時間バッテリー",
+      "直感的な操作が可能な回転式ダイヤル（ローラー）搭載",
+      "英国KEFとのコラボレーションによるサウンドチューニング",
+      "LDACコーデック対応によるハイレゾワイヤレス再生",
+      "Nothing XアプリによるEQカスタマイズとChatGPT連携"
+    ],
+    "negativePoints": [
+      "公式発表情報が乏しく、一部スペック（KEFコラボ等）の裏付けが取れない",
+      "aptX Adaptive等の他コーデック対応状況が不明",
+      "ノイズキャンセリング性能の実力が未知数",
+      "防水性能に関する記載がない"
+    ],
+    "useCases": [
+      "カフェやオフィスでの作業用（ノイズキャンセリング）",
+      "数日間の旅行や出張（充電不要な長時間バッテリー）",
+      "個性的なファッションを好むユーザーの日常使い"
+    ],
+    "userStories": [
+      {
+        "userType": "ガジェット好きの30代男性",
+        "scenario": "外出時の音楽鑑賞",
+        "experience": "（推測）Nothing Earシリーズのデザインが好きで購入。オーバーイヤーになっても透明感のあるデザインは健在で、所有欲を満たしてくれる。ダイヤル操作は直感的で、物理ボタンよりも音量調整がスムーズだ。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "オーディオファンの20代学生",
+        "scenario": "自宅でのリスニング",
+        "experience": "（推測）KEFがチューニングに関わっているという点に惹かれた。バランスの取れた自然なサウンドで、特に中高域のクリアさが際立っている印象。LDAC接続時の解像感も高い。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "Nothing特有のデザインと、KEFコラボ・80時間再生という強力なスペックを兼ね備えた意欲作。実際の音質やANC性能への期待が高い一方、情報の少なさが懸念点。",
+    "sources": [
+      {
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0F66XD5LF",
+        "credibility": "medium"
+      }
+    ],
+    "lastInvestigated": "2026-01-29",
+    "competitiveAnalysis": [
+      {
+        "name": "Sennheiser MOMENTUM 4 Wireless",
+        "asin": "B0B6GHW1SX",
+        "priceComparison": "ほぼ同価格帯（実売3.3〜3.5万円前後）",
+        "featureComparison": [
+          "60時間再生",
+          "aptX Adaptive対応",
+          "定評ある音質"
+        ],
+        "differentiators": [
+          "Nothingは80時間再生と透明デザインで差別化",
+          "ゼンハイザーは音質の信頼性と実績で勝る"
+        ]
+      },
+      {
+        "name": "Sony WH-1000XM4",
+        "asin": "B08F2866Q3",
+        "priceComparison": "Nothingより安価（2.8万円台）",
+        "featureComparison": [
+          "業界最高クラスのノイキャン",
+          "30時間再生",
+          "LDAC対応"
+        ],
+        "differentiators": [
+          "Nothingはバッテリー持ちとデザインの新しさで勝負",
+          "Sonyはノイキャン性能と完成度の高さが強み"
+        ]
+      },
+      {
+        "name": "Anker Soundcore Space Q45",
+        "asin": "B0B5WD4CMW",
+        "priceComparison": "Nothingの半額以下（約1.5万円）",
+        "featureComparison": [
+          "65時間再生",
+          "ウルトラノイズキャンセリング2.0",
+          "LDAC対応"
+        ],
+        "differentiators": [
+          "Nothingはブランド価値とビルドクオリティ、KEFチューニングで差別化"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "Nothing製品のデザインや世界観が好きな人",
+        "充電の手間を減らしたい長時間リスナー",
+        "人と被らないヘッドホンを探している人"
+      ],
+      "pros": [
+        "所有欲を満たす透明デザイン",
+        "驚異的な80時間バッテリーライフ",
+        "物理ダイヤルによる快適な操作性"
+      ],
+      "cons": [
+        "発売直後で信頼性やレビューが不足している",
+        "公式の修理・サポート体制が大手ほど充実していない可能性"
+      ],
+      "score": 80,
+      "scoreRationale": "[基本点: 70]\n[性能・機能: +5] (LDAC対応、最大80時間再生、ダイヤル操作などスペックは高い)\n[品質・デザイン: +10] (Nothing独自の透明デザインは市場で唯一無二の価値)\n[独自の強み: +5] (KEFチューニングとChatGPT連携機能)\n[信頼性・情報: -10] (公式発表前の可能性があり、KEFコラボの裏付けがWebで取れないため懸念あり)\n[合計: 80]"
+    },
+    "technicalSpecs": {
+      "driver": null,
+      "codec": "LDAC, AAC, SBC",
+      "battery": "最大80時間 (ANC ON時は35時間)",
+      "connectivity": [
+        "Bluetooth",
+        "USB-C",
+        "3.5mmジャック",
+        "デュアル接続"
+      ],
+      "noiseCancel": "ハイブリッドアクティブノイズキャンセリング",
+      "other": [
+        "KEFチューニング",
+        "ChatGPT連携",
+        "Nothing Xアプリ対応",
+        "回転式ダイヤル操作"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added product investigation data for Nothing Headphone (1). Included detailed product analysis, competitive comparison with Sennheiser, Sony, and Anker, and technical specifications. Addressed the lack of official collaboration confirmation with KEF in the risk assessment.

---
*PR created automatically by Jules for task [17193649498464246594](https://jules.google.com/task/17193649498464246594) started by @aegisfleet*