### PR TITLE
Implement NaN checks for numeric configuration values

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -152,6 +152,18 @@ export class ConfigManager {
     }
 
     if (
+      Number.isNaN(config.system.maxConcurrentRequests) ||
+      config.system.maxConcurrentRequests < 1 ||
+      config.system.maxConcurrentRequests > 20
+    ) {
+      errors.push('Max concurrent requests must be a number between 1 and 20');
+    }
+
+    if (Number.isNaN(config.jules.timeout) || config.jules.timeout < 1000 || config.jules.timeout > 60000) {
+      errors.push('Jules timeout must be a number between 1s and 60s');
+    }
+
+    if (
       Number.isNaN(config.productSearch.maxResultsPerCategory) ||
       config.productSearch.maxResultsPerCategory < 1 ||
       config.productSearch.maxResultsPerCategory > 50

--- a/src/config/__tests__/ConfigManager_validation_fix.test.ts
+++ b/src/config/__tests__/ConfigManager_validation_fix.test.ts
@@ -48,7 +48,9 @@ describe('ConfigManager Validation Improvements', () => {
   test('should throw if MAX_CONCURRENT_REQUESTS is NaN', async () => {
     process.env.MAX_CONCURRENT_REQUESTS = 'invalid';
     const configManager = ConfigManager.getInstance();
-    await expect(configManager.initialize()).rejects.toThrow('Max concurrent requests must be a number between 1 and 20');
+    await expect(configManager.initialize()).rejects.toThrow(
+      'Max concurrent requests must be a number between 1 and 20',
+    );
   });
 
   test('should throw if JULES_TIMEOUT is NaN', async () => {
@@ -60,7 +62,9 @@ describe('ConfigManager Validation Improvements', () => {
   test('should throw if MAX_RESULTS_PER_CATEGORY is NaN', async () => {
     process.env.MAX_RESULTS_PER_CATEGORY = 'invalid';
     const configManager = ConfigManager.getInstance();
-    await expect(configManager.initialize()).rejects.toThrow('Max results per category must be a number between 1 and 50');
+    await expect(configManager.initialize()).rejects.toThrow(
+      'Max results per category must be a number between 1 and 50',
+    );
   });
 
   test('should throw if MIN_WORD_COUNT is NaN', async () => {

--- a/src/config/__tests__/ConfigManager_validation_fix.test.ts
+++ b/src/config/__tests__/ConfigManager_validation_fix.test.ts
@@ -33,11 +33,39 @@ describe('ConfigManager Validation Improvements', () => {
     );
   });
 
-  test('should throw if numeric values are NaN', async () => {
-    process.env.RETRY_ATTEMPTS = 'invalid'; // Parses to NaN
+  test('should throw if RETRY_ATTEMPTS is NaN', async () => {
+    process.env.RETRY_ATTEMPTS = 'invalid';
     const configManager = ConfigManager.getInstance();
-
-    // This is expected to fail before the fix is implemented because NaN checks are missing
     await expect(configManager.initialize()).rejects.toThrow('Retry attempts must be a number between 0 and 10');
+  });
+
+  test('should throw if RETRY_DELAY is NaN', async () => {
+    process.env.RETRY_DELAY = 'invalid';
+    const configManager = ConfigManager.getInstance();
+    await expect(configManager.initialize()).rejects.toThrow('Retry delay must be a number between 100ms and 60s');
+  });
+
+  test('should throw if MAX_CONCURRENT_REQUESTS is NaN', async () => {
+    process.env.MAX_CONCURRENT_REQUESTS = 'invalid';
+    const configManager = ConfigManager.getInstance();
+    await expect(configManager.initialize()).rejects.toThrow('Max concurrent requests must be a number between 1 and 20');
+  });
+
+  test('should throw if JULES_TIMEOUT is NaN', async () => {
+    process.env.JULES_TIMEOUT = 'invalid';
+    const configManager = ConfigManager.getInstance();
+    await expect(configManager.initialize()).rejects.toThrow('Jules timeout must be a number between 1s and 60s');
+  });
+
+  test('should throw if MAX_RESULTS_PER_CATEGORY is NaN', async () => {
+    process.env.MAX_RESULTS_PER_CATEGORY = 'invalid';
+    const configManager = ConfigManager.getInstance();
+    await expect(configManager.initialize()).rejects.toThrow('Max results per category must be a number between 1 and 50');
+  });
+
+  test('should throw if MIN_WORD_COUNT is NaN', async () => {
+    process.env.MIN_WORD_COUNT = 'invalid';
+    const configManager = ConfigManager.getInstance();
+    await expect(configManager.initialize()).rejects.toThrow('Min word count must be a number between 500 and 10000');
   });
 });

--- a/src/navigation/BrandCounter.ts
+++ b/src/navigation/BrandCounter.ts
@@ -1,6 +1,6 @@
-import matter from 'gray-matter';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import matter from 'gray-matter';
 
 export interface BrandCount {
   name: string;

--- a/src/navigation/BrandManager.ts
+++ b/src/navigation/BrandManager.ts
@@ -62,7 +62,7 @@ export class BrandManager {
     const map = new Map<string, string>();
     for (const key of Object.keys(this.brandGroups)) {
       map.set(BrandManager.normalizeBrandName(key).toLowerCase(), key);
-      
+
       const matcher = this.brandGroups[key]?.matcher;
       if (matcher?.value) {
         map.set(BrandManager.normalizeBrandName(matcher.value).toLowerCase(), key);
@@ -77,10 +77,10 @@ export class BrandManager {
   private findExistingKey(
     brandName: string,
     normalizedName: string,
-    normalizedMap: Map<string, string>
+    normalizedMap: Map<string, string>,
   ): string | null {
     const normalizedKey = normalizedName.toLowerCase();
-    
+
     // 1. 正規化名マップから検索
     const directMatch = normalizedMap.get(normalizedKey);
     if (directMatch) return directMatch;
@@ -113,11 +113,7 @@ export class BrandManager {
   /**
    * 新しいブランドを登録する
    */
-  private registerBrand(
-    brandName: string,
-    normalizedName: string,
-    normalizedMap: Map<string, string>
-  ): void {
+  private registerBrand(brandName: string, normalizedName: string, normalizedMap: Map<string, string>): void {
     const slug = this.generateUniqueSlug(this.generateSlug(normalizedName));
 
     this.brandGroups[normalizedName] = {
@@ -126,8 +122,8 @@ export class BrandManager {
       description: `${normalizedName}の商品一覧`,
       matcher: {
         type: 'brand',
-        value: brandName
-      }
+        value: brandName,
+      },
     };
 
     // マップを更新して以降の重複を防ぐ
@@ -140,8 +136,8 @@ export class BrandManager {
   private generateUniqueSlug(baseSlug: string): string {
     let finalSlug = baseSlug;
     let counter = 1;
-    const existingSlugs = new Set(Object.values(this.brandGroups).map(b => b.slug));
-    
+    const existingSlugs = new Set(Object.values(this.brandGroups).map((b) => b.slug));
+
     while (existingSlugs.has(finalSlug)) {
       finalSlug = `${baseSlug}-${counter++}`;
     }

--- a/src/schemas/InvestigationSchema.ts
+++ b/src/schemas/InvestigationSchema.ts
@@ -8,14 +8,16 @@ export const InvestigationFileSchema = z.looseObject({
     positivePoints: z.array(z.string().trim()),
     negativePoints: z.array(z.string().trim()),
     useCases: z.array(z.string().trim()),
-    userStories: z.array(
-      z.object({
-        userType: z.string().trim(),
-        scenario: z.string().trim(),
-        experience: z.string().trim(),
-        sentiment: z.enum(['positive', 'negative', 'mixed']),
-      }),
-    ).optional(),
+    userStories: z
+      .array(
+        z.object({
+          userType: z.string().trim(),
+          scenario: z.string().trim(),
+          experience: z.string().trim(),
+          sentiment: z.enum(['positive', 'negative', 'mixed']),
+        }),
+      )
+      .optional(),
     userImpression: z.string().trim(),
     sources: z.array(
       z.object({

--- a/src/scripts/enhance-categories.ts
+++ b/src/scripts/enhance-categories.ts
@@ -4,7 +4,7 @@ import * as yaml from 'js-yaml';
 import { CategoryManager } from '../category/CategoryManager';
 import { ProductCounter } from '../category/ProductCounter';
 import { BrandCounter } from '../navigation/BrandCounter';
-import { BrandManager, BrandEntry } from '../navigation/BrandManager';
+import { type BrandEntry, BrandManager } from '../navigation/BrandManager';
 
 const categoryGroupsPath = path.resolve(process.cwd(), 'data/categorygroups.json');
 const contentPath = path.resolve(process.cwd(), 'content');


### PR DESCRIPTION
I have implemented `NaN` checks for all numeric configuration values in `ConfigManager`. This ensures that when an environment variable that is expected to be a number is set to an invalid value (resulting in `NaN` after parsing), the `ConfigManager` will throw a validation error during initialization.

Key changes:
- Modified `src/config/ConfigManager.ts` to include `Number.isNaN` and range checks for `system.maxConcurrentRequests` and `jules.timeout`.
- Verified that existing `NaN` checks for `retryAttempts`, `retryDelay`, `maxResultsPerCategory`, and `minWordCount` are present and consistent.
- Updated `src/config/__tests__/ConfigManager_validation_fix.test.ts` with comprehensive test cases for all numeric fields to ensure they correctly handle `NaN` values.

I encountered some environment issues with `npm install` and `npm test` timing out, but I verified the implementation by inspecting the code and using a Node script to confirm the presence of the required logic. I also restored `package-lock.json` which was accidentally deleted during troubleshooting.

---
*PR created automatically by Jules for task [15449081200748711805](https://jules.google.com/task/15449081200748711805) started by @aegisfleet*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## バグ修正
* 設定パラメータの数値範囲検証を強化しました。指定された範囲外の値は初期化時にキャッチされ、詳細なエラーメッセージが表示されるようになりました。これにより、設定エラーの早期発見と診断が改善されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->