### PR TITLE
Add investigation data for B0DVGRKJV6

### DIFF
--- a/data/investigations/B0DVGRKJV6.json
+++ b/data/investigations/B0DVGRKJV6.json
@@ -1,0 +1,81 @@
+{
+  "analysis": {
+    "productName": "エレコム USBハブ 4ポート U3H-H042BK/E",
+    "parentAsin": "B0DVLV2GQY",
+    "productDescription": "USB-Aポートを4つ増設できる、小型・軽量のUSBハブです。",
+    "productUsage": [
+      "ノートPCのUSBポート増設",
+      "マウスやキーボードなどの周辺機器接続",
+      "USBメモリなどのデータ転送"
+    ],
+    "positivePoints": [
+      "持ち運びに便利な小型・軽量設計(約33g)",
+      "国内メーカー製ながら手頃な価格",
+      "USB3.2(Gen1)対応で高速データ転送が可能"
+    ],
+    "negativePoints": [
+      "ケーブルが15cmと短いためデスクトップPCには不向き",
+      "バスパワー専用のため消費電力の大きい機器（HDDなど）には向かない場合がある",
+      "競合のBuffalo製品の方が安い場合がある"
+    ],
+    "useCases": [
+      "外出先でのノートPC作業",
+      "カフェやオフィスでのテレワーク",
+      "ポート数の少ない薄型ノートPCの拡張"
+    ],
+    "userStories": [
+      {
+        "userType": "ビジネスマン",
+        "scenario": "出張時のホテルでの作業",
+        "experience": "PCのポートが足りない時にさっと取り出してマウスとUSBメモリを同時に使えた。軽くて邪魔にならない。（推測）",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "必要な機能を備え、軽量で持ち運びに適したスタンダードなUSBハブ。安価で信頼できる選択肢。",
+    "sources": [
+      {
+        "name": "Amazon.co.jp 商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0DVGRKJV6",
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "Buffalo BSH4U125U3BK",
+        "asin": "B07XPMR5CW",
+        "priceComparison": "本製品より約100円安い",
+        "featureComparison": ["機能はほぼ同等", "国内メーカー製"],
+        "differentiators": ["価格の安さ"]
+      },
+      {
+        "name": "Anker Ultra Slim 4-Port Hub",
+        "asin": "B07ST84PF5",
+        "priceComparison": "本製品より約80円高い",
+        "featureComparison": ["Ankerブランド", "ウルトラスリム設計"],
+        "differentiators": ["ブランドの信頼性", "18ヶ月保証"]
+      },
+      {
+        "name": "UGREEN USB 3.0 Hub",
+        "asin": "B0CD1BHXPZ",
+        "priceComparison": "本製品より約170円安い",
+        "featureComparison": ["海外ブランド", "コスパ重視"],
+        "differentiators": ["圧倒的な安さ"]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": ["持ち運び用のUSBハブを探している人", "国内メーカーの安心感を求める人"],
+      "pros": ["軽量コンパクト", "十分な転送速度", "手頃な価格"],
+      "cons": ["ケーブルが短い", "バスパワー専用"],
+      "score": 72,
+      "scoreRationale": "[基本点: 70]\n[コストパフォーマンス: +2] (Ankerより安いが、BuffaloやUGREENなどの競合が存在するため微増)\n[品質・デザイン: 0] (標準的なプラスチック筐体)\n[性能・機能: 0] (必要十分な機能)\n[合計: 72]"
+    },
+    "technicalSpecs": {
+      "ports": "4 x USB-A (USB3.2 Gen1 / 5Gbps)",
+      "cableLength": "15cm",
+      "dimensions": { "thickness": "約10mm", "weight": "約33g" },
+      "power": "バスパワー",
+      "compatibility": "Windows, Mac, Chromebook等"
+    }
+  }
+}


### PR DESCRIPTION
Added investigation data for Elecom USB Hub (B0DVGRKJV6) in data/investigations/B0DVGRKJV6.json.
Included product details, competitive analysis, and scoring based on the standardized rubric.

---
*PR created automatically by Jules for task [2849061478225055236](https://jules.google.com/task/2849061478225055236) started by @aegisfleet*