### PR TITLE
Add investigation data for B0FT2DGWRN (Elecom USB Hub)

### DIFF
--- a/data/investigations/B0FT2DGWRN.json
+++ b/data/investigations/B0FT2DGWRN.json
@@ -1,0 +1,134 @@
+{
+  "analysis": {
+    "productName": "エレコム USBハブ USB-C 直挿し 3ポート U3HC-R030EBK",
+    "parentAsin": "B0FT8XXFRG",
+    "productDescription": "USB-Cポートに直挿しできるケーブルレスの3ポートUSBハブ。180度回転するスイングコネクターにより、PCやタブレットの側面に沿わせてスッキリ設置できます。",
+    "productUsage": [
+      "ノートPCやタブレット（iPad等）のUSB-CポートをUSB-Aポートx3に拡張",
+      "マウス、キーボード、USBメモリなどの周辺機器の接続",
+      "外出先やカフェでの省スペース作業（ケーブルレス運用）"
+    ],
+    "positivePoints": [
+      "ケーブルがないため持ち運びに便利で、デスク上がスッキリする",
+      "180度スイングコネクタで、隣接するポートへの干渉を回避しやすい",
+      "3ポート全てがUSB 5Gbps (USB 3.0) に対応し、高速データ転送が可能",
+      "国内メーカー（エレコム）製であることの安心感"
+    ],
+    "negativePoints": [
+      "厚みのあるPCケースやタブレットケースを使用していると、コネクタが奥まで挿さらない場合がある",
+      "直挿しタイプのため、接続機器の重みでポートに負荷がかかる可能性がある",
+      "USB PD（Power Delivery）パススルー充電には非対応（充電しながらの使用は不可）"
+    ],
+    "useCases": [
+      "カフェや移動中の新幹線など、狭いスペースでのPC作業",
+      "iPadでのキーボード・マウス接続によるPCライクな活用",
+      "ポート数が少ない薄型ノートPC（MacBook Airなど）の拡張"
+    ],
+    "userStories": [
+      {
+        "userType": "30代フリーランス (推測)",
+        "scenario": "カフェでのリモートワーク",
+        "experience": "ケーブルがぶら下がらないので、狭いテーブルでも邪魔にならず快適。MacBookの側面にピタッと沿わせられるので見た目もスマート。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "大学生 (推測)",
+        "scenario": "大学でのプレゼン資料作成",
+        "experience": "USBメモリでデータを受け渡す際、充電ケーブルと干渉しがちだったが、コネクタを回転させることで両方同時に使えて便利。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "レビュー数はまだ少ないが、持ち運びやすさと実用性を兼ね備えた製品として評価できる。特に「回転式直挿し」による設置の柔軟性と、全ポート高速転送対応という基本性能の高さが魅力。",
+    "sources": [
+      {
+        "name": "Amazon.co.jp 商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0FT2DGWRN",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-02-01",
+    "competitiveAnalysis": [
+      {
+        "name": "ALLVD USBハブ 回転式 (B0C93PGR84)",
+        "asin": "B0C93PGR84",
+        "priceComparison": "約650円と非常に安価だが、機能面で劣る",
+        "featureComparison": [
+          "USB 3.0 x1 + USB 2.0 x2 (本製品は全ポートUSB 3.0)",
+          "回転機構あり"
+        ],
+        "differentiators": [
+          "価格の安さ",
+          "転送速度の遅さ (USB 2.0混在)"
+        ]
+      },
+      {
+        "name": "サンワサプライ USB-3TCH24SN (B09ZV26GX6)",
+        "asin": "B09ZV26GX6",
+        "priceComparison": "約2,000円とやや高価",
+        "featureComparison": [
+          "USB-A x1 + USB-C x1 (本製品はUSB-A x3)",
+          "スリムな直挿しだが回転機構なし"
+        ],
+        "differentiators": [
+          "Type-Cポート搭載",
+          "アルミボディの質感"
+        ]
+      },
+      {
+        "name": "エレコム U2H-TZ325BGY/EC (B08TH4KFVP)",
+        "asin": "B08TH4KFVP",
+        "priceComparison": "約1,000円と安価",
+        "featureComparison": [
+          "USB 2.0 x3 (本製品はUSB 3.0 x3)",
+          "同じく回転式直挿し"
+        ],
+        "differentiators": [
+          "転送速度 (USB 2.0は遅いためマウス等向き)",
+          "価格"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "頻繁にノートPCを持ち歩くビジネスマンや学生",
+        "iPadやMacBookのポートをすっきり拡張したいユーザー",
+        "USBメモリなどでの高速データ転送が必要なユーザー"
+      ],
+      "pros": [
+        "ケーブルレスで携帯性が高い",
+        "180度回転でポート干渉を防げる",
+        "全ポートUSB 5Gbps対応で高速"
+      ],
+      "cons": [
+        "ケース装着時に挿さらない可能性がある",
+        "パススルー充電機能はない"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (180度回転スイングコネクタによる高い利便性と設置自由度)\n[加点: +5] (全3ポートがUSB 5Gbps対応で、このサイズとしては高性能)\n[加点: +5] (1500円台という手頃な価格で、安価な中華製より信頼性が高い)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "os": null,
+      "cpu": null,
+      "ram": null,
+      "storage": null,
+      "display": null,
+      "battery": null,
+      "camera": null,
+      "dimensions": {
+        "height": "29mm",
+        "width": "65mm",
+        "depth": "21mm",
+        "weight": "21g"
+      },
+      "connectivity": [
+        "USB-C (PC側)",
+        "USB-A x3 (USB 5Gbps/USB3.0)"
+      ],
+      "other": [
+        "180度スイングコネクタ",
+        "バスパワー専用",
+        "ケーブルレス直挿し"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add investigation data for Elecom USB Hub U3HC-R030EBK (B0FT2DGWRN). The JSON includes product analysis, competitive comparison, user stories (inferred due to lack of reviews), and a standardized score calculation.

---
*PR created automatically by Jules for task [13894995909673576093](https://jules.google.com/task/13894995909673576093) started by @aegisfleet*