### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delete-jules-sessions.yml
+++ b/.github/workflows/delete-jules-sessions.yml
@@ -1,4 +1,6 @@
 name: Delete Jules Sessions
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/19](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/19)

In general, the fix is to explicitly set a `permissions` block for the workflow or for the `delete-sessions` job, reducing `GITHUB_TOKEN` to the least privilege needed. Since this job does not interact with the repository or GitHub resources at all, a minimal safe configuration is `permissions: contents: read`, which is effectively read-only and satisfies the rule’s requirement for explicit scoping.

The best change without altering existing behavior is to add a workflow‑level `permissions` block right after the `name:` field. This will apply to all jobs (here, just `delete-sessions`) and ensure `GITHUB_TOKEN` is issued with read-only contents permissions. No other steps, environment variables, or logic in the shell script are affected, and the external `JULES_API_KEY` secret remains unchanged. Concretely, in `.github/workflows/delete-jules-sessions.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Delete Jules Sessions`) and line 3 (`on:`). No additional imports, methods, or definitions are required because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
