### PR TITLE
Add investigation data for Sanwa Direct 400-VGA018

### DIFF
--- a/data/investigations/B0BPB5G1MR.json
+++ b/data/investigations/B0BPB5G1MR.json
@@ -1,0 +1,125 @@
+{
+  "analysis": {
+    "productName": "サンワダイレクト 400-VGA018 スタンド一体型ドッキングステーション",
+    "parentAsin": "B0F52WHZP6",
+    "productDescription": "ノートPCを立てて設置できるスタンドと一体化した、省スペース設計のUSB-Cドッキングステーションです。ケーブル1本で2画面出力や充電、有線LAN接続が可能です。",
+    "productUsage": [
+      "ノートPCを縦置き（クラムシェルモード）してデスクトップPCのように使用",
+      "USB-Cケーブル1本で外部モニター2台、キーボード、マウスを一括接続",
+      "PD 100W対応でノートPCを急速充電しながら作業"
+    ],
+    "positivePoints": [
+      "スタンド一体型でデスクスペースを有効活用できる",
+      "2画面同時出力（4K/30Hz）に対応し作業効率が向上",
+      "PD 100W給電に対応しており、ハイスペックPCでも安心",
+      "PC接触面にシリコーンゴムがあり、傷を防ぐ配慮がある"
+    ],
+    "negativePoints": [
+      "一般的なドッキングステーションと比較して価格がやや高め",
+      "据え置き専用の形状であり、持ち運びには適さない",
+      "Macでの2画面出力はMST非対応のためミラーリングになる制限がある（macOSの仕様）"
+    ],
+    "useCases": [
+      "MacBookをクラムシェルモードで使用するホームオフィス環境",
+      "デスクスペースが狭く、周辺機器をすっきりまとめたい場合"
+    ],
+    "userStories": [
+      {
+        "userType": "在宅勤務の会社員",
+        "scenario": "狭いデスクでのマルチモニター環境構築",
+        "experience": "（推測）ノートPCを開いて置くスペースがなかったが、この製品で縦置きすることでデスクが広くなり、外部モニター2枚で快適に作業できるようになった。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "MacBook Proユーザー",
+        "scenario": "外出と自宅作業の切り替え",
+        "experience": "（推測）帰宅後にケーブル1本を挿すだけで、充電とモニター、有線LANに一瞬で接続完了。クラムシェルモードでの運用が非常にスムーズになった。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "レビューデータ不足のため推測となるが、クラムシェルモードを多用するユーザーにとっては、スタンドとドックが一体化した本製品はデスク整理の最適解となり得る。",
+    "sources": [
+      {
+        "name": "Amazon Product Page Features",
+        "url": "https://www.amazon.co.jp/dp/B0BPB5G1MR",
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "サンワサプライ USB-CVDK18",
+        "asin": "B0DSJ919GB",
+        "priceComparison": "約15,800円（本製品より約2,000円安い）",
+        "featureComparison": [
+          "スタンド一体型で機能はほぼ同等",
+          "サンワサプライブランドの流通モデルと思われる"
+        ],
+        "differentiators": [
+          "機能差は少ないため、価格や販路で選択が変わる可能性がある"
+        ]
+      },
+      {
+        "name": "Anker Monitor Stand (10-in-1)",
+        "asin": "B0D5HPDTWX",
+        "priceComparison": "約17,990円（ほぼ同額）",
+        "featureComparison": [
+          "モニタースタンド型で、モニターを上に置ける",
+          "ポート数が多く、SDカードスロットなども充実"
+        ],
+        "differentiators": [
+          "設置面積はAnkerの方が大きいが、モニター下のデッドスペースを活用できる"
+        ]
+      },
+      {
+        "name": "エレコム DST-P060BPGY",
+        "asin": "B0FD2X5XB2",
+        "priceComparison": "約5,900円（半額以下）",
+        "featureComparison": [
+          "スマホ/タブレット向けスタンド型",
+          "機能は最小限（6-in-1）"
+        ],
+        "differentiators": [
+          "PCを縦置きして安定させるには本製品の方が適している"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "MacBook等のノートPCをクラムシェルモードで運用したい人",
+        "デスク上のケーブルを極限まで減らしたい人"
+      ],
+      "pros": [
+        "スタンドとハブが一体化しており省スペース",
+        "ケーブル1本でデスクトップ環境が整う利便性"
+      ],
+      "cons": [
+        "価格が高い",
+        "縦置き専用のためPCのディスプレイをサブモニターとして使いにくい"
+      ],
+      "score": 80,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] スタンド一体型というユニークな形状で、クラムシェル運用の利便性が高い。\n[加点: +5] PD 100W対応、2画面4K出力と、ドックとしての基本スペックも十分。\n[減点: -5] 17,000円台という価格は、単体ハブ+スタンドの合計よりも高価になる場合があり、コスパはやや劣る。\n[加点: +5] アルミ筐体やシリコン保護など、質感とPC保護への配慮が見られる（推測含む）。\n[合計: 80]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "size": "スタンド型（サイズ詳細不明だがコンパクト設計）",
+        "weight": "約220g（推測）"
+      },
+      "connectivity": [
+        "HDMI x 2 (4K/60Hz Max)",
+        "USB-A (USB3.2 Gen1) x 2",
+        "USB-C (PD 100W Input)",
+        "RJ-45 (Gigabit Ethernet)"
+      ],
+      "power": {
+        "pd_pass_through": "Max 100W",
+        "input": "USB-C"
+      },
+      "display_output": {
+        "max_resolution": "4K/60Hz (Single), 4K/30Hz (Dual)",
+        "note": "macOSではMST非対応のため複数画面への拡張出力に制限あり"
+      },
+      "compatibility": "Windows, macOS"
+    }
+  }
+}


### PR DESCRIPTION
Added market research data for Sanwa Direct 400-VGA018 (ASIN: B0BPB5G1MR).
Since no external reviews were found, user stories and pros/cons were inferred from product specifications and intended use cases (Clamshell mode, etc.).
Competitive analysis includes comparisons with Sanwa Supply, Anker, and Elecom products.

---
*PR created automatically by Jules for task [11398300535909055934](https://jules.google.com/task/11398300535909055934) started by @aegisfleet*