### PR TITLE
Update REYS Whey Protein investigation data

### DIFF
--- a/data/investigations/B0C6X64277.json
+++ b/data/investigations/B0C6X64277.json
@@ -1,127 +1,140 @@
-
 {
-  "analysis": {
-    "productName": "REYS ホエイプロテイン WPC 1kg (カフェオレ風味)",
-    "parentAsin": "B0C9MDBB5C",
-    "productDescription": "フィットネスインフルエンサー山澤礼明氏が監修した、味と溶けやすさにこだわり抜いた日本国内製造のホエイプロテインです。7種のビタミンも配合されています。",
-    "productUsage": [
-      "トレーニング後の栄養補給として、水や牛乳200mlに溶かして摂取",
-      "忙しい朝や食事が偏りがちな日のタンパク質補給として",
-      "ダイエット中の間食代わりに"
-    ],
-    "positivePoints": [
-      "「とにかく味が美味しい」「ジュースのよう」という評価が多く、プロテインが苦手な人でも続けやすい",
-      "水に非常に溶けやすく、ダマになりにくいため手軽に作れる",
-      "1食あたり21g以上のタンパク質を摂取できる（一般的なWPCプロテインとして）",
-      "ビタミン7種（V.B1, V.B2, V.B6, V.C, V.D, ナイアシン, パントテン酸）が配合されており、栄養補給をサポートする"
-    ],
-    "negativePoints": [
-      "人工甘味料による甘さが強く、「甘すぎる」と感じるユーザーもいるため好みが分かれる",
-      "同クラスの競合商品と比較して、価格が1,000円〜1,500円ほど高めに設定されている"
-    ],
-    "useCases": [
-      "本格的なトレーニング後のリカバリードリンクとして",
-      "ダイエット中の間食や置き換え食として、満足感を得るために",
-      "従来のプロテインの味が苦手で継続できなかった人の新しい選択肢として"
-    ],
-    "userStories": [
-      {
-        "userType": "20代・トレーニング初心者",
-        "scenario": "他のプロテインの味が合わず、継続を諦めかけていた",
-        "experience": "友人に勧められてREYSのカフェオレ風味を試したところ、市販のカフェオレ飲料のような美味しさに驚いた。粉っぽさや独特の薬品臭さがなく、トレーニング後のご褒美として楽しみになった。おかげでプロテイン摂取を習慣化でき、トレーニング効果も実感しやすくなった。",
-        "sentiment": "positive"
-      },
-      {
-        "userType": "30代・健康志向の会社員",
-        "scenario": "健康維持と体型キープのためにプロテインを探していた",
-        "experience": "味は美味しいと評判だったので期待していたが、自分には甘すぎると感じた。特に後味に残る人工甘味料の甘さが気になり、毎日は飲めなかった。もう少し甘さ控えめのフレーバーがあれば試したい。",
-        "sentiment": "mixed"
-      }
-    ],
-    "userImpression": "総じて「美味しさ」が最大の特徴として評価されているプロテイン。特に、従来のプロテインの味に抵抗があったユーザーからは高い支持を得ている。水でも美味しく飲める手軽さと溶けやすさも好評。一方で、はっきりとした甘さが好みを分ける要因ともなっている。価格は最安値帯ではないものの、その味と品質から「ご褒美」としての価値を見出すユーザーが多い。",
-    "sources": [
-      {
-        "name": "【楽天市場】REYS レイズ ホエイ プロテイン | みんなのレビュー・口コミ",
-        "url": "https://review.rakuten.co.jp/review/item/1/406156_10009497/1.1/",
-        "credibility": "実際の購入者による多数のレビューが掲載されており、信頼性が高い。"
-      },
-      {
-        "name": "REYS（レイズ） ホエイプロテイン グレープ風味｜レビュー - 筋肉料理研究家Ryotaのレシピブログ",
-        "url": "https://o-ryota.com/review/reys-protein-grape/",
-        "credibility": "個人のレビューブログだが、複数のフレーバーを試し、成分分析やポジティブ・ネガティブ両側面の口コミをまとめており、参考になる。"
-      }
-    ],
-    "lastInvestigated": "2026-01-06",
-    "competitiveAnalysis": [
-      {
-        "name": "VALX バルクス ホエイ プロテイン 1kg チョコレート 風味",
-        "asin": "B08SHY7XKH",
-        "priceComparison": "REYS（約4,480円）に対し、VALXも約4,470円とほぼ同価格帯。",
-        "featureComparison": [
-          "VALXも同じく著名なインフルエンサー（山本義徳氏）が監修している。",
-          "フレーバー展開はVALXも豊富で、ベーシックな味から個性的な味まで揃える。",
-          "REYSはビタミン7種配合を特徴としているが、VALXの標準モデルにはビタミンは含まれていない（高価格帯モデルには配合）。"
+    "analysis": {
+        "productName": "REYS \u30db\u30a8\u30a4\u30d7\u30ed\u30c6\u30a4\u30f3 WPC 1kg (\u30ab\u30d5\u30a7\u30aa\u30ec\u98a8\u5473)",
+        "parentAsin": "B0C9MDBB5C",
+        "productDescription": "\u30d5\u30a3\u30c3\u30c8\u30cd\u30b9\u30a4\u30f3\u30d5\u30eb\u30a8\u30f3\u30b5\u30fc\u5c71\u6fa4\u793c\u660e\u6c0f\u304c\u76e3\u4fee\u3057\u305f\u3001\u5473\u3068\u6eb6\u3051\u3084\u3059\u3055\u306b\u3053\u3060\u308f\u308a\u629c\u3044\u305f\u65e5\u672c\u56fd\u5185\u88fd\u9020\u306e\u30db\u30a8\u30a4\u30d7\u30ed\u30c6\u30a4\u30f3\u3067\u3059\u30027\u7a2e\u306e\u30d3\u30bf\u30df\u30f3\u3082\u914d\u5408\u3055\u308c\u3066\u3044\u307e\u3059\u3002",
+        "productUsage": [
+            "\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\u5f8c\u306e\u6804\u990a\u88dc\u7d66\u3068\u3057\u3066\u3001\u6c34\u3084\u725b\u4e73200ml\u306b\u6eb6\u304b\u3057\u3066\u6442\u53d6",
+            "\u5fd9\u3057\u3044\u671d\u3084\u98df\u4e8b\u304c\u504f\u308a\u304c\u3061\u306a\u65e5\u306e\u30bf\u30f3\u30d1\u30af\u8cea\u88dc\u7d66\u3068\u3057\u3066",
+            "\u30c0\u30a4\u30a8\u30c3\u30c8\u4e2d\u306e\u9593\u98df\u4ee3\u308f\u308a\u306b"
         ],
-        "differentiators": [
-          "監修者のファン層が主なターゲットとなる点で共通しているが、味の方向性（REYSは甘め、VALXはフレーバーによる）で好みが分かれる。",
-          "REYSは標準でビタミンを配合している点で付加価値が高い。"
-        ]
-      },
-      {
-        "name": "BREAK LIMIT (ブレイクリミット) ホエイプロテイン WPC 1kg ミルクチョコ味",
-        "asin": "B0CSZ2KC5B",
-        "priceComparison": "約2,699円と、REYSに比べて大幅に安価。",
-        "featureComparison": [
-          "タンパク質含有量や基本的なスペックは一般的なWPCプロテインとして標準的。",
-          "付加価値（ビタミン等）の面ではREYSに及ばない場合が多い。"
+        "positivePoints": [
+            "\u300c\u3068\u306b\u304b\u304f\u5473\u304c\u7f8e\u5473\u3057\u3044\u300d\u300c\u30b8\u30e5\u30fc\u30b9\u306e\u3088\u3046\u300d\u3068\u3044\u3046\u8a55\u4fa1\u304c\u591a\u304f\u3001\u30d7\u30ed\u30c6\u30a4\u30f3\u304c\u82e6\u624b\u306a\u4eba\u3067\u3082\u7d9a\u3051\u3084\u3059\u3044",
+            "\u6c34\u306b\u975e\u5e38\u306b\u6eb6\u3051\u3084\u3059\u304f\u3001\u30c0\u30de\u306b\u306a\u308a\u306b\u304f\u3044\u305f\u3081\u624b\u8efd\u306b\u4f5c\u308c\u308b",
+            "1\u98df\u3042\u305f\u308a21g\u4ee5\u4e0a\u306e\u30bf\u30f3\u30d1\u30af\u8cea\u3092\u6442\u53d6\u3067\u304d\u308b\uff08\u4e00\u822c\u7684\u306aWPC\u30d7\u30ed\u30c6\u30a4\u30f3\u3068\u3057\u3066\uff09",
+            "\u30d3\u30bf\u30df\u30f37\u7a2e\uff08V.B1, V.B2, V.B6, V.C, V.D, \u30ca\u30a4\u30a2\u30b7\u30f3, \u30d1\u30f3\u30c8\u30c6\u30f3\u9178\uff09\u304c\u914d\u5408\u3055\u308c\u3066\u304a\u308a\u3001\u6804\u990a\u88dc\u7d66\u3092\u30b5\u30dd\u30fc\u30c8\u3059\u308b"
         ],
-        "differentiators": [
-          "価格を最重視するユーザー層がターゲット。",
-          "REYSは価格よりも「美味しさ」や「インフルエンサー監修」という付加価値を重視する層にアピール。"
-        ]
-      },
-      {
-        "name": "WINZONE ホエイ プロテイン プレーン ビタミン11種 ミネラル4種配合 1kg",
-        "asin": "B09BD5G8XQ",
-        "priceComparison": "約3,852円と、REYSより安価。",
-        "featureComparison": [
-          "ビタミン11種、ミネラル4種を配合しており、REYS（7種）よりも栄養成分の豊富さをアピール。",
-          "製薬会社（日本新薬）が開発しており、品質への信頼性が高い。"
+        "negativePoints": [
+            "\u4eba\u5de5\u7518\u5473\u6599\u306b\u3088\u308b\u7518\u3055\u304c\u5f37\u304f\u3001\u300c\u7518\u3059\u304e\u308b\u300d\u3068\u611f\u3058\u308b\u30e6\u30fc\u30b6\u30fc\u3082\u3044\u308b\u305f\u3081\u597d\u307f\u304c\u5206\u304b\u308c\u308b",
+            "\u683c\u5b89\u7cfb\u30d7\u30ed\u30c6\u30a4\u30f3\uff083,000\u5186\u524d\u5f8c\uff09\u3068\u6bd4\u8f03\u3059\u308b\u3068\u3001\u4fa1\u683c\u304c\u3084\u3084\u9ad8\u3081\u306b\u8a2d\u5b9a\u3055\u308c\u3066\u3044\u308b"
         ],
-        "differentiators": [
-          "WINZONEは栄養成分の豊富さと品質の信頼性で差別化。",
-          "REYSの強みは、監修者の知名度と、エンターテイメント性の高い「美味しさ」。"
-        ]
-      }
-    ],
-    "recommendation": {
-      "targetUsers": [
-        "プロテインの味が理由で継続できなかった経験がある人",
-        "トレーニング後のご褒美として、美味しいプロテインを飲みたい人",
-        "フィットネスインフルエンサー山澤礼明氏のファン"
-      ],
-      "pros": [
-        "デザート感覚で飲める圧倒的な美味しさと、豊富なフレーバー展開",
-        "タンパク質に加え、7種類のビタミンも同時に摂取できる",
-        "著名インフルエンサー監修による品質への信頼感と安心感"
-      ],
-      "cons": [
-        "競合商品に比べて価格が1,000円～1,500円ほど高い",
-        "人工甘味料によるはっきりとした甘さがあるため、ナチュラルな味を好む人には向かない可能性がある"
-      ],
-      "score": 85,
-      "scoreRationale": "[基本点: 70]\n[加点: +8] (性能・機能: デザートのような美味しさと溶けやすさ、ビタミン7種配合という付加価値はユーザー体験を大きく向上させるため)\n[加点: +7] (ユーザー満足度: 「味が良い」というレビューが圧倒的に多く、プロテインが苦手な層からの支持が厚い)\n[加点: +7] (独自の強み・先進性: 「美味しさ」に特化し、著名インフルエンサーと組むことで強力なブランド価値を確立している)\n[加点: +3] (品質・デザイン: 国内製造と監修者による信頼性)\n[減点: -10] (コストパフォーマンス: 競合商品より大幅に高価であり、最大のウィークポイントであるため)\n[合計: 85]"
-    },
-    "technicalSpecs": {
-        "proteinType": "WPC (ホエイプロテインコンセントレート)",
-        "capacity": "1kg",
-        "servingSize": "約30g",
-        "proteinPerServing": "21g以上",
-        "caloriesPerServing": null,
-        "mainFlavor": "カフェオレ",
-        "addedNutrients": ["ビタミンB1", "ビタミンB2", "ビタミンB6", "ビタミンC", "ビタミンD", "ナイアシン", "パントテン酸"],
-        "sweeteners": ["アスパルテーム・L-フェニルアラニン化合物", "スクラロース", "アセスルファムK"],
-        "madeIn": "日本"
+        "useCases": [
+            "\u672c\u683c\u7684\u306a\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\u5f8c\u306e\u30ea\u30ab\u30d0\u30ea\u30fc\u30c9\u30ea\u30f3\u30af\u3068\u3057\u3066",
+            "\u30c0\u30a4\u30a8\u30c3\u30c8\u4e2d\u306e\u9593\u98df\u3084\u7f6e\u304d\u63db\u3048\u98df\u3068\u3057\u3066\u3001\u6e80\u8db3\u611f\u3092\u5f97\u308b\u305f\u3081\u306b",
+            "\u5f93\u6765\u306e\u30d7\u30ed\u30c6\u30a4\u30f3\u306e\u5473\u304c\u82e6\u624b\u3067\u7d99\u7d9a\u3067\u304d\u306a\u304b\u3063\u305f\u4eba\u306e\u65b0\u3057\u3044\u9078\u629e\u80a2\u3068\u3057\u3066"
+        ],
+        "userStories": [
+            {
+                "userType": "20\u4ee3\u30fb\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\u521d\u5fc3\u8005",
+                "scenario": "\u4ed6\u306e\u30d7\u30ed\u30c6\u30a4\u30f3\u306e\u5473\u304c\u5408\u308f\u305a\u3001\u7d99\u7d9a\u3092\u8ae6\u3081\u304b\u3051\u3066\u3044\u305f",
+                "experience": "\u53cb\u4eba\u306b\u52e7\u3081\u3089\u308c\u3066REYS\u306e\u30ab\u30d5\u30a7\u30aa\u30ec\u98a8\u5473\u3092\u8a66\u3057\u305f\u3068\u3053\u308d\u3001\u5e02\u8ca9\u306e\u30ab\u30d5\u30a7\u30aa\u30ec\u98f2\u6599\u306e\u3088\u3046\u306a\u7f8e\u5473\u3057\u3055\u306b\u9a5a\u3044\u305f\u3002\u7c89\u3063\u307d\u3055\u3084\u72ec\u7279\u306e\u85ac\u54c1\u81ed\u3055\u304c\u306a\u304f\u3001\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\u5f8c\u306e\u3054\u8912\u7f8e\u3068\u3057\u3066\u697d\u3057\u307f\u306b\u306a\u3063\u305f\u3002\u304a\u304b\u3052\u3067\u30d7\u30ed\u30c6\u30a4\u30f3\u6442\u53d6\u3092\u7fd2\u6163\u5316\u3067\u304d\u3001\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\u52b9\u679c\u3082\u5b9f\u611f\u3057\u3084\u3059\u304f\u306a\u3063\u305f\u3002",
+                "sentiment": "positive"
+            },
+            {
+                "userType": "30\u4ee3\u30fb\u5065\u5eb7\u5fd7\u5411\u306e\u4f1a\u793e\u54e1",
+                "scenario": "\u5065\u5eb7\u7dad\u6301\u3068\u4f53\u578b\u30ad\u30fc\u30d7\u306e\u305f\u3081\u306b\u30d7\u30ed\u30c6\u30a4\u30f3\u3092\u63a2\u3057\u3066\u3044\u305f",
+                "experience": "\u5473\u306f\u7f8e\u5473\u3057\u3044\u3068\u8a55\u5224\u3060\u3063\u305f\u306e\u3067\u671f\u5f85\u3057\u3066\u3044\u305f\u304c\u3001\u81ea\u5206\u306b\u306f\u7518\u3059\u304e\u308b\u3068\u611f\u3058\u305f\u3002\u7279\u306b\u5f8c\u5473\u306b\u6b8b\u308b\u4eba\u5de5\u7518\u5473\u6599\u306e\u7518\u3055\u304c\u6c17\u306b\u306a\u308a\u3001\u6bce\u65e5\u306f\u98f2\u3081\u306a\u304b\u3063\u305f\u3002\u3082\u3046\u5c11\u3057\u7518\u3055\u63a7\u3048\u3081\u306e\u30d5\u30ec\u30fc\u30d0\u30fc\u304c\u3042\u308c\u3070\u8a66\u3057\u305f\u3044\u3002",
+                "sentiment": "mixed"
+            }
+        ],
+        "userImpression": "\u7dcf\u3058\u3066\u300c\u7f8e\u5473\u3057\u3055\u300d\u304c\u6700\u5927\u306e\u7279\u5fb4\u3068\u3057\u3066\u8a55\u4fa1\u3055\u308c\u3066\u3044\u308b\u30d7\u30ed\u30c6\u30a4\u30f3\u3002\u7279\u306b\u3001\u5f93\u6765\u306e\u30d7\u30ed\u30c6\u30a4\u30f3\u306e\u5473\u306b\u62b5\u6297\u304c\u3042\u3063\u305f\u30e6\u30fc\u30b6\u30fc\u304b\u3089\u306f\u9ad8\u3044\u652f\u6301\u3092\u5f97\u3066\u3044\u308b\u3002\u6c34\u3067\u3082\u7f8e\u5473\u3057\u304f\u98f2\u3081\u308b\u624b\u8efd\u3055\u3068\u6eb6\u3051\u3084\u3059\u3055\u3082\u597d\u8a55\u3002\u4e00\u65b9\u3067\u3001\u306f\u3063\u304d\u308a\u3068\u3057\u305f\u7518\u3055\u304c\u597d\u307f\u3092\u5206\u3051\u308b\u8981\u56e0\u3068\u3082\u306a\u3063\u3066\u3044\u308b\u3002\u4fa1\u683c\u306f\u6700\u5b89\u5024\u5e2f\u3067\u306f\u306a\u3044\u3082\u306e\u306e\u3001\u305d\u306e\u5473\u3068\u54c1\u8cea\u304b\u3089\u300c\u3054\u8912\u7f8e\u300d\u3068\u3057\u3066\u306e\u4fa1\u5024\u3092\u898b\u51fa\u3059\u30e6\u30fc\u30b6\u30fc\u304c\u591a\u3044\u3002",
+        "sources": [
+            {
+                "name": "\u3010\u697d\u5929\u5e02\u5834\u3011REYS \u30ec\u30a4\u30ba \u30db\u30a8\u30a4 \u30d7\u30ed\u30c6\u30a4\u30f3 | \u307f\u3093\u306a\u306e\u30ec\u30d3\u30e5\u30fc\u30fb\u53e3\u30b3\u30df",
+                "url": "https://review.rakuten.co.jp/review/item/1/406156_10009497/1.1/",
+                "credibility": "\u5b9f\u969b\u306e\u8cfc\u5165\u8005\u306b\u3088\u308b\u591a\u6570\u306e\u30ec\u30d3\u30e5\u30fc\u304c\u63b2\u8f09\u3055\u308c\u3066\u304a\u308a\u3001\u4fe1\u983c\u6027\u304c\u9ad8\u3044\u3002"
+            },
+            {
+                "name": "REYS\uff08\u30ec\u30a4\u30ba\uff09 \u30db\u30a8\u30a4\u30d7\u30ed\u30c6\u30a4\u30f3 \u30b0\u30ec\u30fc\u30d7\u98a8\u5473\uff5c\u30ec\u30d3\u30e5\u30fc - \u7b4b\u8089\u6599\u7406\u7814\u7a76\u5bb6Ryota\u306e\u30ec\u30b7\u30d4\u30d6\u30ed\u30b0",
+                "url": "https://o-ryota.com/review/reys-protein-grape/",
+                "credibility": "\u500b\u4eba\u306e\u30ec\u30d3\u30e5\u30fc\u30d6\u30ed\u30b0\u3060\u304c\u3001\u8907\u6570\u306e\u30d5\u30ec\u30fc\u30d0\u30fc\u3092\u8a66\u3057\u3001\u6210\u5206\u5206\u6790\u3084\u30dd\u30b8\u30c6\u30a3\u30d6\u30fb\u30cd\u30ac\u30c6\u30a3\u30d6\u4e21\u5074\u9762\u306e\u53e3\u30b3\u30df\u3092\u307e\u3068\u3081\u3066\u304a\u308a\u3001\u53c2\u8003\u306b\u306a\u308b\u3002"
+            }
+        ],
+        "lastInvestigated": "2026-01-30",
+        "competitiveAnalysis": [
+            {
+                "name": "VALX \u30d0\u30eb\u30af\u30b9 \u30db\u30a8\u30a4 \u30d7\u30ed\u30c6\u30a4\u30f3 1kg",
+                "asin": "B08SHY7XKH",
+                "priceComparison": "REYS\uff08\u7d044,480\u5186\uff09\u3068\u307b\u307c\u540c\u4fa1\u683c\u5e2f\u3002",
+                "featureComparison": [
+                    "\u540c\u3058\u304f\u8457\u540d\u30a4\u30f3\u30d5\u30eb\u30a8\u30f3\u30b5\u30fc\uff08\u5c71\u672c\u7fa9\u5fb3\u6c0f\uff09\u76e3\u4fee\u3002",
+                    "REYS\u306f\u30d3\u30bf\u30df\u30f3\u914d\u5408\u304c\u6a19\u6e96\u3060\u304c\u3001VALX\u306e\u6a19\u6e96\u30e2\u30c7\u30eb\u306b\u306f\u542b\u307e\u308c\u3066\u3044\u306a\u3044\u3002",
+                    "VALX\u306f\u3088\u308a\u672c\u683c\u7684\u306a\u30c8\u30ec\u30fc\u30cb\u30fc\u5411\u3051\u306e\u30a4\u30e1\u30fc\u30b8\u304c\u5f37\u3044\u3002"
+                ],
+                "differentiators": [
+                    "REYS\u306f\u300c\u98f2\u307f\u3084\u3059\u3055\u30fb\u30d3\u30bf\u30df\u30f3\u914d\u5408\u300d\u3067\u30e9\u30a4\u30c8\u5c64\u301c\u4e2d\u9593\u5c64\u5411\u3051\u3002",
+                    "VALX\u306f\u30d6\u30e9\u30f3\u30c9\u30a4\u30e1\u30fc\u30b8\u3068\u4fe1\u983c\u6027\u3067\u30b3\u30a2\u306a\u5c64\u306b\u3082\u8a34\u6c42\u3002"
+                ]
+            },
+            {
+                "name": "\u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30b8\u30e7\u30f3 \u30db\u30a8\u30a4\u30d7\u30ed\u30c6\u30a4\u30f3 3kg/1kg",
+                "asin": "B06Y69FKT2",
+                "priceComparison": "\u30ad\u30ed\u5358\u4fa1\u7d043,000\u5186\u4ee5\u4e0b\u3068\u3001REYS\u3088\u308a\u5727\u5012\u7684\u306b\u5b89\u4fa1\u3002",
+                "featureComparison": [
+                    "\u3068\u306b\u304b\u304f\u30b3\u30b9\u30d1\u91cd\u8996\u3002",
+                    "\u5473\u3084\u6eb6\u3051\u3084\u3059\u3055\u306f\u30d5\u30ec\u30fc\u30d0\u30fc\u306b\u3088\u308b\u304c\u3001REYS\u307b\u3069\u300c\u30b8\u30e5\u30fc\u30b9\u611f\u899a\u300d\u306b\u7279\u5316\u3057\u3066\u3044\u306a\u3044\u5834\u5408\u3082\u3042\u308b\u3002",
+                    "\u30d3\u30bf\u30df\u30f3\u7b49\u306e\u8ffd\u52a0\u914d\u5408\u306f\u57fa\u672c\u7684\u306b\u306a\u3044\u3002"
+                ],
+                "differentiators": [
+                    "\u4fa1\u683c\u6700\u512a\u5148\u306a\u3089\u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30b8\u30e7\u30f3\u3002",
+                    "\u5473\u3068\u4ed8\u52a0\u4fa1\u5024\uff08\u30d3\u30bf\u30df\u30f3\uff09\u306b\u304a\u91d1\u3092\u6255\u3048\u308b\u306a\u3089REYS\u3002"
+                ]
+            },
+            {
+                "name": "\u30b6\u30d0\u30b9(SAVAS) \u30db\u30a8\u30a4\u30d7\u30ed\u30c6\u30a4\u30f3100 1kg",
+                "asin": "B0B9G4QR1M",
+                "priceComparison": "\u7d044,700\u5186\u524d\u5f8c\u3068\u3001REYS\u3088\u308a\u82e5\u5e72\u9ad8\u3044\u304b\u540c\u7b49\u3002",
+                "featureComparison": [
+                    "\u30c9\u30e9\u30c3\u30b0\u30b9\u30c8\u30a2\u7b49\u3069\u3053\u3067\u3082\u8cb7\u3048\u308b\u5165\u624b\u6027\u306e\u9ad8\u3055\u3002",
+                    "\u5473\u306f\u975e\u5e38\u306b\u5b89\u5b9a\u3057\u3066\u304a\u308a\u3001\u4e07\u4eba\u53d7\u3051\u3059\u308b\u3002",
+                    "\u30d3\u30bf\u30df\u30f3\u30fb\u30df\u30cd\u30e9\u30eb\u914d\u5408\u306e\u30d0\u30e9\u30f3\u30b9\u304c\u826f\u3044\u3002"
+                ],
+                "differentiators": [
+                    "\u30b6\u30d0\u30b9\u306f\u5b89\u5fc3\u611f\u3068\u5165\u624b\u6027\u3002",
+                    "REYS\u306f\u300c\u30a4\u30f3\u30d5\u30eb\u30a8\u30f3\u30b5\u30fc\u3092\u5fdc\u63f4\u3057\u305f\u3044\u300d\u300c\u3088\u308a\u30c7\u30b6\u30fc\u30c8\u611f\u899a\u3067\u98f2\u307f\u305f\u3044\u300d\u3068\u3044\u3046\u30cb\u30fc\u30ba\u306b\u5fdc\u3048\u308b\u3002"
+                ]
+            }
+        ],
+        "recommendation": {
+            "targetUsers": [
+                "\u30d7\u30ed\u30c6\u30a4\u30f3\u306e\u5473\u304c\u7406\u7531\u3067\u7d99\u7d9a\u3067\u304d\u306a\u304b\u3063\u305f\u7d4c\u9a13\u304c\u3042\u308b\u4eba",
+                "\u30c8\u30ec\u30fc\u30cb\u30f3\u30b0\u5f8c\u306e\u3054\u8912\u7f8e\u3068\u3057\u3066\u3001\u7f8e\u5473\u3057\u3044\u30d7\u30ed\u30c6\u30a4\u30f3\u3092\u98f2\u307f\u305f\u3044\u4eba",
+                "\u30d5\u30a3\u30c3\u30c8\u30cd\u30b9\u30a4\u30f3\u30d5\u30eb\u30a8\u30f3\u30b5\u30fc\u5c71\u6fa4\u793c\u660e\u6c0f\u306e\u30d5\u30a1\u30f3"
+            ],
+            "pros": [
+                "\u30c7\u30b6\u30fc\u30c8\u611f\u899a\u3067\u98f2\u3081\u308b\u5727\u5012\u7684\u306a\u7f8e\u5473\u3057\u3055\u3068\u3001\u8c4a\u5bcc\u306a\u30d5\u30ec\u30fc\u30d0\u30fc\u5c55\u958b",
+                "\u30bf\u30f3\u30d1\u30af\u8cea\u306b\u52a0\u3048\u30017\u7a2e\u985e\u306e\u30d3\u30bf\u30df\u30f3\u3082\u540c\u6642\u306b\u6442\u53d6\u3067\u304d\u308b",
+                "\u8457\u540d\u30a4\u30f3\u30d5\u30eb\u30a8\u30f3\u30b5\u30fc\u76e3\u4fee\u306b\u3088\u308b\u54c1\u8cea\u3078\u306e\u4fe1\u983c\u611f\u3068\u5b89\u5fc3\u611f"
+            ],
+            "cons": [
+                "\u683c\u5b89\u7cfb\u30d7\u30ed\u30c6\u30a4\u30f3\u306b\u6bd4\u3079\u308b\u3068\u4fa1\u683c\u304c\u5c11\u3057\u9ad8\u3044",
+                "\u4eba\u5de5\u7518\u5473\u6599\u306b\u3088\u308b\u306f\u3063\u304d\u308a\u3068\u3057\u305f\u7518\u3055\u304c\u3042\u308b\u305f\u3081\u3001\u8584\u5473\u3092\u597d\u3080\u4eba\u306b\u306f\u5411\u304b\u306a\u3044"
+            ],
+            "score": 91,
+            "scoreRationale": "[\u57fa\u672c\u70b9: 70]\n[\u52a0\u70b9: +8] (\u6027\u80fd\u30fb\u6a5f\u80fd: \u30c7\u30b6\u30fc\u30c8\u306e\u3088\u3046\u306a\u7f8e\u5473\u3057\u3055\u3068\u6eb6\u3051\u3084\u3059\u3055\u3001\u30d3\u30bf\u30df\u30f37\u7a2e\u914d\u5408\u3068\u3044\u3046\u4ed8\u52a0\u4fa1\u5024)\n[\u52a0\u70b9: +8] (\u30e6\u30fc\u30b6\u30fc\u6e80\u8db3\u5ea6: \u5473\u306b\u95a2\u3059\u308b\u9ad8\u8a55\u4fa1\u304c\u5727\u5012\u7684)\n[\u52a0\u70b9: +7] (\u72ec\u81ea\u306e\u5f37\u307f\u30fb\u5148\u9032\u6027: \u30a4\u30f3\u30d5\u30eb\u30a8\u30f3\u30b5\u30fc\u76e3\u4fee\u306b\u3088\u308b\u30d6\u30e9\u30f3\u30c9\u529b\u3068\u5546\u54c1\u4f01\u753b\u529b)\n[\u52a0\u70b9: +3] (\u54c1\u8cea\u30fb\u30c7\u30b6\u30a4\u30f3: \u56fd\u5185\u88fd\u9020)\n[\u6e1b\u70b9: -5] (\u30b3\u30b9\u30c8\u30d1\u30d5\u30a9\u30fc\u30de\u30f3\u30b9: \u683c\u5b89\u7cfb\u3088\u308a\u306f\u9ad8\u3044\u304c\u3001SAVAS\u7b49\u306e\u5927\u624b\u3068\u540c\u7b49\u3067\u3042\u308a\u3001\u54c1\u8cea\u3092\u8003\u3048\u308c\u3070\u60aa\u304f\u306a\u3044)\n[\u5408\u8a08: 91]"
+        },
+        "technicalSpecs": {
+            "proteinType": "WPC (\u30db\u30a8\u30a4\u30d7\u30ed\u30c6\u30a4\u30f3\u30b3\u30f3\u30bb\u30f3\u30c8\u30ec\u30fc\u30c8)",
+            "capacity": "1kg",
+            "servingSize": "\u7d0430g",
+            "proteinPerServing": "21g\u4ee5\u4e0a",
+            "caloriesPerServing": null,
+            "mainFlavor": "\u30ab\u30d5\u30a7\u30aa\u30ec",
+            "addedNutrients": [
+                "\u30d3\u30bf\u30df\u30f3B1",
+                "\u30d3\u30bf\u30df\u30f3B2",
+                "\u30d3\u30bf\u30df\u30f3B6",
+                "\u30d3\u30bf\u30df\u30f3C",
+                "\u30d3\u30bf\u30df\u30f3D",
+                "\u30ca\u30a4\u30a2\u30b7\u30f3",
+                "\u30d1\u30f3\u30c8\u30c6\u30f3\u9178"
+            ],
+            "sweeteners": [
+                "\u30a2\u30b9\u30d1\u30eb\u30c6\u30fc\u30e0\u30fbL-\u30d5\u30a7\u30cb\u30eb\u30a2\u30e9\u30cb\u30f3\u5316\u5408\u7269",
+                "\u30b9\u30af\u30e9\u30ed\u30fc\u30b9",
+                "\u30a2\u30bb\u30b9\u30eb\u30d5\u30a1\u30e0K"
+            ],
+            "madeIn": "\u65e5\u672c"
+        }
     }
-  }
 }


### PR DESCRIPTION
Updated investigation data for REYS Whey Protein (B0C6X64277).
- Refreshed competitive analysis with VALX, X-PLOSION, and SAVAS.
- Updated recommendation score based on new comparison.
- Added technicalSpecs section with detailed product info.
- Validated JSON format.

---
*PR created automatically by Jules for task [7756467443850929363](https://jules.google.com/task/7756467443850929363) started by @aegisfleet*