### PR TITLE
docs: 調査データ追加 B0DNZ4X84R (Selore 16-in-1 Dock)

### DIFF
--- a/data/investigations/B0DNZ4X84R.json
+++ b/data/investigations/B0DNZ4X84R.json
@@ -1,0 +1,136 @@
+{
+  "analysis": {
+    "productName": "Selore 16-in-1 USB-C ドッキングステーション (4画面出力対応)",
+    "parentAsin": "B0DJW3KCNQ",
+    "productDescription": "USB-Cポート1つで最大4画面同時出力（HDMIx2, DP, VGA）と16種類のインターフェースを拡張できる多機能ドッキングステーション。PD充電や高速データ転送にも対応。",
+    "productUsage": [
+      "ノートPCのUSB-Cポートを拡張し、デスクトップ並みの作業環境を構築",
+      "最大4台の外部モニターへの同時出力（4K/1080p対応）",
+      "有線LAN接続による安定したインターネット通信",
+      "SD/microSDカードからのデータ取り込み",
+      "USB機器（キーボード、マウス、外付けHDDなど）の接続"
+    ],
+    "positivePoints": [
+      "16-in-1という豊富なポート数で、ほぼ全ての周辺機器を接続可能",
+      "最大4画面の同時出力に対応し、マルチタスク作業に最適",
+      "最大100WのPD急速充電に対応（PCへの給電も可能）",
+      "10Gbpsの高速データ転送に対応したUSBポートを搭載",
+      "アルミニウム合金製の筐体で放熱性に優れる"
+    ],
+    "negativePoints": [
+      "macOSではMST（Multi-Stream Transport）非対応のため、拡張モードでの多画面出力に制限がある可能性が高い",
+      "4画面同時出力時は解像度が1080pに制限される場合がある",
+      "PD充電器は付属していないため、別途用意が必要",
+      "使用中に本体が発熱する場合がある（一般的なドックの特性）",
+      "VGAポートは現在では使用頻度が低い可能性がある"
+    ],
+    "useCases": [
+      "自宅でのテレワーク環境構築（ノートPCをメインマシンとして使用）",
+      "オフィスでのプレゼンテーション（プロジェクターや大型モニターへの接続）",
+      "クリエイティブ作業（動画編集や画像編集で複数のモニターを使用）",
+      "出張や外出先での一時的な作業環境の拡張"
+    ],
+    "userStories": [
+      {
+        "userType": "在宅勤務の会社員",
+        "scenario": "テレワーク環境の改善",
+        "experience": "ノートPCの画面だけでは作業効率が悪いため購入。3画面に出力してメール、チャット、資料作成を並行して行えるようになり、生産性が向上した。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "動画編集者",
+        "scenario": "データ転送と画面拡張",
+        "experience": "外付けHDDやSDカードリーダーを多用するため、ポート不足を解消するために導入。10Gbpsの転送速度で大容量データの移動もスムーズ。発熱はあるが許容範囲。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "学生",
+        "scenario": "オンライン授業と課題作成",
+        "experience": "オンライン授業と課題作成を同時に行うために購入。安価なハブでは不安定だったが、これなら安定して有線LANも使えて満足。PD充電器が別売りなのは少し残念。（推測）",
+        "sentiment": "mixed"
+      }
+    ],
+    "userImpression": "多機能でコストパフォーマンスが高いという評価が期待される一方、macOSでの制限や発熱に関する指摘が懸念される。Windowsユーザーにとっては強力なツールとなるが、Macユーザーは注意が必要。",
+    "sources": [
+      {
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0DNZ4X84R",
+        "credibility": "高"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "ORICO 20-in-1 USB-C ドッキングステーション",
+        "asin": "B0FVL59RT5",
+        "priceComparison": "Seloreの方が約1,600円安く、コストパフォーマンスが高い。",
+        "featureComparison": [
+          "ORICOは20ポート、Seloreは16ポート",
+          "どちらも4画面出力対応",
+          "ORICOも10Gbps USB-C対応"
+        ],
+        "differentiators": [
+          "Seloreは価格優位性がある",
+          "ORICOはポート数がさらに多い"
+        ]
+      },
+      {
+        "name": "MOKiN USB Cドッキングステーション",
+        "asin": "B0D62PTJVL",
+        "priceComparison": "Seloreとほぼ同価格帯だが、Seloreの方が若干高い（割引クーポン考慮時は変動あり）。",
+        "featureComparison": [
+          "MOKiNはHDMI x3構成",
+          "SeloreはHDMI x2 + DP + VGA構成"
+        ],
+        "differentiators": [
+          "SeloreはVGAポートがあり、古いプロジェクターなどに対応しやすい",
+          "MOKiNはHDMIモニターが多い環境向け"
+        ]
+      },
+      {
+        "name": "UGREEN Revodok USB-C ハブ",
+        "asin": "B0CR6J2HCK",
+        "priceComparison": "UGREENの方が約6,000円安く、非常に安価。",
+        "featureComparison": [
+          "UGREENは13ポート、3画面出力",
+          "Seloreは16ポート、4画面出力"
+        ],
+        "differentiators": [
+          "Seloreは4画面同時出力が可能",
+          "UGREENは手軽な3画面拡張向け"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "WindowsノートPCユーザー",
+        "マルチモニター環境を構築したい人",
+        "多くの周辺機器を接続したい人"
+      ],
+      "pros": [
+        "16-in-1の多機能性",
+        "最大4画面出力",
+        "100W PD充電対応",
+        "10Gbpsデータ転送"
+      ],
+      "cons": [
+        "macOSでの画面拡張制限（MST非対応）",
+        "4画面時の解像度制限（1080p）",
+        "PD充電器別売り",
+        "発熱の可能性"
+      ],
+      "score": 87,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (16ポート、4画面出力は強力だが、macOS制限や4画面時の解像度低下があるため満点ではない)\n[加点: +10] (16-in-1で1.1万円は非常に安い。競合のORICOは1.2万円超)\n[加点: +0] (標準的なアルミニウム筐体)\n[加点: +0] (レビューが少ないため判断保留、中立)\n[加点: +2] (VGAポートを含むレガシー対応と最新規格の混在は一部ユーザーに便利)\n[合計: 87]"
+    },
+    "technicalSpecs": {
+      "dimensions": null,
+      "power": "100W Input, 87W Output",
+      "capacity": "16 Ports",
+      "ports": "HDMI x2, DP x1, VGA x1, USB-C 3.1 x1, USB-A 3.1 x1, USB-A 3.0 x2, USB 2.0 x2, USB-C x2, SD x1, TF x1, RJ45 x1, Audio x1",
+      "displayOutput": "Max 4 screens (HDMI 1: 4K@60Hz, HDMI 2: 4K@30Hz, DP: 4K@60Hz, VGA: 1080p)",
+      "dataTransfer": "USB 3.1 (10Gbps)",
+      "lan": "1Gbps (RJ45)",
+      "audio": "3.5mm Jack"
+    }
+  }
+}


### PR DESCRIPTION
Selore 16-in-1 USB-C ドッキングステーション (B0DNZ4X84R) の調査データを追加しました。
- 16-in-1 ポート構成、4画面出力対応、PD充電などの仕様を記載
- 競合製品 (ORICO, MOKiN, UGREEN) との比較を追加
- スコア算出 (87点) とその根拠を明記
- 技術仕様 (technicalSpecs) を追加

---
*PR created automatically by Jules for task [14844295040255466887](https://jules.google.com/task/14844295040255466887) started by @aegisfleet*