### PR TITLE
Add investigation data for B0BJTJNQFD

### DIFF
--- a/data/investigations/B0BJTJNQFD.json
+++ b/data/investigations/B0BJTJNQFD.json
@@ -1,0 +1,207 @@
+{
+  "analysis": {
+    "productName": "DualSense Edge ワイヤレスコントローラー(CFI-ZCP1J)",
+    "parentAsin": "B0BJTJNQFD",
+    "productDescription": "プレイスタイルに合わせてカスタマイズ可能な、PlayStation 5用の高性能ワイヤレスコントローラーです。",
+    "productUsage": [
+      "PS5ゲームのプレイ",
+      "eスポーツや競技性の高いゲームでの使用",
+      "PCゲームのプレイ"
+    ],
+    "positivePoints": [
+      "背面ボタンが2つ追加可能で、ボタン割り当てを自由にカスタマイズできる",
+      "スティックキャップや背面ボタンの形状を好みに合わせて交換可能",
+      "スティックモジュールごと交換可能なため、長期間の使用でドリフト現象が起きてもモジュール交換だけで対応できる",
+      "トリガーの深さを3段階で調整でき、FPSなどで素早い入力が可能",
+      "プロファイルを複数保存でき、ゲームに合わせて瞬時に切り替え可能"
+    ],
+    "negativePoints": [
+      "通常のDualSenseコントローラーと比べて価格が非常に高い",
+      "バッテリー容量が通常のDualSenseよりも少なく、駆動時間が短め",
+      "重量がやや重く、長時間のプレイで負担になる可能性がある"
+    ],
+    "useCases": [
+      "FPSやTPSゲームで、エイム中にジャンプやしゃがみを行うために背面ボタンを活用する",
+      "格闘ゲームで複数のボタンを同時に押しやすくするためにボタン配置をカスタマイズする",
+      "ゲームタイトルごとに異なるボタン設定プロファイルを作成し、ワンボタンで切り替える"
+    ],
+    "userStories": [
+      {
+        "userType": "FPS/TPSプレイヤー",
+        "scenario": "競技性の高いシューティングゲームをプレイする際",
+        "experience": "背面ボタンにジャンプやスライディングを割り当てることで、右スティックから親指を離さずにエイムを維持しながら移動アクションができるようになり、対面での勝率が大きく上がった。トリガーストップを最短に設定することで、単発武器の連射も非常にしやすくなった。",
+        "supportingSourceIds": [
+          "src-amazon-reviews"
+        ],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "ヘビーゲーマー",
+        "scenario": "長期間、様々なゲームをプレイする際",
+        "experience": "通常のコントローラーではスティックのドリフトが起きたら買い替えになっていたが、Edgeはスティックモジュールだけを交換できるのが非常にありがたい。ただ、バッテリーの持ちが少し悪いため、長時間のプレイ時は有線接続にすることが多い。",
+        "supportingSourceIds": [
+          "src-amazon-reviews"
+        ],
+        "sentiment": "mixed"
+      }
+    ],
+    "userImpression": "価格は高いものの、背面ボタンの追加やトリガーストップ、スティックモジュールの交換機能など、ハードコアゲーマーが求める機能を網羅しており、特にFPS/TPSプレイヤーからの評価が非常に高い。一方で、バッテリー持ちの悪さと重量の増加は妥協点として挙げられることが多い。",
+    "sources": [
+      {
+        "id": "src-amazon-page",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0BJTJNQFD",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2023-01-26",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "基本スペック、価格、機能の確認"
+      },
+      {
+        "id": "src-amazon-reviews",
+        "name": "Amazonカスタマーレビュー",
+        "url": "https://www.amazon.co.jp/dp/B0BJTJNQFD",
+        "tier": "medium",
+        "evidenceType": "secondary",
+        "publishedAt": "2023-01-26",
+        "author": "Amazon購入者",
+        "conflictOfInterest": "none",
+        "notes": "使用感、メリット・デメリットの抽出"
+      },
+      {
+        "id": "src-ps-official",
+        "name": "PlayStation公式ページ",
+        "url": "https://www.playstation.com/ja-jp/accessories/dualsense-edge-wireless-controller/",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2023-01-26",
+        "author": "ソニー・インタラクティブエンタテインメント",
+        "conflictOfInterest": "possible",
+        "notes": "公式の機能説明、仕様確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "スティックモジュールが交換可能で、ドリフト問題に対応しやすい",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-ps-official",
+          "src-amazon-page"
+        ],
+        "crossChecked": true,
+        "notes": "公式サイトおよび商品ページで機能として明記"
+      },
+      {
+        "claim": "トリガーのストロークを調整可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-ps-official",
+          "src-amazon-page"
+        ],
+        "crossChecked": true,
+        "notes": "物理的なスイッチでL2/R2の深さを調整できる"
+      }
+    ],
+    "lastInvestigated": "2026-04-10",
+    "competitiveAnalysis": [
+      {
+        "name": "DualSense ワイヤレスコントローラー",
+        "asin": "B0CK86ZXHJ",
+        "priceComparison": "対象商品は通常版の3倍近い価格設定となっており、競技用機能やモジュール交換などの付加価値に対する投資が必要。",
+        "featureComparison": [
+          "共通点：PS5純正コントローラーとしての基本機能（ハプティックフィードバック、アダプティブトリガーなど）",
+          "相違点：対象商品は背面ボタン、交換可能なスティックキャップ/モジュール、トリガーストップ、プロファイル切り替え機能を搭載。"
+        ],
+        "differentiators": [
+          "DualSense Edgeの利点：背面ボタンやトリガーストップを活用して競技性の高いゲームを有利に進めたい場合や、スティック交換による長期的な運用を重視する場合。",
+          "DualSense ワイヤレスコントローラーの利点：背面ボタンなどの追加機能が不要で、コストを抑えてPS5のゲームを楽しみたい場合。"
+        ]
+      },
+      {
+        "name": "PDP Victrix Pro BFG Wireless Gaming Controller",
+        "asin": "B0B9LDPXBF",
+        "priceComparison": "対象商品はVictrix Pro BFGよりやや高い。両者とも高価格帯のプロ向けコントローラー。",
+        "featureComparison": [
+          "共通点：PS5対応、背面ボタン搭載、カスタマイズ可能なプロ向けコントローラー",
+          "相違点：対象商品はスティックモジュール自体の交換が可能。Victrix Pro BFGはモジュールの配置（左右非対称など）を変更でき、格闘ゲーム用の6ボタンパッドモジュールが付属する。"
+        ],
+        "differentiators": [
+          "DualSense Edgeの利点：ソニー純正品としての高い互換性と、ハプティックフィードバック等のPS5特有の機能が完全動作する点。モジュール交換による修理しやすさ。",
+          "PDP Victrix Pro BFGの利点：Xbox配置（左右非対称）のスティック配置が好みの場合や、格闘ゲーム用の6ボタンパッドを使用したい場合。"
+        ]
+      },
+      {
+        "name": "Razer Raiju V3 Pro",
+        "asin": "B0FXGJHM4P",
+        "priceComparison": "対象商品とほぼ同等の高価格帯。どちらもプレミアムな選択肢。",
+        "featureComparison": [
+          "共通点：PS5対応、追加ボタン搭載、トリガーストップ機能、プロ向けカスタマイズ",
+          "相違点：対象商品は背面2ボタン＋スティックモジュール交換。Razer Raiju V3 Proは背面4ボタン＋クローグリップバンパー2ボタンの計6ボタンを追加し、マウスクリックのような超高速トリガーを搭載。"
+        ],
+        "differentiators": [
+          "DualSense Edgeの利点：純正ならではの安定性と、スティックが壊れた際の部分交換が可能な点。",
+          "Razer Raiju V3 Proの利点：より多くの追加ボタン（6個）が必要な場合や、マウスクリックのような浅く速いトリガー操作を求める場合。"
+        ]
+      },
+      {
+        "name": "NACON REVOLUTION 5 Pro",
+        "asin": "B0DLMXMV9F",
+        "priceComparison": "対象商品とほぼ同等の価格帯。",
+        "featureComparison": [
+          "共通点：PS5対応、カスタマイズ可能なプロ向けコントローラー",
+          "相違点：対象商品は対称配置のスティック。NACON REVOLUTION 5 Proは非対称配置のスティックで、ホールエフェクトセンサーを採用しドリフトしにくい構造。また重量調整用のウェイトが付属。"
+        ],
+        "differentiators": [
+          "DualSense Edgeの利点：PS5純正の振動機能（ハプティックフィードバック等）への完全対応と、対称配置のスティックを好む場合。",
+          "NACON REVOLUTION 5 Proの利点：非対称スティック配置が好みで、ホールエフェクトセンサーによるドリフト耐性と細かい重量調整を求める場合。"
+        ]
+      },
+      {
+        "name": "SCUF REFLEX PRO",
+        "asin": "B09W5L9SML",
+        "priceComparison": "対象商品よりSCUF REFLEX PROの方が大幅に高い（並行輸入品等でさらに高騰傾向）。",
+        "featureComparison": [
+          "共通点：PS5ベースのカスタムコントローラー、背面パドル搭載",
+          "相違点：対象商品は背面2ボタンでモジュール交換可能。SCUF REFLEX PROは背面4パドルを搭載し、より多くの操作を背面に割り当て可能だが、スティックモジュールの交換は不可。"
+        ],
+        "differentiators": [
+          "DualSense Edgeの利点：価格が比較的抑えられており、日本国内での公式サポート・保証が受けやすい。スティック交換による長期運用。",
+          "SCUF REFLEX PROの利点：背面パドルが4つ必要で、SCUF特有のエルゴノミクスデザインとパドル操作感を求める場合。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "FPSやTPS、アクションゲームを本格的にプレイする層",
+        "背面ボタンを活用して複雑な操作をスムーズに行いたいプレイヤー",
+        "スティックのドリフト故障に悩まされており、長く使えるコントローラーを求めている人"
+      ],
+      "pros": [
+        "背面ボタンとトリガーストップによる操作性の向上",
+        "スティックモジュール交換による高いメンテナンス性",
+        "PS5のシステムに統合された設定画面で簡単にカスタマイズ可能"
+      ],
+      "cons": [
+        "通常のコントローラーに比べてかなり高価",
+        "バッテリー駆動時間が短め"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (背面ボタンやトリガーストップなど競技向け機能の充実と操作性向上)\n[加点: +10] (スティックモジュール交換機能による高い耐久性と修理のしやすさ)\n[加点: +5] (PS5純正としての高い互換性とシステム統合)\n[減点: -10] (バッテリー容量が少なく駆動時間が短い点)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "width": "約160mm",
+        "height": "約66mm",
+        "depth": "約106mm"
+      },
+      "weight": "約330g",
+      "connectivity": "USB Type-Cケーブル（有線）, Bluetooth（無線）",
+      "compatibleHardware": "PlayStation 5, PC/Mac, モバイルデバイス",
+      "features": "ハプティックフィードバック, アダプティブトリガー, 内蔵マイク, 交換可能スティックモジュール, 背面ボタン(2種付属), トリガーストップ機能(3段階)",
+      "origin": "中国"
+    }
+  }
+}


### PR DESCRIPTION
Adds investigation data for the DualSense Edge Wireless Controller (ASIN: B0BJTJNQFD).

The investigation includes:
- Product details and specifications
- User stories and use cases
- Competitive analysis against 5 competitors (DualSense, Victrix Pro BFG, Razer Raiju V3 Pro, NACON REVOLUTION 5 Pro, SCUF REFLEX PRO)
- Recommendation with score rationale
- Metric system dimensions and weight

Verified the JSON format and passed the `validate_artifact.py` script.

---
*PR created automatically by Jules for task [9635332995437253202](https://jules.google.com/task/9635332995437253202) started by @aegisfleet*