### PR TITLE
Add investigation data for B0CX7XL9QX (Kirin Namacha Hojicha)

### DIFF
--- a/data/investigations/B0CX7XL9QX.json
+++ b/data/investigations/B0CX7XL9QX.json
@@ -1,0 +1,125 @@
+{
+  "analysis": {
+    "productName": "キリン 生茶 ほうじ煎茶 525ml 24本",
+    "parentAsin": "B0CX7XL9QX",
+    "productDescription": "おいしさはもちろん、これまでのPETほうじ茶にはない現代的で上品な佇まいで「飲んで満たされる」「持っていて満たされる」ほうじ茶です。",
+    "productUsage": [
+      "毎日の水分補給",
+      "食事のお供として"
+    ],
+    "positivePoints": [
+      "上品な佇まいのパッケージデザイン",
+      "エネルギー0kcal、無糖でヘルシー",
+      "持ち運びしやすい525mlサイズ"
+    ],
+    "negativePoints": [
+      "特に際立った欠点は見当たらない"
+    ],
+    "useCases": [
+      "外出先への持ち運び",
+      "自宅やオフィスでのストック飲料として"
+    ],
+    "userStories": [],
+    "userImpression": "上品なパッケージと確かな品質のほうじ茶として、日常使いに適している印象を受けます。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0CX7XL9QX",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-11",
+        "author": "キリンビバレッジ",
+        "conflictOfInterest": "disclosed",
+        "notes": "製品仕様および特徴の確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "エネルギー0kcal、無糖",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "商品仕様に明記されている"
+      }
+    ],
+    "lastInvestigated": "2026-04-11",
+    "competitiveAnalysis": [
+      {
+        "name": "伊藤園 おーいお茶 ほうじ茶 600ml×24本",
+        "asin": "B0BMTDGXB5",
+        "priceComparison": "容量あたりの単価は伊藤園の方が安く、コストパフォーマンスに優れている。",
+        "featureComparison": [
+          "共通点：ほうじ茶飲料、ペットボトル、24本入り",
+          "相違点：伊藤園は600mlと容量が多く、キリンは525mlで持ち運びやすさやデザインに特化している。"
+        ],
+        "differentiators": [
+          "キリン 生茶 ほうじ煎茶 525ml 24本の利点：上品なパッケージデザインと持ち運びやすいサイズ感",
+          "伊藤園 おーいお茶 ほうじ茶 600ml×24本の利点：容量が多くコストパフォーマンスが高い点"
+        ]
+      },
+      {
+        "name": "アサヒ飲料 おいしい水 天然水 シンプルecoラベル 600ml×24本",
+        "asin": "B0DVGN6Q4S",
+        "priceComparison": "水のため、お茶飲料である対象商品よりも低価格で販売されている。",
+        "featureComparison": [
+          "共通点：飲料水、ペットボトル、24本入り",
+          "相違点：対象商品がほうじ茶であるのに対し、こちらは天然水（無糖・ノンカフェイン）。"
+        ],
+        "differentiators": [
+          "キリン 生茶 ほうじ煎茶 525ml 24本の利点：お茶の風味や香りを楽しめる点",
+          "アサヒ飲料 おいしい水 天然水 シンプルecoラベル 600ml×24本の利点：低価格かつ、エコラベルで環境に優しい点"
+        ]
+      },
+      {
+        "name": "サントリー ボス BOSS クラフトボス すっきり無糖 紅茶 600ml×24本",
+        "asin": "B0DYCD6ZWW",
+        "priceComparison": "価格帯は同等レベルだが、クラフトボスの方がわずかに容量が多く割安。",
+        "featureComparison": [
+          "共通点：無糖茶飲料、ペットボトル、24本入り",
+          "相違点：対象商品がほうじ茶であるのに対し、こちらは無糖紅茶。"
+        ],
+        "differentiators": [
+          "キリン 生茶 ほうじ煎茶 525ml 24本の利点：ほうじ茶特有の香ばしさとスッキリ感",
+          "サントリー ボス BOSS クラフトボス すっきり無糖 紅茶 600ml×24本の利点：紅茶特有の華やかな香りと600mlの大容量"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "日常的にほうじ茶を飲む人",
+        "持ち運びに便利なサイズを求める人",
+        "パッケージデザインにこだわる人"
+      ],
+      "pros": [
+        "持ち運びやすい525ml",
+        "無糖・カロリーゼロで健康的",
+        "洗練されたデザイン"
+      ],
+      "cons": [
+        "600mlサイズの製品と比較すると容量あたりのコスパはやや劣る"
+      ],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +3] (洗練されたデザイン)\n[加点: +2] (持ち運びやすいサイズ感による実用性)\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "221mm",
+        "width": "280mm",
+        "depth": "423mm"
+      },
+      "weight": "13500g",
+      "capacity": "525ml",
+      "material": "ペットボトル",
+      "origin": "日本",
+      "other": [
+        "カロリー: 0kcal",
+        "賞味期限: 明記なし",
+        "アレルギー物質: 該当なし"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
キリン 生茶 ほうじ煎茶 525ml 24本の製品調査データを作成しました。
- ASIN B0CX7XL9QXに基づく詳細情報、および競合品（B0BMTDGXB5, B0DVGN6Q4S, B0DYCD6ZWW）の比較を含みます。
- ガイドラインに従って、scoreRationaleでの評価項目分離や、メートル法への統一などを行いました。

---
*PR created automatically by Jules for task [14045083997742276591](https://jules.google.com/task/14045083997742276591) started by @aegisfleet*