### PR TITLE
Add investigation data for GTRacing B0DPZM16GK

### DIFF
--- a/data/investigations/B0DPZM16GK.json
+++ b/data/investigations/B0DPZM16GK.json
@@ -1,0 +1,128 @@
+{
+  "analysis": {
+    "productName": "GTRacing ゲーミングチェア GTR510-BLACK (型押しデザイン/ポケットコイル)",
+    "parentAsin": "B0F53KRGJ1",
+    "productDescription": "上品な型押しデザインとポケットコイル内蔵の座面を採用し、ソファーのような座り心地と高級感を両立したゲーミングチェアです。",
+    "productUsage": [
+      "長時間のデスクワーク・テレワークでの疲労軽減",
+      "没入感を高めるPCゲームプレイ",
+      "150度リクライニングを使用した仮眠・休憩"
+    ],
+    "positivePoints": [
+      "高級感のある型押しPUレザーデザイン",
+      "ポケットコイル内蔵により、ソファのように快適でへたりにくい座り心地",
+      "体格に合わせて調整可能な昇降式アームレスト",
+      "最大150度まで倒せるリクライニング機能"
+    ],
+    "negativePoints": [
+      "PUレザー素材のため、夏場や長時間使用で蒸れやすい可能性がある",
+      "重量が約15kgあり、一人での組み立てや移動がやや大変",
+      "サイズが大きく、狭い部屋では圧迫感が出る場合がある"
+    ],
+    "useCases": [
+      "書斎や個室でのPC環境アップグレード",
+      "長時間の在宅勤務を行うホームオフィス",
+      "インテリアにこだわりたいゲーミングルーム"
+    ],
+    "userStories": [
+      {
+        "userType": "30代 在宅ワーカー",
+        "scenario": "長時間座っての作業で腰痛に悩んでいた",
+        "experience": "（推測）ポケットコイルの座面が適度な反発力で、長時間座ってもお尻や腰が痛くなりにくいと感じた。型押しのデザインもWeb会議で背景に映っても安っぽく見えないのが良い。",
+        "sentiment": "positive"
+      },
+      {
+        "userType": "20代 ゲーマー",
+        "scenario": "夏場の長時間プレイ",
+        "experience": "（推測）座り心地は最高だが、やはりPUレザーなので長時間座っていると太ももの裏が蒸れてくる。別途メッシュのクッションなどを併用する必要があるかもしれない。",
+        "sentiment": "mixed"
+      }
+    ],
+    "userImpression": "価格以上の高級感と座り心地を提供するコストパフォーマンスの高い製品。特にポケットコイル採用による座面の質感が評価されているが、通気性や組み立ての手間については留意が必要。",
+    "sources": [
+      {
+        "name": "Amazon Product Detail Page",
+        "url": "https://www.amazon.co.jp/dp/B0DPZM16GK",
+        "credibility": "High"
+      },
+      {
+        "name": "Comparable Product Analysis (GTRacing/SKYE)",
+        "url": null,
+        "credibility": "Medium"
+      }
+    ],
+    "lastInvestigated": "2026-02-02",
+    "competitiveAnalysis": [
+      {
+        "name": "GTRacing GT002F-GRAY",
+        "asin": "B0BXPGGBRM",
+        "priceComparison": "約4,000円安い (￥15,817)",
+        "featureComparison": [
+          "スタンダードなウレタン座面 (GTR510はポケットコイル)",
+          "一般的なPUレザーデザイン"
+        ],
+        "differentiators": [
+          "価格の安さ",
+          "オットマン付きモデルが一般的"
+        ]
+      },
+      {
+        "name": "SKYE ゲーミングチェア (ファブリック)",
+        "asin": "B0F21JFTL1",
+        "priceComparison": "ほぼ同価格帯 (￥19,182)",
+        "featureComparison": [
+          "ファブリック素材で通気性が良い",
+          "こちらも「ソファーの座り心地」を訴求"
+        ],
+        "differentiators": [
+          "素材の違い (ファブリック vs PUレザー)",
+          "耐荷重180kgの堅牢性"
+        ]
+      },
+      {
+        "name": "GXTRACE ゲーミングチェア",
+        "asin": "B0FLJWVBHN",
+        "priceComparison": "かなり安い (￥13,780)",
+        "featureComparison": [
+          "ファブリック素材",
+          "機能は標準的"
+        ],
+        "differentiators": [
+          "圧倒的なコストパフォーマンス"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "価格を抑えつつ高級感のあるチェアが欲しい人",
+        "長時間のデスクワークで座面のへたりを気にする人",
+        "デザイン性を重視するゲーマー"
+      ],
+      "pros": [
+        "ポケットコイルによる優れた座り心地と耐久性",
+        "他社製品と差別化された上品な型押しデザイン",
+        "GTRacingという定番ブランドの安心感"
+      ],
+      "cons": [
+        "通気性の悪さ (PUレザー特有)",
+        "組み立ての手間"
+      ],
+      "score": 90,
+      "scoreRationale": "[基本点: 70]\n[性能・機能: +5] (ポケットコイル、150度リクライニング、昇降アームレスト)\n[コストパフォーマンス: +10] (2万円以下でこの機能とデザインは優秀)\n[品質・デザイン: +5] (型押しデザインによる高級感)\n[ユーザー満足度: 0] (新規モデル等のためレビューデータ不足により中立)\n[合計: 90]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "width": "28.0インチ (約71cm)",
+        "depth": "51.0インチ (約130cm)",
+        "height": "23.0インチ (約58cm)",
+        "weight": "33ポンド (約15kg)"
+      },
+      "material": "PUレザー (型押しデザイン)",
+      "cushion": "ポケットコイル内蔵・非再生ウレタン",
+      "reclining": "最大150度",
+      "armrest": "昇降可能",
+      "color": "アップグレードBLACK",
+      "model": "GTR510"
+    }
+  }
+}


### PR DESCRIPTION
Added product investigation data for GTRacing Gaming Chair GTR510-BLACK (ASIN: B0DPZM16GK) including product analysis, competitive comparison, and technical specs.

---
*PR created automatically by Jules for task [2066765270155984747](https://jules.google.com/task/2066765270155984747) started by @aegisfleet*