### PR TITLE
fix: Biomeワークフローのdetached HEAD問題を修正

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2


### PR DESCRIPTION
## 概要

Biome Checkワークフローで `git push` が detached HEAD エラーで失敗する問題を修正。

## 問題

```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD) state now, use
    git push origin HEAD:<name-of-remote-branch>
```

`actions/checkout` は `pull_request` イベントではデフォルトでマージコミット（detached HEAD）をチェックアウトするため、ブランチ名なしの `git push` が失敗していた。

## 修正内容

`actions/checkout` に `ref: ${{ github.head_ref }}` を追加し、PRのソースブランチを直接チェックアウトするように変更。これにより `git push` が正常にブランチにプッシュできるようになる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

このプルリクエストには、ユーザーに直接影響する変更がありません。内部の開発インフラストラクチャの調整が行われています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->