### PR TITLE
Update investigation data for B0CP58HPYH

### DIFF
--- a/data/investigations/B0CP58HPYH.json
+++ b/data/investigations/B0CP58HPYH.json
@@ -2,123 +2,154 @@
   "analysis": {
     "productName": "Amazon Basics 6-in-1 USB-C 3.2 (10G) ハブ",
     "parentAsin": "B0CP58HPYH",
-    "productDescription": "USB-Cポートを拡張し、HDMI 4K出力、有線LAN、複数のUSB機器接続を可能にする多機能ハブです。",
+    "productDescription": "USB-Cポート1つから、4K 60Hz HDMI、有線LAN、そして最大10Gbpsのデータ転送が可能なUSBポートを拡張できる多機能ハブです。",
     "productUsage": [
-      "ノートPCのポート拡張（MacBook, Windows等）",
-      "外付けSSDなどの高速データ転送（10Gbps対応）",
-      "4K 60Hzでの外部モニター出力",
+      "MacBookやWindowsノートPCのポート拡張",
+      "外付けSSD等への最大10Gbpsでの高速データ転送",
+      "4K 60Hzモニターへの高画質映像出力",
       "安定した有線LANインターネット接続"
     ],
     "positivePoints": [
-      "USB-A/Cポート共に最大10Gbpsの高速転送に対応",
-      "HDMIポートが4K 60Hzの高リフレッシュレートに対応",
-      "最大100WのUSB PDパススルー充電が可能",
-      "有線LANポート搭載で安定した通信が可能"
+      "USB-A/C全ポートがUSB 3.2 Gen 2 (10Gbps) に対応し高速",
+      "HDMIポートが4K 60Hzに対応し、滑らかな映像出力が可能",
+      "最大100WのUSB PDパススルー充電に対応",
+      "Amazonベーシックブランドによる保証と安心感"
     ],
     "negativePoints": [
-      "同等スペックの競合製品に比べて価格が高い",
-      "SDカードリーダーが非搭載",
-      "使用中に表面温度が高くなる場合がある（50℃程度）",
-      "ユーザーレビューが少なく、実使用での信頼性が未知数"
+      "同等スペックの競合製品（UGREEN等）と比較して価格が約2倍と高い",
+      "SD/microSDカードスロットが非搭載",
+      "筐体がプラスチック製で、放熱性や高級感に欠ける可能性がある",
+      "ケーブル長が約15cmと短く、配置の自由度が低い"
     ],
     "useCases": [
-      "動画編集など大容量データを扱うクリエイティブ作業",
-      "4Kモニターを使用したデスクワーク環境の構築",
-      "Wi-Fiが不安定な場所での有線LAN接続"
+      "4Kモニターを使用したクリエイティブ作業や動画視聴",
+      "大容量ファイルを頻繁に移動するデータ管理",
+      "Wi-Fiが不安定な環境でのオンライン会議（有線LAN利用）"
     ],
     "userStories": [
       {
-        "userType": "リモートワーカー",
-        "scenario": "自宅でのデスク環境構築",
-        "experience": "（推測）ノートPC 1台でモニター、キーボード、マウス、有線LANを一括接続でき、デスク周りがスッキリする体験。",
+        "userType": "映像クリエイター",
+        "scenario": "動画素材の取り込み",
+        "experience": "（推測）10Gbps対応の外付けSSDから素材をコピーする際、従来の5Gbpsハブよりも明らかに速く、作業待ち時間が短縮された。",
         "sentiment": "positive"
       },
       {
-        "userType": "クリエイター",
-        "scenario": "大容量データの移動",
-        "experience": "（推測）10Gbps対応のSSDを接続した際、従来のハブ（5Gbps）よりも高速にファイルをコピーでき、作業効率が向上する。",
-        "sentiment": "positive"
-      },
-      {
-        "userType": "ガジェット比較検討者",
-        "scenario": "購入前の価格比較",
-        "experience": "（推測）機能は申し分ないが、UGREENなどの他社製品と比較すると価格が倍近くするため、購入を躊躇してしまう。",
+        "userType": "ガジェット好きの学生",
+        "scenario": "購入検討",
+        "experience": "（推測）スペックは理想的だが、全く同じ機能を持つUGREEN製品が半額以下で売られているのを見て、そちらを購入することにした。",
         "sentiment": "negative"
+      },
+      {
+        "userType": "在宅勤務の会社員",
+        "scenario": "デスク環境の整備",
+        "experience": "（推測）会社のPCにUSB-Cポートが少ないため購入。LANケーブルとHDMI、マウスを一本でまとめられ、デスクが非常にスッキリした。",
+        "sentiment": "positive"
       }
     ],
-    "userImpression": "10Gbps転送と4K60Hz出力に対応した高性能なハブですが、価格設定が競合他社と比較して高めであるため、コストパフォーマンスを重視するユーザーには選びにくい製品です。",
+    "userImpression": "性能面では10Gbps転送と4K 60Hz出力を備え非常に優秀ですが、価格設定が競合他社と比較して高すぎるため、コストパフォーマンスの観点から厳しい評価とならざるを得ません。",
     "sources": [
       {
         "name": "Amazon商品ページ仕様詳細",
         "url": "https://www.amazon.co.jp/dp/B0CP58HPYH",
         "credibility": "高"
+      },
+      {
+        "name": "UGREEN Revodok商品ページ（価格比較）",
+        "url": "https://www.amazon.co.jp/dp/B0D1XN2LF1",
+        "credibility": "高"
       }
     ],
-    "lastInvestigated": "2026-01-22",
+    "lastInvestigated": "2026-01-31",
     "competitiveAnalysis": [
       {
         "name": "UGREEN Revodok 6-in-1 (10Gbps)",
         "asin": "B0D1XN2LF1",
-        "priceComparison": "約2,800円（本製品の半額以下）",
+        "priceComparison": "約2,800円（本製品の約半額）",
         "featureComparison": [
           "USB 3.2 Gen 2 (10Gbps) 対応で同等",
           "HDMI 4K@60Hz 対応で同等"
         ],
         "differentiators": [
           "圧倒的なコストパフォーマンス",
-          "セール頻度が高い"
+          "アルミ筐体"
         ]
       },
       {
-        "name": "Anker PowerExpand 6-in-1",
-        "asin": "B08C74W2QK",
-        "priceComparison": "約4,000円（本製品より安い）",
+        "name": "エレコム DST-W10 8in1",
+        "asin": "B0DSZGR9BC",
+        "priceComparison": "約4,900円（本製品より安い）",
         "featureComparison": [
-          "USB 3.0 (5Gbps) で本製品より遅い",
-          "HDMI 4K@30Hz で本製品より劣る"
+          "10Gbps対応、4K60Hz対応で同等以上",
+          "SDカードスロット搭載"
         ],
         "differentiators": [
-          "Ankerブランドの信頼性とサポート",
-          "知名度が高い"
+          "日本メーカーの信頼性",
+          "ポート数が多い（8in1）"
+        ]
+      },
+      {
+        "name": "Anker PowerExpand 8-in-1",
+        "asin": "B087TB7YM7",
+        "priceComparison": "約5,000円（本製品より若干安い）",
+        "featureComparison": [
+          "ポート数が8つで本製品より多い",
+          "SDカードスロット搭載"
+        ],
+        "differentiators": [
+          "Ankerブランドの信頼性",
+          "より多機能"
+        ]
+      },
+      {
+        "name": "BENFEI 5in1 USB-Cハブ",
+        "asin": "B0CSYYKB97",
+        "priceComparison": "約1,000円（本製品の1/5以下）",
+        "featureComparison": [
+          "4K 30Hzのため映像出力は劣る",
+          "一部ポートのみ10Gbps"
+        ],
+        "differentiators": [
+          "圧倒的な低価格",
+          "最低限の機能"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "Amazon Basicsブランドで周辺機器を統一したいユーザー",
-        "10Gbps転送と4K60Hz出力の両方が必須なユーザー"
+        "Amazonブランド製品で統一したいユーザー",
+        "企業の備品購入などでAmazonベーシック指定がある場合"
       ],
       "pros": [
-        "USB 3.2 Gen 2 (10Gbps) による高速データ転送",
-        "4K 60Hzの滑らかな映像出力",
-        "Amazonブランドの安心感（返品対応など）"
+        "全てのデータポートが10Gbps対応で高速",
+        "4K 60Hz出力によりスムーズな映像体験が可能",
+        "Amazonによるサポート体制"
       ],
       "cons": [
-        "機能に対して価格が割高",
-        "SDカードスロットがないため写真取り込みには不向き"
+        "機能に対する価格が割高",
+        "写真や動画を扱うユーザーにはSDスロットがない点が不便"
       ],
       "score": 60,
-      "scoreRationale": "[基本点: 70]\n[加点: +5] (10Gbpsポートと4K60Hz対応は高性能)\n[減点: -15] (同等スペックの競合製品が半額以下で購入可能)\n[合計: 60]"
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (10Gbpsポートと4K60Hz対応の実用性は高い)\n[減点: -15] (同等スペックの競合製品が半額以下であり、価格競争力が低い)\n[減点: -5] (SDスロット不在など、価格に対する機能不足感)\n[合計: 60]"
     },
     "technicalSpecs": {
       "dimensions": {
-        "height": "1.5 cm",
         "width": "11.94 cm",
         "depth": "4.6 cm",
+        "height": "1.5 cm",
         "weight": "約80g"
       },
-      "power": "PD 100W入力 (85W出力)",
       "connectivity": [
-        "USB-C (PD Input) x1",
-        "USB-C (10Gbps Data) x1",
-        "USB-A (10Gbps Data) x2",
+        "USB-C 3.2 Gen 2 (10Gbps) x1",
+        "USB-A 3.2 Gen 2 (10Gbps) x2",
+        "USB-C (PD 100W Input) x1",
         "HDMI (4K@60Hz) x1",
         "Ethernet (1Gbps) x1"
       ],
+      "power": "PD 100W入力 (最大85W出力)",
       "other": [
-        "SDカードリーダー非搭載",
-        "ケーブル長 15cm",
-        "筐体材質: プラスチック（推定）"
+        "ケーブル長: 約15cm",
+        "SDカードスロットなし",
+        "ドライバ不要プラグアンドプレイ"
       ]
     }
   }


### PR DESCRIPTION
Updated the investigation data for Amazon Basics 6-in-1 USB-C Hub (B0CP58HPYH).
Includes updated pricing, expanded competitor list, and structured technical specifications.
Score calculated as 60/100 based on high performance but low cost-efficiency compared to market alternatives.

---
*PR created automatically by Jules for task [4388640803607450391](https://jules.google.com/task/4388640803607450391) started by @aegisfleet*