### PR TITLE
feat: add investigation data for UGREEN Revodok Pro 314

### DIFF
--- a/data/investigations/B0DYTVVLH4.json
+++ b/data/investigations/B0DYTVVLH4.json
@@ -1,0 +1,129 @@
+{
+  "analysis": {
+    "productName": "UGREEN Revodok Pro 314 USB-C ドッキングステーション 14-in-1",
+    "parentAsin": "B0DYTVVLH4",
+    "productDescription": "WindowsノートPCの拡張性を最大化するハイエンド・ドッキングステーションです。8K映像出力や10Gbpsの高速データ転送に対応し、クリエイティブな作業環境をケーブル1本で構築できます。",
+    "productUsage": [
+      "最大3台の外部モニターを接続したマルチディスプレイ環境の構築（Windows）",
+      "ノートPCへの最大100W急速充電と周辺機器への給電",
+      "外付けSSDやSDカードからの高速データ転送（最大10Gbps）",
+      "有線LANによる安定したインターネット接続"
+    ],
+    "positivePoints": [
+      "DisplayPortは最大8K@30Hzまたは4K@120Hzに対応し、高解像度・高リフレッシュレートのモニター性能を活かせる",
+      "USB-CおよびUSB-Aポートのうち3基が10Gbps転送に対応しており、大容量ファイルの移動が高速",
+      "HDMIポートを2基搭載し、DPと合わせて柔軟なマルチモニター構成が可能",
+      "ギガビット有線LANポートを搭載し、Web会議やダウンロードも安定して行える"
+    ],
+    "negativePoints": [
+      "macOSではMST（マルチストリーム転送）非対応のため、複数画面への異なる画面の出力（拡張モード）に制限がある",
+      "同クラスの競合製品と比較して価格がやや高めに設定されている",
+      "PCへの給電には別途USB PD対応の充電器が必要になる場合がある（パススルー充電）"
+    ],
+    "useCases": [
+      "高解像度モニターを使用する動画編集やグラフィックデザイン",
+      "複数のウィンドウを開いて作業する在宅勤務・テレワーク",
+      "大容量データを頻繁に扱うデータ分析やバックアップ作業"
+    ],
+    "userStories": [
+      {
+        "userType": "映像クリエイター",
+        "scenario": "4Kモニターでの動画編集作業",
+        "experience": "（推測）これまではモニターのリフレッシュレートが60Hzに制限されていたが、このドックのDPポートを使うことで4K/120Hzでの滑らかなプレビューが可能になり、作業効率が向上した。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "在宅勤務の会社員",
+        "scenario": "毎日のPCセットアップ",
+        "experience": "（推測）出社と在宅を繰り返す中で、ケーブル1本を挿すだけで3画面と有線LAN、キーボード類が一気に繋がるため、準備の時間が大幅に短縮された。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "レビューはまだ少ないものの、スペック面では同価格帯の製品を凌駕しており、特にWindowsユーザーで画質と転送速度を重視する層から高い評価が期待できる製品です。",
+    "sources": [
+      {
+        "name": "Amazon商品ページ (B0DYTVVLH4)",
+        "url": "https://www.amazon.co.jp/dp/B0DYTVVLH4",
+        "credibility": "high"
+      },
+      {
+        "name": "競合比較データ (PA-API)",
+        "url": null,
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "Anker USB-C ハブ (14-in-1, Triple Display)",
+        "asin": "B0CG5CF9GF",
+        "priceComparison": "本製品より約5,000円安価",
+        "featureComparison": [
+          "映像出力に古いVGAポートを含む",
+          "USBポートは最大5Gbpsのみ",
+          "最大解像度は4K@60Hzまで"
+        ],
+        "differentiators": [
+          "UGREENは8K対応および10Gbps転送に対応しており、スペックで大きく上回る",
+          "Ankerはコストパフォーマンス重視の旧世代スペック"
+        ]
+      },
+      {
+        "name": "Selore USB C ドッキングステーション 13-in-1",
+        "asin": "B0CX59NVY2",
+        "priceComparison": "本製品の半額以下（約6,400円）",
+        "featureComparison": [
+          "10Gbpsポートは一部のみ",
+          "ビルドクオリティや安定性に不安が残る価格帯"
+        ],
+        "differentiators": [
+          "UGREENはポート全体の性能バランスが高く、信頼性が期待できる"
+        ]
+      },
+      {
+        "name": "ORICO 20-in-1 ドッキングステーション",
+        "asin": "B0FVL59RT5",
+        "priceComparison": "本製品と同等の価格帯（約12,800円）",
+        "featureComparison": [
+          "ポート数がさらに多い（20-in-1）",
+          "VGAポートを含む"
+        ],
+        "differentiators": [
+          "UGREENは最新規格（DP 8K/4K120Hz）にフォーカスしており、ポート数よりも質を重視している"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "4K/120Hzなどの高性能モニターを使用しているWindowsユーザー",
+        "動画データなどの大容量ファイルを頻繁に移動するクリエイター",
+        "最新スペックのドッキングステーションを長く使いたい人"
+      ],
+      "pros": [
+        "クラス最高レベルの映像出力性能（8K/30Hz, 4K/120Hz）",
+        "複数の10Gbps USBポートによる高速データ転送",
+        "豊富なポート数ですべての周辺機器を集約可能"
+      ],
+      "cons": [
+        "macOSではマルチディスプレイ機能に制限がある",
+        "一般的なハブと比較すると導入コストが高い"
+      ],
+      "score": 78,
+      "scoreRationale": "[基本点: 70]\n[加点: +8] (8K対応および10Gbpsポート複数搭載という高いスペック)\n[減点: -5] (競合製品と比較して価格が高価)\n[加点: +2] (UGREENブランドの信頼性とビルドクオリティ)\n[加点: +3] (この価格帯で4K/120Hz対応は希少で独自性がある)\n[合計: 78]"
+    },
+    "technicalSpecs": {
+      "ports": "14-in-1 (HDMI x2, DP x1, USB-C 10Gbps x1, USB-A 10Gbps x2, USB-A 5Gbps x2, RJ45, SD/TF, Audio, PD Input)",
+      "videoOutput": {
+        "hdmi1": "4K@60Hz",
+        "hdmi2": "4K@60Hz",
+        "displayPort": "8K@30Hz / 4K@120Hz"
+      },
+      "usbSpeed": "最大10Gbps (USB 3.2 Gen 2)",
+      "pdCharging": "最大100W (ホスト給電)",
+      "compatibility": "Windows 10/11, macOS (制限あり), Linux",
+      "ethernet": "1000Mbps (Gigabit)",
+      "audio": "3.5mm AUX",
+      "cardReader": "SD/TF (UHS-I 104MB/sまたは170MB/s)"
+    }
+  }
+}


### PR DESCRIPTION
Added detailed product analysis for UGREEN Revodok Pro 314 (B0DYTVVLH4) in JSON format.
Included product description, usage, competitive analysis against Anker and Selore, and technical specifications.
Scoring rationale included based on high specs (8K/10Gbps) and price point.
Verified JSON structure and content.

---
*PR created automatically by Jules for task [8541497259315931125](https://jules.google.com/task/8541497259315931125) started by @aegisfleet*