### PR TITLE
Add investigation for cocopar 34" Monitor (B0FCLK86BL)

### DIFF
--- a/data/investigations/B0FCLK86BL.json
+++ b/data/investigations/B0FCLK86BL.json
@@ -1,0 +1,146 @@
+{
+  "analysis": {
+    "productName": "cocopar 34インチ UWQHD 165Hz 曲面ウルトラワイドモニター HG-4K34C",
+    "parentAsin": "B0G1SPRKKH",
+    "productDescription": "3万円台前半という圧倒的な低価格でUWQHD解像度と165Hzの高リフレッシュレートを実現した34インチ曲面モニター。同価格帯では珍しくUSB-C入力（15W給電）に対応しており、コストパフォーマンスに優れた一台。",
+    "productUsage": [
+      "FPSやレーシングゲームなどの広視野角・高リフレッシュレートを活かしたゲーミング用途",
+      "Excelとブラウザを並べて作業するなど、2画面分の作業領域を確保するデスクワーク",
+      "21:9のシネマスコープ比率での映画鑑賞",
+      "スマホやタブレットの映像をUSB-C一本で大画面に出力（給電能力には注意）"
+    ],
+    "positivePoints": [
+      "3万円台前半でUWQHD・165Hz・USB-C搭載という驚異的なコストパフォーマンス",
+      "USB Type-Cポート搭載により、対応デバイスからの映像出力がケーブル1本で可能（15W給電）",
+      "回転・高さ調整・チルト・スイベルに対応した多機能スタンドを標準装備",
+      "PIP/PBP機能により2つの入力を同時に表示可能"
+    ],
+    "negativePoints": [
+      "USB-Cの給電能力が最大15Wのため、ノートPCへの給電には不十分（別途電源が必要）",
+      "VAパネル特有の視野角の狭さや、高速な動きに対する若干の残像感（推定）",
+      "HDMI接続時はリフレッシュレートが最大100Hzに制限される（165HzはDP/USB-Cのみ）",
+      "発売直後のため長期的な信頼性やレビュー情報が不足している"
+    ],
+    "useCases": [
+      "予算を抑えつつ没入感のあるゲーム環境を構築したい場合",
+      "マルチモニターの代わりに1枚のウルトラワイドで作業効率を上げたい場合"
+    ],
+    "userStories": [
+      {
+        "userType": "ゲーマー（推測）",
+        "scenario": "FPSやレーシングゲームでの使用",
+        "experience": "1500Rの湾曲と横長の画面により、視界全体がゲーム画面に覆われるような没入感が得られる。165Hzの滑らかな描写も相まって、これまでの16:9モニターとは別次元の体験が可能。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "在宅ワーカー（推測）",
+        "scenario": "ノートPCと接続しての事務作業",
+        "experience": "USB-Cケーブル1本で映像出力ができるのは便利だが、給電が15Wしかないため、結局PCの電源アダプタも接続する必要があり、デスク周りの配線は期待したほどスッキリしない可能性がある。（推測）",
+        "sentiment": "mixed"
+      }
+    ],
+    "userImpression": "発売直後のためユーザーレビューはまだ蓄積されていないが、スペックと価格のバランスから、コスパ重視の層には非常に魅力的な選択肢として映るだろう。ただし、USB-C給電の弱さやパネル品質への過度な期待は禁物である。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B0FCLK86BL",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "Z-Edge UG34",
+        "asin": "B0CRCZ1Q6L",
+        "priceComparison": "ほぼ同価格帯（約3.3万円）",
+        "featureComparison": [
+          "165Hz、UWQHD、VAパネルなど基本スペックは酷似",
+          "USB-Cポート非搭載（HDMI/DPのみ）"
+        ],
+        "differentiators": [
+          "cocoparはUSB-C搭載でスマホ等の接続に有利",
+          "Z-Edgeは純粋なゲーミング仕様で差別化要素が少ない"
+        ]
+      },
+      {
+        "name": "IODATA GigaCrysta LCD-GCWQ341XDB/E",
+        "asin": "B0C6PV4SSH",
+        "priceComparison": "約1.7万円高い（約5万円）",
+        "featureComparison": [
+          "リフレッシュレートが75Hzと低い（cocoparは165Hz）",
+          "日本メーカー製で5年保証、リモコン付き"
+        ],
+        "differentiators": [
+          "cocoparはゲーミング性能（Hz）と価格で圧倒",
+          "IODATAは信頼性とサポート重視"
+        ]
+      },
+      {
+        "name": "ASUS TUF Gaming VG34VQL3A",
+        "asin": "B0D2948FZD",
+        "priceComparison": "約2万円高い（約5.3万円）",
+        "featureComparison": [
+          "180Hzの高リフレッシュレート",
+          "DisplayHDR 400認証取得"
+        ],
+        "differentiators": [
+          "ASUSはブランド力と画質性能で上回る",
+          "cocoparは半額近い価格で7-8割の性能を提供"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めてウルトラワイドモニターを導入するコスパ重視のゲーマー",
+        "スマホやタブレットを大画面で楽しみたいユーザー",
+        "ブランドにこだわらず、スペック対価格を最優先するユーザー"
+      ],
+      "pros": [
+        "3万円台で165Hz UWQHDが手に入る圧倒的安さ",
+        "USB-C映像入力に対応",
+        "多機能スタンド付属で設置の自由度が高い"
+      ],
+      "cons": [
+        "USB-C給電が15WのためPC充電用途には向かない",
+        "HDMI接続では100Hz制限がある",
+        "初期不良対応などのサポート面で国内メーカーほどの安心感はない"
+      ],
+      "score": 90,
+      "scoreRationale": "[基本点: 70]\n[コストパフォーマンス: +15] (3万円台前半でのUWQHD 165Hz USB-C搭載は市場破壊的な安さ)\n[性能・機能: +5] (基本スペックが高く、多機能スタンドも優秀。15W給電の弱点はあるが価格帯を考慮すれば十分な加点対象)\n[品質・デザイン: 0] (標準的なVA曲面パネルと推測)\n[ユーザー満足度: -5] (発売直後でレビュー実績がないためリスクとして減点)\n[独自の強み: +5] (この価格帯でUSB-C入力を備えている希少性)\n[合計: 90]"
+    },
+    "technicalSpecs": {
+      "os": null,
+      "cpu": null,
+      "ram": null,
+      "storage": null,
+      "display": {
+        "size": "34インチ",
+        "resolution": "3440×1440 (UWQHD)",
+        "type": "VA (非光沢)",
+        "refreshRate": "165Hz (DP/USB-C), 100Hz (HDMI)",
+        "curvature": "1500R"
+      },
+      "battery": null,
+      "camera": null,
+      "dimensions": {
+        "height": "42.3cm",
+        "width": "81.0cm",
+        "depth": "24.0cm",
+        "weight": "不明"
+      },
+      "connectivity": [
+        "USB Type-C x1 (15W PD/DP Alt)",
+        "HDMI 2.1(TMDS) x1",
+        "DisplayPort 1.4 x1",
+        "Audio Out"
+      ],
+      "other": [
+        "FreeSync",
+        "HDR",
+        "PIP/PBP",
+        "スピーカー内蔵",
+        "VESA対応"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added detailed investigation data for cocopar HG-4K34C monitor, including competitive analysis and technical specifications. The investigation highlights its high refresh rate and USB-C connectivity at a competitive price point.

---
*PR created automatically by Jules for task [9684960367769090828](https://jules.google.com/task/9684960367769090828) started by @aegisfleet*