### PR TITLE
Add investigation for XUNDEFINED 34-inch Gaming Monitor

### DIFF
--- a/data/investigations/B0F4WWLXF4.json
+++ b/data/investigations/B0F4WWLXF4.json
@@ -1,0 +1,116 @@
+{
+  "analysis": {
+    "productName": "XUNDEFINED 34インチ 湾曲ゲーミングモニター",
+    "parentAsin": "B0FLQ7TTVL",
+    "productDescription": "180Hzの高速リフレッシュレートと1msの応答速度を誇る、34インチUWQHD曲面ゲーミングモニター。没入感のある1500Rの曲率と、広大な作業領域を提供するコストパフォーマンスに優れたモデルです。",
+    "productUsage": [
+      "FPSやアクションゲームでの高速プレイ（180Hz/1ms）",
+      "広大なデスクトップ領域を活用したマルチタスク作業（PIP/PBP対応）",
+      "映画鑑賞や動画編集（1500R曲面による没入感）"
+    ],
+    "positivePoints": [
+      "180Hzの高リフレッシュレートと1msの応答速度による滑らかな映像表現",
+      "34インチUWQHD（3440×1440）の高解像度と広大な表示領域",
+      "1500Rの曲面パネルによる高い没入感",
+      "PIP/PBP機能による効率的なマルチタスク環境",
+      "このスペックで3万円台という驚異的なコストパフォーマンス"
+    ],
+    "negativePoints": [
+      "VAパネル特有の視野角の狭さと残像感の懸念",
+      "HDR性能は標準的（輝度300cd/m²）",
+      "知名度が低く、長期的な信頼性が未知数"
+    ],
+    "useCases": [
+      "予算を抑えて本格的なゲーミング環境を構築したいFPSプレイヤー",
+      "ウルトラワイドモニターで作業効率を上げたいビジネスユーザー",
+      "没入感のある映像体験を求める映画ファン"
+    ],
+    "userStories": [
+      {
+        "userType": "FPS Gamer",
+        "scenario": "FPSゲームでの対戦プレイ",
+        "experience": "以前は60HzのフルHDモニターを使っていたが、この180Hzモニターに変えてから敵の動きが滑らかに見えるようになり、キルレートが上がった。曲面のおかげで画面端の情報も視界に入りやすい。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "Remote Worker",
+        "scenario": "Excelとブラウザを並べての作業",
+        "experience": "ノートPCの小さな画面で作業していたが、34インチUWQHDにしたことでExcelとブラウザを並べて作業できるようになり、効率が劇的に向上した。PIP機能で休憩中に動画を見るのも快適。（推測）",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "圧倒的なコストパフォーマンスで、スペック通りの性能を発揮すれば非常に満足度が高い製品。ブランド知名度の低さが懸念点だが、180Hzの高リフレッシュレートとUWQHD解像度は魅力的。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B0F4WWLXF4",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "CRUA 34インチ UWQHD 165Hz",
+        "asin": "B0DPKN9HXB",
+        "priceComparison": "約27,000円でXUNDEFINEDより安いが、リフレッシュレートが15Hz低い。",
+        "featureComparison": ["165Hzリフレッシュレート", "120% sRGB", "1500R曲率"],
+        "differentiators": ["さらに低価格", "リフレッシュレートが少し低い"]
+      },
+      {
+        "name": "Xiaomi G34WQi",
+        "asin": "B0CWS2YKNK",
+        "priceComparison": "約34,000円でXUNDEFINEDより高いが、ブランド信頼性は高い。",
+        "featureComparison": ["180Hzリフレッシュレート", "100% sRGB", "FreeSync Premium"],
+        "differentiators": ["ブランドの信頼性", "RGBライティング"]
+      },
+      {
+        "name": "KOORUI 34インチ WQHD 180Hz",
+        "asin": "B0BZYP24JC",
+        "priceComparison": "約38,000円でXUNDEFINEDより高い。",
+        "featureComparison": ["180Hzリフレッシュレート", "HDR400", "1ms応答速度"],
+        "differentiators": ["HDR400対応", "価格が高い"]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": ["コスパ重視のゲーマー", "作業効率を重視するビジネスユーザー"],
+      "pros": ["180Hzの高リフレッシュレート", "UWQHDの高解像度", "圧倒的な低価格"],
+      "cons": ["ブランドの信頼性", "VAパネルの特性（視野角・残像感）"],
+      "score": 80,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (180Hzの高リフレッシュレートとUWQHD解像度は同価格帯で優秀)\n[加点: +10] (競合製品よりも低価格で高いスペックを提供しており、コストパフォーマンスが非常に高い)\n[減点: -5] (ブランド知名度が低く、長期的な信頼性やサポート体制に懸念がある)\n[合計: 80]"
+    },
+    "technicalSpecs": {
+      "display": {
+        "size": "34インチ",
+        "resolution": "3440×1440 (UWQHD)",
+        "type": "VA",
+        "refreshRate": "180Hz",
+        "responseTime": "1ms (MPRT)",
+        "curvature": "1500R",
+        "contrast": "4000:1",
+        "brightness": "300cd/m²",
+        "colorGamut": "126% sRGB"
+      },
+      "connectivity": [
+        "HDMI 2.0 × 2",
+        "DisplayPort 1.4 × 2",
+        "3.5mm Audio Out"
+      ],
+      "features": [
+        "FreeSync & G-Sync Compatible",
+        "PIP/PBP",
+        "HDR",
+        "Blue Light Filter",
+        "Flicker Free"
+      ],
+      "dimensions": {
+        "vesa": "75×75mm",
+        "tilt": "-5°~25°",
+        "swivel": "±45°",
+        "heightAdjust": "13.5cm"
+      },
+      "audio": {
+        "speakers": "2×3W Built-in"
+      }
+    }
+  }
+}


### PR DESCRIPTION
XUNDEFINED 34インチ 湾曲ゲーミングモニター (B0F4WWLXF4) の詳細調査結果を追加しました。
競合比較（CRUA, Xiaomi, KOORUI）、ユーザー推測ストーリー、および詳細な技術仕様を含みます。
スコア算出は指定されたルーブリックに基づき、80点としています。

---
*PR created automatically by Jules for task [15370246737724886712](https://jules.google.com/task/15370246737724886712) started by @aegisfleet*