### PR TITLE
Add investigation data for Moondrop DawnPro 2

### DIFF
--- a/data/investigations/B0GFD3CV9N.json
+++ b/data/investigations/B0GFD3CV9N.json
@@ -1,0 +1,124 @@
+{
+  "analysis": {
+    "productName": "水月雨 Moondrop 破暁 – DawnPro 2",
+    "parentAsin": "B0GFD3CV9N",
+    "productDescription": "デュアルCS43198 DACチップと独立した3つのLDO電源チップを搭載した、ハイレゾ対応ポータブルDAC/AMP。100段階の精密な音量調整が可能で、4.4mmバランス接続と3.5mmシングルエンド接続の両方に対応しています。",
+    "productUsage": [
+      "スマートフォンでの高音質音楽再生（Apple Music, Amazon Music HDなど）",
+      "PC/ラップトップに接続してのハイレゾ再生",
+      "高感度イヤホン（IEM）からヘッドホンまでの駆動"
+    ],
+    "positivePoints": [
+      "デュアルCS43198搭載による高い解像度と低歪み",
+      "スマホから独立した100段階のハードウェアボリューム調整",
+      "放熱性を考慮したエアフロー孔付きアルミニウム合金筐体",
+      "3つの独立LDO電源チップによる安定した電源供給",
+      "コストパフォーマンスの高さ"
+    ],
+    "negativePoints": [
+      "高負荷時の発熱の可能性（エアフローで改善されているとはいえ注意が必要）",
+      "専用アプリ（Moondrop Link）の接続性や使い勝手に改善の余地がある場合がある",
+      "ケーブル接続部に負荷がかかりやすいため、丁寧な取り扱いが必要"
+    ],
+    "useCases": [
+      "通勤・通学時のスマートフォンでの音楽鑑賞",
+      "カフェやオフィスでのPC作業中の高音質リスニング",
+      "ゲーミング用途（高解像度による定位感の向上）"
+    ],
+    "userStories": [
+      {
+        "userType": "オーディオファン",
+        "scenario": "高感度IEMでの音楽鑑賞",
+        "experience": "（推測）前作Dawn Proで好評だった独立ボリューム調整が継承されており、100段階の調整により、能率の高いイヤホンでも最適な音量を得やすい。CS43198デュアル構成によるS/N比の高さが、静寂時のノイズレスな背景を実現しているだろう。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "スマホユーザー",
+        "scenario": "外出先でのハイレゾストリーミング",
+        "experience": "（推測）軽量なアルミニウム筐体は持ち運びに負担にならず、USB Type-C接続で手軽にスマホの音質を向上できる。新しいエアフロー設計により、長時間使用時の熱ごもりが軽減されていることが期待できる。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "1万円台前半という価格帯ながら、デュアルDAC、バランス接続、独立ボリューム制御を備えた極めてコストパフォーマンスの高い製品。前作からの正統進化として、音質と使い勝手の両立が評価される。",
+    "sources": [
+      {
+        "name": "Amazon Product Page Features",
+        "url": "https://www.amazon.co.jp/dp/B0GFD3CV9N",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "QDC QD1",
+        "asin": "B0DHCVHXG7",
+        "priceComparison": "約8,000円と本製品より安価",
+        "featureComparison": [
+          "同じくCS43198デュアルDAC搭載",
+          "2段階ゲイン切替",
+          "よりシンプルなデザイン"
+        ],
+        "differentiators": [
+          "価格の安さではQDC QD1が優位",
+          "DawnPro 2は100段階ボリュームや放熱設計で機能的に差別化"
+        ]
+      },
+      {
+        "name": "TRN TE Pro",
+        "asin": "B0DDXPYG8P",
+        "priceComparison": "約12,950円と本製品より若干高価",
+        "featureComparison": [
+          "CS43198チップ搭載",
+          "32bit/768kHz対応（DawnPro 2は384kHzまで記載）",
+          "出力端子は同等"
+        ],
+        "differentiators": [
+          "DawnPro 2の方が安価で入手しやすい可能性がある",
+          "ブランド認知度ではMoondropが優勢な場合がある"
+        ]
+      },
+      {
+        "name": "SHANLING UA4",
+        "asin": "B0DTTLZ9BD",
+        "priceComparison": "約16,830円と高価",
+        "featureComparison": [
+          "ESS ES9069Q DAC搭載",
+          "ディスプレイ搭載でステータス確認が可能",
+          "物理ボタンによる操作性"
+        ],
+        "differentiators": [
+          "ディスプレイの有無が大きな違い",
+          "音質の傾向（ESS系 vs Cirrus Logic系）で好みが分かれる"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "スマホで手軽に高音質を楽しみたいユーザー",
+        "4.4mmバランス接続を試してみたい初心者〜中級者",
+        "コストパフォーマンス重視のオーディオファン"
+      ],
+      "pros": [
+        "価格以上の高スペック（CS43198 Dual, バランス出力）",
+        "微調整可能なハードウェアボリューム",
+        "放熱を考慮した設計"
+      ],
+      "cons": [
+        "PC接続時にドライバインストールが必要な場合がある",
+        "付属ケーブルの耐久性に注意"
+      ],
+      "score": 90,
+      "scoreRationale": "[基本点: 70]\n[性能・機能: +8] (CS43198 Dual, 独立ボリューム, エアフロー設計)\n[コストパフォーマンス: +10] (1万円強でこのスペックは非常に高い)\n[品質・デザイン: +2] (アルミ合金、放熱考慮のデザイン)\n[合計: 90]"
+    },
+    "technicalSpecs": {
+      "dac": "Cirrus Logic CS43198 x2",
+      "decoding": "PCM 32bit/384kHz, DSD256",
+      "outputs": "3.5mm Single-ended, 4.4mm Balanced",
+      "volumeControl": "100 steps hardware volume (independent)",
+      "powerSupply": "3 Independent LDO chips",
+      "interface": "USB Type-C",
+      "body": "Aluminum Alloy with Airflow Vents",
+      "dimensions": null
+    }
+  }
+}


### PR DESCRIPTION
Added detailed product analysis for Moondrop DawnPro 2, including product overview, user stories (inferred), competitive analysis with QDC QD1 and TRN TE Pro, and technical specifications. Used PA-API data for accurate feature extraction.

---
*PR created automatically by Jules for task [13511677557348403676](https://jules.google.com/task/13511677557348403676) started by @aegisfleet*