### PR TITLE
fix: iOSのSafariで商品詳細テーブルの文字サイズが拡大される問題を修正

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -497,6 +497,8 @@ a:hover {
 .product-comparison {
   overflow-x: auto;
   margin: var(--spacing-lg) 0;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 /* Buttons */


### PR DESCRIPTION
## 概要

iPhoneのSafariで「🛒 商品詳細・購入」セクションのテーブルの「詳細」列の文字サイズが意図せず大きく表示される問題を修正しました。

## 原因

iOSのSafariには **text inflation**（テキスト膨張）機能があり、テーブル内の狭いセルに含まれるテキストを「読みやすくする」ために自動的にフォントサイズを拡大します。`product-comparison` テーブルの「詳細」列はテキストが長くなりがちで、この自動拡大の影響を受けていました。

## 修正内容

`static/css/style.css` の `.product-comparison` に以下を追加:

```
css\n-webkit-text-size-adjust: 100%;
/* iOS Safari向け */
text-size-adjust: 100%;
/* 標準プロパティ */
```

これにより、CSSで指定したフォントサイズがiOS Safariでもそのまま適用されるようになります。