### PR TITLE
Add investigation for B0CRCZ1Q6L (Z-Edge UG34)

### DIFF
--- a/data/investigations/B0CRCZ1Q6L.json
+++ b/data/investigations/B0CRCZ1Q6L.json
@@ -1,0 +1,135 @@
+{
+  "analysis": {
+    "productName": "Z-Edge UG34 湾曲ゲーミングモニター 34インチ",
+    "parentAsin": "B0D83Y8KZ7",
+    "productDescription": "165HzのリフレッシュレートとUWQHD解像度を備え、没入感のあるゲーム体験を提供するコストパフォーマンスに優れた34インチ湾曲ウルトラワイドモニターです。",
+    "productUsage": [
+      "PCゲーム（特にMMORPGやレーシングシミュレーター）での没入プレイ",
+      "ウルトラワイド画面を活かしたマルチタスク業務や動画編集",
+      "映画や動画コンテンツの鑑賞"
+    ],
+    "positivePoints": [
+      "3万円台前半で購入できる圧倒的なコストパフォーマンス",
+      "165Hzの高リフレッシュレートと1msの応答速度",
+      "高さ調整可能なスタンドを標準装備し、快適な視聴位置に調整可能",
+      "HDMIポートとDisplayPortを各2つ搭載する豊富な接続性"
+    ],
+    "negativePoints": [
+      "Xiaomiなどの競合と比較してブランド知名度が低い",
+      "USB-CポートやKVMスイッチ機能は非搭載",
+      "VAパネル特有の視野角の狭さや残像感が気になる場合がある"
+    ],
+    "useCases": [
+      "予算を抑えてウルトラワイド環境を構築したいゲーマー",
+      "2画面置くスペースはないが作業領域を広げたい在宅ワーカー"
+    ],
+    "userStories": [
+      {
+        "userType": "ゲーマー (推測)",
+        "scenario": "FPSやレーシングゲームのプレイ",
+        "experience": "165Hzの滑らかさと湾曲画面の没入感により、ゲーム体験が向上しました。特に横長の視野が有利に働くタイトルで真価を発揮します。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "在宅ワーカー (推測)",
+        "scenario": "複数ウィンドウを開いての作業",
+        "experience": "ウィンドウを左右に並べても窮屈さがなく、デュアルモニターのような使い勝手を1枚で実現でき、デスク周りもすっきりしました。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "3万円台でこのスペックは破格であり、エントリー向けのウルトラワイドモニターとして十分な性能を持っていますが、競合製品（特にXiaomi）との比較検討が必要です。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B0CRCZ1Q6L",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "Xiaomi G34WQi ゲーミングモニター",
+        "asin": "B0CWS2YKNK",
+        "priceComparison": "ほぼ同価格（+1,000円〜2,000円程度）",
+        "featureComparison": [
+          "リフレッシュレートが180Hzと高い",
+          "Xiaomiブランドの信頼性"
+        ],
+        "differentiators": [
+          "Xiaomiは180Hz駆動でスペックが若干高い",
+          "Z-EdgeはHDMIx2, DPx2とポート数が豊富（XiaomiはDPx2, HDMIx2と同様の構成の場合が多いが要確認）"
+        ]
+      },
+      {
+        "name": "CRUA 34インチ ゲーミングモニター",
+        "asin": "B0DPKN9HXB",
+        "priceComparison": "約5,000円安い",
+        "featureComparison": [
+          "価格最優先の構成",
+          "高さ調整機能がないモデルが多い"
+        ],
+        "differentiators": [
+          "圧倒的な安さ",
+          "Z-Edgeは高さ調整スタンド付きでエルゴノミクスに優れる"
+        ]
+      },
+      {
+        "name": "cocopar HG-4K34C",
+        "asin": "B0FCLK86BL",
+        "priceComparison": "同価格帯",
+        "featureComparison": [
+          "USB-C対応",
+          "スピーカー内蔵"
+        ],
+        "differentiators": [
+          "cocoparはUSB-C接続が可能でMacBook等との相性が良い",
+          "Z-Edgeは純粋なゲーミングスペック重視"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めてウルトラワイドモニターを試す人",
+        "コストを抑えつつ144Hz以上の環境が欲しいゲーマー",
+        "高さ調整機能を重視する人"
+      ],
+      "pros": [
+        "34インチUWQHDで165Hzという高い基本スペック",
+        "高さ調整可能なスタンド",
+        "豊富な入力端子 (HDMI x2, DP x2)"
+      ],
+      "cons": [
+        "競合Xiaomiの存在（180Hz）により選択肢としての決定打に欠ける場合がある",
+        "パネル品質やサポートへの不安（マイナーブランド）"
+      ],
+      "score": 76,
+      "scoreRationale": "[基本点: 70]\n[コスパ: +10] (3万円台前半でUWQHD/165Hz/高さ調整付きは非常に優秀)\n[性能: +2] (165Hz, 1ms, 高さ調整ありと機能は十分)\n[品質: -3] (ブランドの信頼性が大手と比較して未知数)\n[競合比較: -3] (同価格帯にXiaomi (180Hz) が存在するため、スペックだけで選ぶと負ける)\n[合計: 76]"
+    },
+    "technicalSpecs": {
+      "display": {
+        "size": "34インチ",
+        "resolution": "3440 x 1440 (UWQHD)",
+        "type": "VA非光沢",
+        "refreshRate": "165Hz",
+        "response": "1ms"
+      },
+      "dimensions": {
+        "width": "約81cm",
+        "height": "高さ調整対応",
+        "weight": "約9kg"
+      },
+      "connectivity": [
+        "HDMI 2.0 x 2",
+        "DisplayPort 1.4 x 2",
+        "Audio Out"
+      ],
+      "other": [
+        "1500R曲面",
+        "FreeSync Premium",
+        "HDR",
+        "フリッカーフリー",
+        "ブルーライトカット"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added investigation data for ASIN B0CRCZ1Q6L (Z-Edge UG34 Gaming Monitor).
Conducted PA-API search for product details and competitors.
Constructed the JSON file according to the specified format, including:
- Product overview and usage
- Competitive analysis with Xiaomi, CRUA, and cocopar
- Recommendation and scoring rationale
- Detailed technical specifications

---
*PR created automatically by Jules for task [13550129144953867558](https://jules.google.com/task/13550129144953867558) started by @aegisfleet*