### PR TITLE
Update B0CR6J2HCK investigation with strict compliance and competitive analysis

### DIFF
--- a/data/investigations/B0CR6J2HCK.json
+++ b/data/investigations/B0CR6J2HCK.json
@@ -1,126 +1,171 @@
 {
   "analysis": {
-    "productName": "UGREEN Revodok 7-in-1 USB-C ハブ (CM639)",
+    "productName": "UGREEN Revodok USB-C ハブ 7-in-1 CM639",
     "parentAsin": "B0F29L7PZC",
-    "productDescription": "HDMI×2とDisplayPortを搭載し、最大3画面の同時出力が可能なUSB-Cドッキングステーション。全USBポートが10Gbpsの高速転送に対応。",
+    "productDescription": "最大3画面の外部出力に対応した、USB-Cドッキングステーション。100W PD急速充電と10Gbpsのデータ転送ポートを備え、マルチタスクの効率を大幅に向上させます。",
     "productUsage": [
-      "ノートPCの画面を最大3台の外部モニターに拡張（Windows）",
-      "USBメモリや外付けSSDとの10Gbps高速データ転送",
-      "PD 100WによるノートPCへのパススルー急速充電"
+      "ノートパソコンの画面拡張（最大3画面）",
+      "USBデバイスの接続と10Gbps高速データ転送",
+      "ノートPCの100W PD急速充電"
     ],
     "positivePoints": [
-      "5,000円以下の価格でトリプルディスプレイ出力（HDMI x2 + DP）に対応",
-      "USB-A/Cポートすべてが10Gbpsの高速転送に対応",
-      "100W PD急速充電対応でハイエンドノートPCも充電可能"
+      "HDMIポート2つとDisplayPort1つを搭載し、最大3つの外部ディスプレイに4K@60Hzで出力可能",
+      "USB 3.2 Gen2対応のUSB-AおよびUSB-Cポートにより、最大10Gbpsの高速データ転送を実現",
+      "最大100WのPD急速充電に対応（PC本体への給電は最大85W）",
+      "放熱性に優れた高品質なアルミニウム合金素材を採用"
     ],
     "negativePoints": [
-      "SDカードスロットと有線LANポートがない",
-      "macOSではMST非対応のため、複数モニタへの拡張出力ができずミラーリングになる"
+      "Mac OSデバイスでは拡張デュアルスクリーン/トリプルスクリーン表示においてミラーモード（同じ画面の複製）に制限される場合がある（MST非対応）",
+      "SD/microSDカードスロットや有線LANポートは非搭載"
     ],
     "useCases": [
-      "WindowsノートPCでのマルチモニター環境構築",
-      "大容量データの頻繁な移動が必要なクリエイティブ作業"
+      "テレワークでのマルチモニター環境構築",
+      "複数のUSBデバイスや外部ストレージとの高速データ連携",
+      "充電ポートが少ないノートPCの機能拡張と同時充電"
     ],
-    "userStories": [
-      {
-        "userType": "在宅勤務のエンジニア",
-        "scenario": "効率的な作業環境の構築",
-        "experience": "以前は画面切り替えが面倒だったが、このハブで3画面環境を構築し、コード、仕様書、チャットを別々に表示できるようになり生産性が向上した。（推測）",
-        "sentiment": "positive"
-      },
-      {
-        "userType": "MacBookユーザー",
-        "scenario": "外部モニター拡張の試み",
-        "experience": "3画面出力を期待して購入したが、macOSの制限で全て同じ画面しか映らずがっかりした。Windows機では問題なく使えている。（推測）",
-        "sentiment": "negative"
-      }
-    ],
-    "userImpression": "映像出力とデータ転送速度に特化した高コスパモデル。必要な機能がマッチすれば非常に満足度が高いが、Macユーザーやオールインワン（LAN/SD込み）を求める層には不向き。",
+    "userStories": [],
+    "userImpression": "3画面出力対応でありながらコンパクトで、価格設定も手頃なためコストパフォーマンスが非常に高いと評価される製品。特にWindows環境でのマルチモニター構築において強力な機能を発揮するが、Macユーザーは画面拡張の仕様に注意が必要。",
     "sources": [
       {
-        "name": "Amazon商品ページ",
+        "id": "src-amazon-b0cr6j2hck",
+        "name": "Amazon.co.jp: UGREEN Revodok USB-C ハブ ドッキングステーション 3画面出力",
         "url": "https://www.amazon.co.jp/dp/B0CR6J2HCK",
-        "credibility": "high"
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-17",
+        "author": "Ugreen Japan Co., Ltd",
+        "conflictOfInterest": "possible",
+        "notes": "製品仕様、価格、対応OS（Macはミラーモード制限の記載あり）、出力仕様の確認"
       }
     ],
-    "lastInvestigated": "2026-01-31",
+    "claims": [
+      {
+        "claim": "最大3画面の同時出力に対応（HDMI×2、DP×1、いずれも最大4K@60Hz）",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon-b0cr6j2hck"
+        ],
+        "crossChecked": false,
+        "notes": "製品仕様より"
+      },
+      {
+        "claim": "最大10Gbpsのデータ転送が可能（USB-A 3.2、USB-C 3.2ポート）",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon-b0cr6j2hck"
+        ],
+        "crossChecked": false,
+        "notes": "製品仕様より"
+      }
+    ],
+    "lastInvestigated": "2026-04-17",
     "competitiveAnalysis": [
       {
-        "name": "Selore 13-in-1 ドッキングステーション",
-        "asin": "B0CX59NVY2",
-        "priceComparison": "約1,400円高い",
-        "featureComparison": [
-          "SDカード、有線LAN、VGAポートあり",
-          "ポート数が多い"
-        ],
-        "differentiators": [
-          "オールインワンだが価格が高い",
-          "サイズが大きい"
-        ]
-      },
-      {
-        "name": "Anker PowerExpand 8-in-1",
-        "asin": "B0D7PXM8D6",
-        "priceComparison": "同価格帯（約200円高い）",
-        "featureComparison": [
-          "SDカードスロットあり",
-          "HDMIは1ポートのみ"
-        ],
-        "differentiators": [
-          "Ankerブランドの安心感",
-          "3画面出力は非対応"
-        ]
-      },
-      {
-        "name": "UGREEN Revodok Pro 209",
+        "name": "UGREEN 7 in 1 Revodok Pro USB C ドッキングステーション (B0D1XSKZRJ)",
         "asin": "B0D1XSKZRJ",
-        "priceComparison": "約1,100円安い",
+        "priceComparison": "本商品よりも安価だが、画面出力はHDMI×2の2画面までとなる。",
         "featureComparison": [
-          "DPポートなし",
-          "HDMI x2のみ"
+          "共通点：100W PD充電、10Gbpsデータ転送(USB-A, USB-C)、有線LANやSDスロットがない点",
+          "相違点：本商品はDisplayPortを含む3画面出力に対応しているが、競合はHDMI×2の2画面出力のみ対応"
         ],
         "differentiators": [
-          "DP不要ならこちらがコスパ良し"
+          "UGREEN Revodok 7-in-1 CM639の利点：3台の外部モニターを利用したい場合に最適",
+          "UGREEN 7 in 1 Revodok Pro (B0D1XSKZRJ)の利点：外部モニターが2台以下で十分な場合、より安価に導入可能"
+        ]
+      },
+      {
+        "name": "UGREEN ドッキングステーション 14-in-1 (CM843)",
+        "asin": "B0FGHX59G2",
+        "priceComparison": "本商品の約2.7倍の価格設定。",
+        "featureComparison": [
+          "共通点：最大3画面の外部出力に対応、100W PD充電、10Gbpsデータ転送",
+          "相違点：競合はDP×2＋HDMI×1の構成で、有線LAN、SD/TFカードリーダー、オーディオジャックなど14ポートを備えるハイエンドモデル。4K@120Hz(DP)出力にも対応"
+        ],
+        "differentiators": [
+          "UGREEN Revodok 7-in-1 CM639の利点：コンパクトで持ち運びやすく、低価格で3画面出力を実現できる",
+          "UGREEN ドッキングステーション 14-in-1 (CM843)の利点：有線LANやSDカードなど多様なポートが必要な場合や、より高リフレッシュレートでの出力が求められる環境に適している"
+        ]
+      },
+      {
+        "name": "エレコム ドッキングステーション 13in1 DST-W14",
+        "asin": "B0DPQ6ZHGZ",
+        "priceComparison": "本商品よりも大幅に高価である。",
+        "featureComparison": [
+          "共通点：最大3画面の外部出力に対応、100W PD充電",
+          "相違点：競合はDisplayLinkチップを搭載しており、Macでも3画面の拡張（非ミラー）表示が可能。多数のポートを備える"
+        ],
+        "differentiators": [
+          "UGREEN Revodok 7-in-1 CM639の利点：Windowsユーザーや、映像出力にDisplayLinkチップを必要としない環境において、圧倒的に安価に3画面出力を構築できる",
+          "エレコム ドッキングステーション 13in1 DST-W14の利点：Mac環境で複数の画面をそれぞれ別の内容（拡張モード）で表示したい場合に必須となる"
+        ]
+      },
+      {
+        "name": "RayCue Macbook Pro/Air専用 14-IN-2 ドッキングステーション",
+        "asin": "B0FWHR4TD2",
+        "priceComparison": "本商品よりも高価である。",
+        "featureComparison": [
+          "共通点：最大3画面の出力に対応（Mac環境）、100W PD充電、10Gbpsデータ転送",
+          "相違点：競合はMacBook専用のデュアルUSB-C接続設計であり、MacでMST（マルチストリームトランスポート）による複数画面拡張が可能。SDスロットや有線LANも搭載"
+        ],
+        "differentiators": [
+          "UGREEN Revodok 7-in-1 CM639の利点：汎用的なUSB-Cケーブル接続のため、WindowsPCやタブレットなど幅広いデバイスで使用可能",
+          "RayCue Macbook Pro/Air専用 14-IN-2の利点：MacBook Pro/Airで安定してマルチディスプレイ（拡張表示）を行いたい場合に最適化されている"
+        ]
+      },
+      {
+        "name": "Anker Prime ドッキングステーション 14-in-1 (A83B3)",
+        "asin": "B0F8VNSTYC",
+        "priceComparison": "本商品と比較して非常に高価なプレミアムモデルである。",
+        "featureComparison": [
+          "共通点：最大3画面出力に対応、USB PD充電対応",
+          "相違点：競合はDisplayLinkチップ搭載、本体にディスプレイ内蔵、最大140W給電、最大8K出力対応など、最上位クラスの性能と多機能を持つ"
+        ],
+        "differentiators": [
+          "UGREEN Revodok 7-in-1 CM639の利点：コストを抑えて手軽に3画面出力を試したいユーザーに圧倒的な価格的優位性がある",
+          "Anker Prime ドッキングステーション 14-in-1 (A83B3)の利点：Macでの多画面拡張や、8K解像度、140Wの高出力など、妥協のない最高峰の環境を求めるクリエイターやプロユーザー向け"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "WindowsノートPCで3画面出力を安価に実現したいユーザー",
-        "高速データ転送が必要なユーザー"
+        "Windowsノートパソコンで安価に3画面以上のマルチモニター環境を構築したいユーザー",
+        "高速なデータ転送（10Gbps）と映像出力を1台のハブで済ませたいユーザー"
       ],
       "pros": [
-        "圧倒的なコストパフォーマンス",
-        "10Gbpsの転送速度"
+        "3画面出力対応ハブとしては非常にコストパフォーマンスが高い",
+        "10Gbpsの高速USBポート（Type-C/A）を備える",
+        "放熱性の高いアルミボディ"
       ],
       "cons": [
-        "Macユーザーには不向き（MST非対応）",
-        "SDカード/LANが必要な場合は別途アダプタが必要"
+        "Mac環境では複数画面の拡張出力（それぞれ別画面）に制限がある可能性が高い",
+        "有線LANやSDカードリーダーがないため、これらが必要な場合は別途アダプタが必要"
       ],
-      "score": 92,
-      "scoreRationale": "[基本点: 70]\n[加点: +7] (3画面4K対応かつ全ポート10Gbpsという高性能)\n[加点: +12] (競合他社と比較して圧倒的に安価)\n[加点: +3] (UGREENブランドのビルドクオリティ)\n[合計: 92]"
+      "score": 93,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (同クラスの3画面出力対応ハブと比較して、4000円台という圧倒的なコストパフォーマンス)\n[加点: +8] (HDMI×2、DP×1による最大3画面出力と、10Gbps高速転送の実用性の高さ)\n[加点: +5] (UGREENブランドの信頼性と高品質なアルミ合金筐体)\n[合計: 93]"
     },
     "technicalSpecs": {
       "dimensions": {
-        "height": "2.3cm",
-        "width": "19.5cm",
-        "depth": "11.0cm",
-        "weight": "240g"
+        "height": "23mm",
+        "width": "195mm",
+        "depth": "110mm"
       },
-      "ports": {
-        "hdmi": "2x (Max 4K@60Hz)",
-        "displayPort": "1x (Max 4K@60Hz)",
-        "usb_a": "2x USB 3.2 Gen 2 (10Gbps)",
-        "usb_c": "1x USB 3.2 Gen 2 (10Gbps)",
-        "pd_input": "1x USB-C (Max 100W)"
-      },
-      "compatibility": [
-        "Windows 10/11",
-        "macOS (Mirror only for multi-display)",
-        "Linux",
-        "Android"
+      "weight": "240g",
+      "color": "グレー",
+      "model": "CM639",
+      "ports": [
+        "HDMI (最大4K@60Hz) x 2",
+        "DisplayPort (最大4K@60Hz) x 1",
+        "USB-C 3.2 (最大10Gbps) x 1",
+        "USB-A 3.2 (最大10Gbps) x 2",
+        "USB-C PD 3.0 (入力最大100W / パススルー出力最大85W)"
       ],
-      "material": "Aluminum Alloy"
+      "material": "アルミニウム合金",
+      "other": [
+        "Windows / Mac OS / Chrome OS 等に対応（※Mac OSは外部複数モニター出力時、ミラーモードに制限される場合あり）",
+        "2年間のメーカー保証"
+      ]
     }
   }
 }


### PR DESCRIPTION
This commit applies updates to `data/investigations/B0CR6J2HCK.json` in accordance with the specified investigation rules and the code review feedback. Specifically:
- Correctly parsed the technical specifications of the UGREEN Revodok CM639, translating them to metric units.
- Refactored the `userStories` section to be empty, as there are no verifiable specific user stories in the source data.
- Structured the `competitiveAnalysis` exactly as required (共通点, 相違点, etc.) to evaluate B0CR6J2HCK against 5 other docking stations.
- Adhered strictly to the scoring rationale requirements, correctly assigning a +23 total adjustment to arrive at a 93 score.
- Adjusted the `claims` property to only use allowed categories per the enum constraint.
- Fixed the total port count computation to accurately match a 7-in-1 device.
- Addressed all validation and formatting constraints.

---
*PR created automatically by Jules for task [15034895678487999867](https://jules.google.com/task/15034895678487999867) started by @aegisfleet*