### PR TITLE
Add investigation data for Xiaomi POCO Pad (B0G6L5NRY8)

### DIFF
--- a/data/investigations/B0G6L5NRY8.json
+++ b/data/investigations/B0G6L5NRY8.json
@@ -1,0 +1,151 @@
+{
+  "analysis": {
+    "productName": "Xiaomi POCO Pad",
+    "parentAsin": "B0GKLTFYQD",
+    "productDescription": "12.1インチの大型2.5Kディスプレイと120Hzリフレッシュレートを備えた、エンターテインメントに最適なAndroidタブレットです。",
+    "productUsage": [
+      "大画面での映画やアニメの動画視聴",
+      "電子書籍や雑誌の閲覧",
+      "ブラウジングやSNSの閲覧",
+      "別売りのペンやキーボードを組み合わせた軽作業"
+    ],
+    "positivePoints": [
+      "12.1インチの大画面で2.5K解像度、120Hz駆動とディスプレイ性能が高い",
+      "Snapdragon 7s Gen 2搭載で、日常使いや軽いゲームには十分な性能",
+      "Dolby Atmos対応のクアッドスピーカーによる迫力あるサウンド",
+      "10000mAhの大容量バッテリーと33W急速充電",
+      "同クラスの競合と比較してコストパフォーマンスが非常に高い"
+    ],
+    "negativePoints": [
+      "GPS非搭載のため、ナビゲーション用途には不向き",
+      "生体認証が顔認証のみで指紋認証がない",
+      "Amazonの商品説明に一部スペックの誤記（SoC世代やバッテリー容量）が見られるため注意が必要"
+    ],
+    "useCases": [
+      "自宅でのエンターテインメント消費用タブレットとして",
+      "学生の学習用・資料閲覧用デバイスとして",
+      "外出先でのプレゼンテーションやサブモニターとして"
+    ],
+    "userStories": [
+      {
+        "userType": "30代 男性 会社員",
+        "scenario": "自宅でのリラックスタイムに",
+        "experience": "スマホでは画面が小さく、PCを開くのは億劫な時に、ソファで寝転がりながらYouTubeやNetflixを見るのに最適。画質も音も良く、バッテリー持ちも良いので充電を気にせず使える。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "大学生",
+        "scenario": "大学の講義と課題作成",
+        "experience": "PDFの教科書を開きながらノートを取るのに十分な画面サイズ。iPadは高くて手が出なかったが、この価格でこの性能なら満足。キーボードと合わせてレポート作成にも使っている。",
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "圧倒的なコストパフォーマンスが高く評価されている。特にディスプレイの美しさとスピーカーの音質に対する満足度が高い。一方で、GPSがない点や指紋認証がない点を惜しむ声もあるが、価格を考えれば納得という意見が大半。",
+    "sources": [
+      {
+        "name": "Amazon Product Page",
+        "url": "https://www.amazon.co.jp/dp/B0G6L5NRY8",
+        "credibility": "High"
+      }
+    ],
+    "lastInvestigated": "2026-02-01",
+    "competitiveAnalysis": [
+      {
+        "name": "Xiaomi Redmi Pad Pro",
+        "asin": "B0D6N7GW4P",
+        "priceComparison": "ほぼ同等のスペックだが、POCO Padの方が実売価格が安い場合が多い。",
+        "featureComparison": [
+          "スペックはほぼ共通（Snapdragon 7s Gen 2, 12.1インチなど）",
+          "POCOブランドならではのデザイン違い",
+          "Redmi Pad Proは販路によっては保証やサポートが手厚い場合がある"
+        ],
+        "differentiators": [
+          "ブランドとデザイン",
+          "コストパフォーマンス（POCOが有利な傾向）"
+        ]
+      },
+      {
+        "name": "Apple iPad (第10世代)",
+        "asin": "B0DZ895SXY",
+        "priceComparison": "iPadの方が約1.4万円高い。",
+        "featureComparison": [
+          "iPadは10.9インチ 60Hz液晶、POCOは12.1インチ 120Hz液晶",
+          "iPadOSのアプリ品質とエコシステムはiPadが優位",
+          "POCOは基本ストレージが256GBに対し、同価格帯のiPadは64GB"
+        ],
+        "differentiators": [
+          "OS（iPadOS vs Android）",
+          "リフレッシュレート（60Hz vs 120Hz）",
+          "ストレージ容量のコスパ"
+        ]
+      },
+      {
+        "name": "Apple iPad (第9世代) 整備済み品",
+        "asin": "B0BKPM58BP",
+        "priceComparison": "整備済み品であればiPad 第9世代の方が5000円程度安い。",
+        "featureComparison": [
+          "iPad 第9世代はホームボタンありの旧デザイン、画面も10.2インチと小さい",
+          "充電端子がLightning（iPad 9）対 USB-C（POCO）",
+          "スピーカーが片側（iPad 9）対 クアッド（POCO）"
+        ],
+        "differentiators": [
+          "価格の安さ（iPad 9整備品）",
+          "モダンなデザインと機能（POCO）"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "動画視聴や電子書籍のために大画面タブレットが欲しい人",
+        "コスパ重視で性能の良いAndroidタブレットを探している人",
+        "iPadの価格やストレージ容量に不満がある人"
+      ],
+      "pros": [
+        "4万円台で12.1インチ・120Hz・256GBストレージという破格のコスパ",
+        "動画やゲームを快適に楽しめる高い基本性能",
+        "高級感のあるメタルボディ"
+      ],
+      "cons": [
+        "GPS非搭載のためカーナビ代わりにはならない",
+        "生体認証が顔認証のみ",
+        "重い3Dゲームを最高画質でプレイするにはスペック不足"
+      ],
+      "score": 95,
+      "scoreRationale": "[基本点: 70]\n[性能・機能: +7] (12.1インチ120Hzディスプレイと実用十分な処理性能)\n[コストパフォーマンス: +12] (競合のiPadやGalaxy Tab S9 FEより安価で大画面、ストレージも256GBと余裕がある)\n[品質・デザイン: +2] (金属筐体の質感が高い)\n[ユーザー満足度: +4] (Xiaomiタブレットの実績とコスパへの評価が高い)\n[合計: 95]"
+    },
+    "technicalSpecs": {
+      "os": "Android 14 (HyperOS)",
+      "cpu": "Snapdragon 7s Gen 2",
+      "ram": "8GB",
+      "storage": "256GB",
+      "display": {
+        "size": "12.1インチ",
+        "resolution": "2560×1600 (2.5K)",
+        "type": "LCD, 120Hz"
+      },
+      "battery": {
+        "capacity": "10000mAh",
+        "charging": "33W急速充電"
+      },
+      "camera": {
+        "main": "8MP",
+        "ultrawide": null
+      },
+      "connectivity": [
+        "Wi-Fi 6",
+        "Bluetooth 5.2"
+      ],
+      "dimensions": {
+        "height": "280mm",
+        "width": "181.85mm",
+        "depth": "7.52mm",
+        "weight": "571g"
+      },
+      "other": [
+        "Dolby Atmos対応クアッドスピーカー",
+        "microSDカード対応(最大1.5TB)",
+        "イヤホンジャックあり"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Xiaomi POCO Pad M1 タブレットの調査データを追加しました。
既存データが存在しなかったため、PA-APIとWeb調査に基づき新規作成しました。
競合としてRedmi Pad Pro、iPad (第9/10世代) との比較を行いました。
スペック誤記（Gen 4表記など）については、正しい情報（Gen 2）とAmazon表記を勘案して記載しました。

---
*PR created automatically by Jules for task [17182783904703128589](https://jules.google.com/task/17182783904703128589) started by @aegisfleet*