### PR TITLE
Add investigation data for UGREEN USB-C Hub (B0D9Q9WCLX)

### DIFF
--- a/data/investigations/B0D9Q9WCLX.json
+++ b/data/investigations/B0D9Q9WCLX.json
@@ -1,0 +1,116 @@
+{
+  "analysis": {
+    "productName": "UGREEN USB-C ハブ 10Gbps 5-in-1 (4x USB-Cデータ + PD 100W)",
+    "parentAsin": "B0D9Q9WCLX",
+    "productDescription": "4つのUSB-C 3.2 Gen 2データポート（最大10Gbps）と1つの100W PD充電ポートを搭載した、USB-C特化型の拡張ハブ。",
+    "productUsage": [
+      "MacBook Air/ProなどのUSB-Cポート不足を解消し、4台のUSB-C機器を同時接続",
+      "外付けSSDやUSBメモリ間での最大10Gbpsの高速データ転送",
+      "PC本体を最大100Wで急速充電しながらの周辺機器利用（パススルー充電）",
+      "スマートフォンやタブレット（iPad/Galaxy）への周辺機器接続"
+    ],
+    "positivePoints": [
+      "圧倒的なコストパフォーマンス（同等スペックの競合他社製品の半額以下）",
+      "全データポートがUSB-Cかつ10Gbps対応という先進的な構成",
+      "100W PD充電ポートを搭載しており、ハブ利用中もPCへの給電が可能",
+      "コンパクトで軽量（約50g）、持ち運びに適したデザイン"
+    ],
+    "negativePoints": [
+      "HDMIやDisplayPortなどの映像出力ポートは非搭載",
+      "USB-Aポートがないため、旧来のUSB機器を使用するには変換が必要",
+      "データポートは映像出力や充電（給電）には非対応（データ転送のみ）"
+    ],
+    "useCases": [
+      "USB-C端子の外付けSSDを複数台接続して動画データを整理するクリエイター",
+      "MacBook Airのポートを塞がずに充電しながら、スマホとタブレットを同期したいユーザー",
+      "USB-C周辺機器でデスク環境を統一しているミニマリスト"
+    ],
+    "userStories": [
+      {
+        "userType": "動画クリエイター（30代男性）",
+        "scenario": "外出先での動画編集作業",
+        "experience": "MacBook Airのポートが2つしかなく、充電とSSD接続で埋まってしまうのが悩みだった。このハブなら充電しながら複数のSSDやカードリーダー（USB-C接続）を繋げられ、しかも転送速度が10Gbpsと速いので大容量ファイルの移動もストレスがない。何より2000円以下で買えるのは驚き。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "大学生（20代女性）",
+        "scenario": "大学でのレポート作成とスマホ充電",
+        "experience": "iPad Proで作業する際、充電しながらUSB-Cメモリを使いたくて購入。純正や有名メーカー品は高いが、これは非常に安くて機能も十分。ただ、たまに持っているUSB-Aのメモリを使いたい時に変換が必要なのが少し不便だと気づいた。",
+        "sentiment": "mixed"
+      }
+    ],
+    "userImpression": "「USB-Cポートだけを増やしたい」という明確なニーズを持つユーザーにとっての最適解。映像出力やUSB-Aを排除した割り切った仕様により、驚異的な低価格と小型化を実現しており、サブのハブとしても非常に優秀と評価できる。",
+    "sources": [
+      {
+        "name": "UGREEN Official Product Page (Amazon)",
+        "url": "https://www.amazon.co.jp/dp/B0D9Q9WCLX",
+        "credibility": "high"
+      }
+    ],
+    "lastInvestigated": "2026-01-31",
+    "competitiveAnalysis": [
+      {
+        "name": "Selore USB Cハブ 5ポート (4xUSB-C + PD)",
+        "asin": "B0DLB7L8M6",
+        "priceComparison": "約3,700円前後。UGREENの約2倍の価格。",
+        "featureComparison": [
+          "ポート構成はほぼ同じ（4x Data + 1x PD）",
+          "どちらも10Gbps対応"
+        ],
+        "differentiators": [
+          "機能差はほとんどないが、価格差が大きい",
+          "ブランド認知度はUGREENの方が高い傾向"
+        ]
+      },
+      {
+        "name": "UGREEN 4-in-1 USB-Cハブ (B0C4DFB8RH)",
+        "asin": "B0C4DFB8RH",
+        "priceComparison": "約3,800円前後。本製品より高い。",
+        "featureComparison": [
+          "こちらは4ポート（データのみの場合や構成違いあり）",
+          "本製品（B0D9Q9WCLX）の方がポート数が多く安い"
+        ],
+        "differentiators": [
+          "本製品は新モデルまたはWeb限定等の理由で戦略的な低価格設定になっている可能性がある"
+        ]
+      },
+      {
+        "name": "Aceele USB Cハブ 4ポート (B0FQNP3NHQ)",
+        "asin": "B0FQNP3NHQ",
+        "priceComparison": "約2,100円前後。近い価格帯。",
+        "featureComparison": [
+          "データポートのみでPD充電ポートがない（または明確な記載が弱い）",
+          "ケーブル長が選べるモデルがある"
+        ],
+        "differentiators": [
+          "PD充電（100W）の有無が決定的違い。充電しながら使いたいならUGREEN一択"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "USB-C接続の周辺機器（SSD、スマホ等）が多いユーザー",
+        "MacBook Airなどポート数の少ないPCを使用している人",
+        "安価に高速なポート拡張を行いたい人"
+      ],
+      "pros": [
+        "市場破壊的な低価格（1000円台後半）",
+        "全ポートUSB-Cかつ10Gbps対応の高性能",
+        "100W PDパススルー充電対応"
+      ],
+      "cons": [
+        "USB-A機器やHDMI出力は使えない（割り切りが必要）",
+        "データポートからの映像出力は不可"
+      ],
+      "score": 93,
+      "scoreRationale": "[基本点: 70]\n[コストパフォーマンス: +15] (10Gbps対応でPD付きかつ1800円台は競合の半額以下であり、極めて高いコスパ)\n[性能・機能: +3] (映像出力はないが、USB-C x4 + PDという構成は需要に対して適切かつ高性能)\n[独自の強み: +5] (USB-Aを完全に廃したフルUSB-C構成という先進性)\n[品質・デザイン: +0] (標準的なUGREEN品質)\n[合計: 93]"
+    },
+    "technicalSpecs": {
+      "dimensions": { "height": "1.3cm", "width": "10.4cm", "depth": "3.8cm", "weight": "50g" },
+      "connectivity": ["USB-C 3.2 Gen 2 (10Gbps) x 4", "USB-C PD 3.0 (100W Input) x 1"],
+      "power": "100W PD Pass-through Charging",
+      "compatibility": ["Windows", "macOS", "Linux", "iPadOS", "Android", "iOS"],
+      "other": ["Driver-free (Plug & Play)", "OTG Support"]
+    }
+  }
+}


### PR DESCRIPTION
Added detailed product analysis, competitive comparison, and scoring for UGREEN 5-in-1 USB-C Hub (B0D9Q9WCLX).

---
*PR created automatically by Jules for task [7166033746976020370](https://jules.google.com/task/7166033746976020370) started by @aegisfleet*