### PR TITLE
Add investigation report for Nothing Phone (3a)

### DIFF
--- a/data/investigations/B0DZ6245MD.json
+++ b/data/investigations/B0DZ6245MD.json
@@ -1,0 +1,182 @@
+{
+  "analysis": {
+    "productName": "Nothing Phone (3a) 8+128GB Black",
+    "parentAsin": "B0F437WVFC",
+    "productDescription": "Nothing(ナッシング)の最新スマートフォン。進化したデザイン、強力なTrueLensエンジン3.0搭載のトリプルカメラ、大容量バッテリーを備えたモデルです。",
+    "productUsage": [
+      "日常的なコミュニケーション",
+      "写真・動画撮影",
+      "エンターテインメント（動画視聴、ゲーム等）"
+    ],
+    "positivePoints": [
+      "TrueLensエンジン3.0を搭載した高性能トリプルカメラで高品質な写真が撮影可能",
+      "Snapdragon 7s Gen 3プロセッサーと大容量バッテリー搭載で最大2日間の連続使用が可能",
+      "洗練されたデザインと専用のハードウェアボタンを備えた独自性のあるNothing OS"
+    ],
+    "negativePoints": [
+      "おサイフケータイ(FeliCa)の対応有無が公式仕様から読み取れない（要確認）",
+      "他社の一部競合モデルに比べると防水・防塵性能に関する記載が不足している"
+    ],
+    "useCases": [
+      "外出先での高画質カメラ撮影",
+      "長時間の外出や旅行時の利用（バッテリー持ちが良いため）",
+      "個性的なデザインのスマートフォンを好むユーザーの日常使い"
+    ],
+    "userStories": [],
+    "userImpression": "洗練されたデザインや長時間のバッテリー持ち、そしてAIツールが統合された優れたカメラ性能により、デザイン性と実用性のバランスが高い評価を受けています。独自のOSやハードウェアボタンの追加により操作性が向上している印象です。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon Product Data (B0DZ6245MD)",
+        "url": "https://www.amazon.co.jp/dp/B0DZ6245MD",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-15",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "製品スペック、特徴、価格情報を取得"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "最大2日間の連続使用が可能",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "Amazonの商品説明（特徴）に記載あり"
+      },
+      {
+        "claim": "TrueLensエンジン3.0を搭載したトリプルカメラシステム",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "Amazonの商品説明（特徴）に記載あり"
+      }
+    ],
+    "lastInvestigated": "2026-04-15",
+    "competitiveAnalysis": [
+      {
+        "name": "Nothing Phone (2a) 8+128GB Black",
+        "asin": "B0CZTLBF2Z",
+        "priceComparison": "対象商品（3a）は新モデルでありながら、2aと近い価格帯に設定されており、より新しいCPU（Snapdragon 7s Gen 3）やトリプルカメラを搭載しているため、コストパフォーマンスが向上しています。",
+        "featureComparison": [
+          "共通点：独自のデザインとNothing OSを搭載している点",
+          "相違点：2aがMediaTek Dimensity 7200 Proを搭載しているのに対し、対象商品はSnapdragon 7s Gen 3を採用。対象商品はトリプルカメラ、2aはデュアルカメラ。"
+        ],
+        "differentiators": [
+          "Nothing Phone (3a)の利点：より高性能なカメラ（トリプルカメラシステム）と新しいプロセッサーを搭載し、最新の機能を備えている点。",
+          "Nothing Phone (2a)の利点：価格がわずかに安く、FeliCa（おサイフケータイ）に対応している（ミルクカラーモデル等で確認）実績がある点。"
+        ]
+      },
+      {
+        "name": "Motorola motorola g66j 5G PANTONE",
+        "asin": "B0FDKRNK5C",
+        "priceComparison": "対象商品より安い価格設定ですが、対象商品の方がより高性能なプロセッサーとカメラシステムを備えています。対象商品はデザイン性にも特化しています。",
+        "featureComparison": [
+          "共通点：170mm程度の大型ディスプレイを搭載し、大容量バッテリーを備えている点。",
+          "相違点：モトローラは防水防塵（IP68/IP69）やおサイフケータイ（FeliCa）に対応していることが明記されているのに対し、対象商品はこれらの仕様が不明瞭です。プロセッサーの性能は対象商品の方が上です。"
+        ],
+        "differentiators": [
+          "Nothing Phone (3a)の利点：洗練されたデザインと独自のUI、より高性能なカメラとプロセッサーを備えている点。",
+          "Motorola motorola g66j 5Gの利点：高い防水防塵性能とおサイフケータイ対応が確実であり、日常の実用性が高い点。"
+        ]
+      },
+      {
+        "name": "Nothing PHONE(2) 12+256GB",
+        "asin": "B0C9LP8D22",
+        "priceComparison": "対象商品の方が大幅に安価です。PHONE(2)はフラッグシップ寄りの性能を持つため価格が高く設定されています。",
+        "featureComparison": [
+          "共通点：Nothing独自のOSとGlyph Interfaceを搭載している点。",
+          "相違点：PHONE(2)はSnapdragon 8+ Gen 1を搭載し、全体的な処理性能が高い。対象商品は最新のミッドレンジ向けプロセッサー（7s Gen 3）を搭載。"
+        ],
+        "differentiators": [
+          "Nothing Phone (3a)の利点：最新のトリプルカメラを搭載し、価格が安くコストパフォーマンスに優れている点。",
+          "Nothing PHONE(2)の利点：より高い処理性能（Snapdragon 8+ Gen 1）とメモリ・ストレージ容量（12+256GB）を備えている点。"
+        ]
+      },
+      {
+        "name": "Nothing Phone (1) 8+256GB Black",
+        "asin": "B0B76GR1V7",
+        "priceComparison": "対象商品の方が安価でありながら、より新しい世代のプロセッサーとカメラを搭載しているため、コストパフォーマンスが高いです。",
+        "featureComparison": [
+          "共通点：Nothing独自のOSとデザインを採用している点。",
+          "相違点：Phone(1)はSnapdragon 778G+を搭載していますが、対象商品はより新しいSnapdragon 7s Gen 3を搭載し、カメラもトリプルカメラに進化しています。"
+        ],
+        "differentiators": [
+          "Nothing Phone (3a)の利点：最新のプロセッサーとカメラを搭載し、価格も安く設定されているため、全体的な性能とコスパで上回っている点。",
+          "Nothing Phone (1)の利点：発売から時間が経過しており、中古市場などでの入手性が高い可能性がある点（ストレージ容量も256GB）。"
+        ]
+      },
+      {
+        "name": "Nothing Phone (2a) 12+256GB Milk",
+        "asin": "B0CQ88L871",
+        "priceComparison": "対象商品（3a）はメモリとストレージが少ない分（8+128GB）、2aの12+256GBモデルに近い価格設定です。ストレージを重視するか、カメラとCPU性能を重視するかで選び方が分かれます。",
+        "featureComparison": [
+          "共通点：大型のディスプレイと大容量バッテリーを搭載。",
+          "相違点：2aはメモリ12GB、ストレージ256GBと大容量ですが、プロセッサーは旧世代（Dimensity 7200 Pro）。対象商品は最新のSnapdragon 7s Gen 3を搭載。"
+        ],
+        "differentiators": [
+          "Nothing Phone (3a)の利点：より新しいプロセッサーとトリプルカメラによる基本性能の高さ。",
+          "Nothing Phone (2a) 12+256GBの利点：より大容量のメモリとストレージを備えており、多くのアプリやデータを保存できる点。"
+        ]
+      },
+      {
+        "name": "Nothing Phone (2a) 8+128GB Milk",
+        "asin": "B0CZT1F5ZQ",
+        "priceComparison": "同等の価格帯であり、対象商品（3a）は後継または上位版の位置づけと考えられます。",
+        "featureComparison": [
+          "共通点：メモリ・ストレージ構成（8+128GB）とディスプレイサイズ。",
+          "相違点：プロセッサー（2a: Dimensity 7200 Pro vs 3a: Snapdragon 7s Gen 3）、カメラ（2a: デュアル vs 3a: トリプル）、また2aはおサイフケータイ対応が明記されています。"
+        ],
+        "differentiators": [
+          "Nothing Phone (3a)の利点：より高い処理性能と優れたカメラ性能を備えている点。",
+          "Nothing Phone (2a) Milkの利点：おサイフケータイ（FeliCa）に対応していることが確実である点。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "デザイン性の高いスマートフォンを求めるユーザー",
+        "コストパフォーマンスと性能のバランスを重視するユーザー",
+        "日常的に写真撮影を楽しむユーザー"
+      ],
+      "pros": [
+        "個性的なデザインとNothing OSによる独自のユーザー体験",
+        "最新プロセッサーと大容量バッテリーによる長時間の安定稼働",
+        "高性能なトリプルカメラによる高品質な写真撮影"
+      ],
+      "cons": [
+        "おサイフケータイ(FeliCa)や防水・防塵に関する性能が公式情報では不明確",
+        "ストレージ容量が128GBと少なめ（大容量モデルを求める場合は別モデルの検討が必要）"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (洗練されたデザインによる品質の高さ)\n[加点: +3] (Nothing OSによる独自のユーザー体験)\n[加点: +4] (最新のSnapdragon 7s Gen 3プロセッサー搭載による性能の向上)\n[加点: +3] (トリプルカメラ搭載によるコストパフォーマンスの高さ)\n[加点: +5] (最大2日間の連続使用が可能な大容量バッテリーの搭載)\n[減点: -5] (おサイフケータイ(FeliCa)や防水・防塵性能に関する記載が不足している懸念)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "162.2mm",
+        "width": "76.5mm",
+        "depth": "8.7mm"
+      },
+      "weight": "190g",
+      "capacity": "128GB",
+      "material": "ガラス（背面曲面ガラス）",
+      "origin": "中国",
+      "other": [
+        "RAM: 8GB",
+        "CPU: Qualcomm Snapdragon 7s Gen 3",
+        "ディスプレイ: 170mm フレキシブル AMOLED",
+        "カメラ: TrueLensエンジン3.0搭載トリプルカメラ",
+        "OS: Nothing OS (Android 15ベース想定)",
+        "カラー: ブラック",
+        "モデル番号: A10400154"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the investigation report for Nothing Phone (3a) (B0DZ6245MD).

- Extracted product data using `creators_get_item.py` for B0DZ6245MD and competitive models.
- Generated the report following the JSON schema.
- Replaced non-metric dimensions with metric equivalents (e.g., 6.7 inches to 170mm).
- Separated score rationales to ensure each point corresponds to a single reason.
- Validated the report using `validate_artifact.py`.

---
*PR created automatically by Jules for task [16791291958048394146](https://jules.google.com/task/16791291958048394146) started by @aegisfleet*