### PR TITLE
Investigate USB-C Magnetic Adapter B09WJWQMML

### DIFF
--- a/data/investigations/B09WJWQMML.json
+++ b/data/investigations/B09WJWQMML.json
@@ -1,0 +1,115 @@
+{
+  "analysis": {
+    "productName": "DuHeSin USB-C マグネットアダプター (24ピン/2個セット)",
+    "parentAsin": "B0DXDZ3DGF",
+    "productDescription": "USB-Cケーブルをマグネット着脱式に変換し、ポート保護と利便性を向上させる24ピンアダプター（2個セット）。",
+    "productUsage": [
+      "MacBookやスマホの充電ポートに装着し、ケーブルの抜き差しを容易にする",
+      "ケーブルに足を引っ掛けた際のデバイス落下防止（MagSafeライクな使用感）",
+      "頻繁な抜き差しによるUSB-Cポートの摩耗・破損防止"
+    ],
+    "positivePoints": [
+      "24ピン全結線仕様により、充電(100W)、データ(10Gbps)、映像(4K)の全てに対応",
+      "L字型ではなくストレート型なので、隣接ポートに干渉しにくい",
+      "強力なマグネットで確実に接続される"
+    ],
+    "negativePoints": [
+      "同等スペックの競合他社品と比較して価格が非常に高い（約1.5〜2倍）",
+      "USB-IF非準拠の規格外製品であり、理論上ショートや発熱のリスクがある",
+      "端子部分が小さく、紛失しやすい"
+    ],
+    "useCases": [
+      "デスクワーク中のMacBook充電（不意のケーブル引っ掛け対策）",
+      "車内など不安定な場所でのスマートフォン充電"
+    ],
+    "userStories": [
+      {
+        "userType": "MacBook Proユーザー",
+        "scenario": "カフェでの作業中",
+        "experience": "トイレに立つ際にケーブルを抜く手間が省け、戻ったときも近づけるだけでパチっと繋がり快適。（推測）",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "ガジェット好き",
+        "scenario": "複数デバイスの運用",
+        "experience": "全てのデバイスにチップをつけておけば、1本のケーブルで使い回せるのが非常に便利。（推測）",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "MagSafeのような利便性を汎用USB-C機器で実現できる点は評価されているが、価格設定が競合に比べて強気である。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B09WJWQMML",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-02-01",
+    "competitiveAnalysis": [
+      {
+        "name": "DuHeSin USB-C マグネットアダプター (40Gbpsモデル)",
+        "asin": "B09WRC7KK8",
+        "priceComparison": "同価格帯",
+        "featureComparison": [
+          "こちらは40Gbps/8K対応の上位スペック"
+        ],
+        "differentiators": [
+          "価格が同じなら、スペックの高いB09WRC7KK8の方が推奨される"
+        ]
+      },
+      {
+        "name": "EC-GOOD 24ピン マグネットアダプター",
+        "asin": "B0D8XN5XKJ",
+        "priceComparison": "約35%安い (￥1,280)",
+        "featureComparison": [
+          "同等の24ピン、100W、10Gbps、4K対応"
+        ],
+        "differentiators": [
+          "機能差はほぼなく、コストパフォーマンスで圧倒的に優れる"
+        ]
+      },
+      {
+        "name": "fine-R USB4 マグネットアダプター",
+        "asin": "B0BPS42YFN",
+        "priceComparison": "約50%安い (￥998)",
+        "featureComparison": [
+          "USB4 (40Gbps) 対応でスペックも上"
+        ],
+        "differentiators": [
+          "スペック、価格ともに本製品を上回る"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "DuHeSinブランドで統一したいユーザー",
+        "特定の形状（ストレート型かつ特定デザイン）を求めるユーザー"
+      ],
+      "pros": [
+        "ポート保護と着脱の利便性",
+        "フル機能対応（充電・データ・映像）"
+      ],
+      "cons": [
+        "コストパフォーマンスが非常に悪い",
+        "USB規格外による潜在的リスク"
+      ],
+      "score": 60,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (利便性とフル機能対応)\n[減点: -15] (競合他社製品と比較して価格が高すぎ、コスパが悪い)\n[合計: 60]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "width": "N/A",
+        "height": "N/A",
+        "depth": "N/A",
+        "weight": "20g"
+      },
+      "power": "Max 100W (20V/5A)",
+      "capacity": null,
+      "other": [
+        "USB 3.1 Gen2 (10Gbps)",
+        "4K@60Hz Video",
+        "24-pin design"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Investigated the DuHeSin USB-C Magnetic Adapter (B09WJWQMML). The analysis highlights its functionality (24-pin, 100W PD, 4K video) but notes a significantly higher price point compared to competitors with similar or better specifications. The score reflects this price/performance disparity.

---
*PR created automatically by Jules for task [13644147842772210126](https://jules.google.com/task/13644147842772210126) started by @aegisfleet*