### PR TITLE
Investigate Anker Prime Docking Station B0D31FK2W6

### DIFF
--- a/data/investigations/B0D31FK2W6.json
+++ b/data/investigations/B0D31FK2W6.json
@@ -1,0 +1,134 @@
+{
+  "analysis": {
+    "productName": "Anker Prime ドッキングステーション (14-in-1, Dual Display, 160W)",
+    "parentAsin": "B0D31FK2W6",
+    "productDescription": "GaN技術採用によりACアダプタを内蔵し、コンセントから直接給電可能な14ポート搭載ドッキングステーションです。前面のディスプレイで各ポートの充電状況をリアルタイムに確認できます。",
+    "productUsage": [
+      "ノートPCのポート拡張と最大100Wの急速充電",
+      "HDMIポートを使用したデュアルディスプレイ出力（Windows推奨）",
+      "デスク周りの配線整理（巨大なACアダプタ不要）",
+      "前面ディスプレイによる接続機器の充電状況モニタリング"
+    ],
+    "positivePoints": [
+      "ACアダプタが内蔵されており、電源ケーブル1本でスッキリ設置できる",
+      "合計最大160W、単ポート最大100Wの高出力でノートPCとスマホ等を同時急速充電可能",
+      "前面ディスプレイで出力ワット数や接続状況が可視化され、ギミックとして満足度が高い",
+      "USB-C 10Gbpsポートを複数搭載し、高速データ転送に対応"
+    ],
+    "negativePoints": [
+      "Mac製品ではOSの仕様上（MST非対応）、2つのHDMIポートを使用しても拡張デスクトップではなくミラーリング出力になる可能性が高い（DisplayLink非搭載のため）",
+      "Belkin等の競合製品と比較して価格がやや高め設定である",
+      "ファン内蔵のため、負荷時にはファンの動作音が気になる可能性がある"
+    ],
+    "useCases": [
+      "WindowsノートPCを使用し、外部モニター2台で作業効率を上げたいオフィスワーク",
+      "デスク上のケーブルやアダプタを極力減らし、ミニマルな環境を構築したいユーザー",
+      "複数のUSB機器やSDカードを頻繁に使用するクリエイター"
+    ],
+    "userStories": [
+      {
+        "userType": "在宅勤務の会社員（Windowsユーザー）",
+        "scenario": "デスク周りの整理とマルチモニター環境の構築",
+        "experience": "これまで巨大なACアダプタが床やデスクを占領していたが、このドックに変えて電源ケーブル1本になり劇的にスッキリした。Windows PCに繋いで4Kモニター2枚に出力でき、仕事の効率も上がった。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "MacBook Proユーザー",
+        "scenario": "デュアルディスプレイ環境の構築を期待して購入",
+        "experience": "AC内蔵のデザインに惹かれて購入したが、MacBookでは2台の外部モニターに別々の画面を出力できず、同じ画面が表示されてしまった。DisplayLink対応の上位モデルを買うべきだった。（推測）",
+        "sentiment": "negative"
+      }
+    ],
+    "userImpression": "ACアダプタ内蔵による省スペース性と、Anker Primeシリーズ特有のディスプレイ搭載による先進性が高く評価される一方、Macユーザーにとってはマルチディスプレイの制約が注意点となる製品。",
+    "sources": [
+      {
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0D31FK2W6",
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "Belkin Connect 11-in-1 GaNドック (INC020qcSGY)",
+        "asin": "B0DM1TWPDY",
+        "priceComparison": "約22,500円で、本製品より約7,500円安い",
+        "featureComparison": [
+          "同じくAC電源内蔵（GaN採用）",
+          "出力は合計150W（PD 96W）とほぼ同等",
+          "ポート数は11とやや少ない",
+          "ディスプレイは非搭載"
+        ],
+        "differentiators": [
+          "Belkinの方がコストパフォーマンスが高い",
+          "Ankerはディスプレイ搭載とポート数の多さで勝る"
+        ]
+      },
+      {
+        "name": "Anker Prime ドッキングステーション (14-in-1, Triple Display)",
+        "asin": "B0F8VNSTYC",
+        "priceComparison": "約32,000円で、本製品とほぼ同価格帯（+2,000円程度）",
+        "featureComparison": [
+          "DisplayLinkチップ搭載でMacでも3画面拡張出力が可能",
+          "その他のポート構成やデザインは酷似"
+        ],
+        "differentiators": [
+          "MacユーザーにはDisplayLink搭載のこちら（B0F8VNSTYC）が圧倒的に推奨される",
+          "本製品（B0D31FK2W6）はWindowsユーザー向けまたはDisplayLinkドライバを入れたくないユーザー向け"
+        ]
+      },
+      {
+        "name": "Anker PowerExpand Elite 13-in-1 Thunderbolt 3 Dock",
+        "asin": "B087JKDD4M",
+        "priceComparison": "約26,500円",
+        "featureComparison": [
+          "Thunderbolt 3対応で帯域が広い (40Gbps)",
+          "ACアダプタが巨大（外付け）"
+        ],
+        "differentiators": [
+          "本製品はAC内蔵で設置性が高い",
+          "速度重視ならThunderbolt 3/4モデルが有利"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "WindowsノートPCを使用しているユーザー",
+        "デスク上のACアダプタを排除したいミニマリスト",
+        "ガジェットの充電状況を見るのが好きなユーザー"
+      ],
+      "pros": [
+        "ACアダプタ内蔵ですっきり設置可能",
+        "160Wの高出力で複数デバイスを急速充電",
+        "情報表示ディスプレイが便利でカッコいい"
+      ],
+      "cons": [
+        "Macではデュアルディスプレイ拡張ができない可能性大（DisplayLink非搭載）",
+        "同価格帯にDisplayLink搭載の上位モデルが存在するため、選び方が難しい"
+      ],
+      "score": 80,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] ACアダプタ内蔵のデザインと省スペース性は非常に優秀\n[加点: +5] ディスプレイによる情報表示は独自性があり所有欲を満たす\n[加点: +5] 14ポート、合計160W出力とスペックは十分高い\n[減点: -5] ほぼ同価格でDisplayLink搭載モデルが存在し、Macユーザーへの訴求力が弱い\n[合計: 80] Windowsユーザーには+5点しても良いが、汎用性とラインナップ内の立ち位置の難しさでこの点数"
+    },
+    "technicalSpecs": {
+      "ports": "14 (USB-C x3, USB-A x4, HDMI 2.0 x2, Ethernet, Audio, etc.)",
+      "power": {
+        "input": "AC 100-240V (Built-in GaN)",
+        "output": "Total 160W, Max 100W (Host)"
+      },
+      "display": {
+        "ports": "HDMI 2.0 x 2",
+        "maxResolution": "4K 60Hz",
+        "multiMonitor": "Dual 4K (MST for Windows, Mirror for macOS likely)"
+      },
+      "connectivity": [
+        "USB-C (10Gbps)",
+        "USB-A (USB 2.0/3.1)",
+        "Ethernet (1Gbps)"
+      ],
+      "dimensions": {
+        "size": "約 140 x 97 x 47 mm (推測値)",
+        "weight": "約 890g (推測値)"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added investigation data for ASIN B0D31FK2W6 (Anker Prime Docking Station 14-in-1, Dual Display).
Includes detailed analysis of features, competitive landscape (vs Belkin, Anker DisplayLink model), and technical specifications.
Highlighted the distinction between this model and the DisplayLink version regarding Mac compatibility.

---
*PR created automatically by Jules for task [1062338735418121002](https://jules.google.com/task/1062338735418121002) started by @aegisfleet*