### PR TITLE
Add investigation data for B09WR52Z3G

### DIFF
--- a/data/investigations/B09WR52Z3G.json
+++ b/data/investigations/B09WR52Z3G.json
@@ -1,0 +1,167 @@
+{
+  "analysis": {
+    "productName": "Maledan iPad mini (A17 Pro/第6世代) ケース",
+    "parentAsin": "B09WR52Z3G",
+    "productDescription": "iPad mini 第7世代(A17 Pro)および第6世代(8.3インチ)に対応した軽量・耐衝撃TPUケース。ペンシル収納やオートスリープ機能を備える。",
+    "productUsage": [
+      "iPad miniの保護",
+      "Apple Pencilの収納と充電",
+      "動画視聴やタイピング時のスタンド"
+    ],
+    "positivePoints": [
+      "軽量でコンパクトなデザイン",
+      "Apple Pencil 第2世代のワイヤレス充電に対応",
+      "オートスリープ/ウェイク機能対応",
+      "三つ折りスタンド機能"
+    ],
+    "negativePoints": [
+      "Apple Pencil 第1世代には非対応"
+    ],
+    "useCases": [
+      "自宅での動画視聴",
+      "外出時の持ち運び",
+      "オフィスでのタイピング作業"
+    ],
+    "userStories": [],
+    "userImpression": "手頃な価格でありながら、Apple Pencilの収納とワイヤレス充電、オートスリープ機能など必要な機能を過不足なく備えたコストパフォーマンスの高いケース。",
+    "sources": [
+      {
+        "id": "src-amazon",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B09WR52Z3G",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-17",
+        "author": "Maledan",
+        "conflictOfInterest": "disclosed",
+        "notes": "製品仕様、価格、機能説明を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "Apple Pencil 第2世代のワイヤレス充電対応",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon"
+        ],
+        "crossChecked": false,
+        "notes": "公式の製品特徴に明記"
+      }
+    ],
+    "lastInvestigated": "2026-04-17",
+    "competitiveAnalysis": [
+      {
+        "name": "JETech iPad mini 7/6 用ケース ソフトTPU",
+        "asin": "B0CL4RC7NR",
+        "priceComparison": "対象商品と同価格帯（対象商品よりわずかに安価）。",
+        "featureComparison": [
+          "共通点：iPad mini 7/6対応、TPU素材のソフトケース",
+          "相違点：JETechは透明なクリアケースであるのに対し、対象商品はカラーバリエーションがあり、ペンシル収納スペースやスタンド機能のあるフロントカバーが付いている"
+        ],
+        "differentiators": [
+          "Maledan iPad mini ケースの利点：画面保護カバー、スタンド機能、Apple Pencil専用収納スペースがある点",
+          "JETech ソフトTPUケースの利点：フロントカバーがないため、より薄くシンプルで、端末本来のデザインを活かせる点"
+        ]
+      },
+      {
+        "name": "ESR iPad mini7/6 ケース Classicシリーズ クリア",
+        "asin": "B099RZ72N5",
+        "priceComparison": "対象商品よりやや高価。",
+        "featureComparison": [
+          "共通点：iPad mini 7/6対応、Pencil Pro/USB-C対応",
+          "相違点：ESRはハード背面とソフトフレームのハイブリッド構造で耐黄変を謳うのに対し、対象商品はフロントカバー付きのTPU素材"
+        ],
+        "differentiators": [
+          "Maledan iPad mini ケースの利点：フロントカバーによる画面保護とスタンド機能が一体化している点",
+          "ESR Classicシリーズ クリアケースの利点：背面ハードケースによる保護力と耐黄変性"
+        ]
+      },
+      {
+        "name": "MS factory iPad mini 7/6 用 ケース ペン収納 耐衝撃",
+        "asin": "B09LCC9DBR",
+        "priceComparison": "対象商品よりやや高価。",
+        "featureComparison": [
+          "共通点：iPad mini 7/6対応、ペン収納あり、オートスリープ対応、ソフトTPU",
+          "相違点：基本的な仕様は酷似しているが、ブランドとカラーバリエーションが異なる"
+        ],
+        "differentiators": [
+          "Maledan iPad mini ケースの利点：同様の機能を有しながら、より安価で購入できる点",
+          "MS factory iPad mini 7/6 用 ケースの利点：独自のカラーバリエーション（ピンクサンドなど）がある点"
+        ]
+      },
+      {
+        "name": "Fintie iPad Mini 7/6 ケース 透明バックカバー",
+        "asin": "B09W15T5JS",
+        "priceComparison": "対象商品よりやや高価。",
+        "featureComparison": [
+          "共通点：iPad mini 7/6対応、Pencil収納、ワイヤレス充電対応、三つ折りスタンド、オートスリープ",
+          "相違点：Fintieは背面が透明なバックカバーを採用しているのに対し、対象商品は背面も不透明なTPU素材"
+        ],
+        "differentiators": [
+          "Maledan iPad mini ケースの利点：より安価で購入できる点",
+          "Fintie 透明バックカバー ケースの利点：背面が透明なため、iPad本体のカラーやAppleロゴが見える点"
+        ]
+      },
+      {
+        "name": "ProCase iPad Mini 7/6 ケース 三つ折りスタンド",
+        "asin": "B0DSP497PN",
+        "priceComparison": "対象商品と同価格帯。",
+        "featureComparison": [
+          "共通点：iPad mini 7/6対応、ペンホルダー付き、オートスリープ対応、三つ折りスタンド",
+          "相違点：機能的にはほぼ同等"
+        ],
+        "differentiators": [
+          "Maledan iPad mini ケースの利点：カラーバリエーションの好みに応じて選べる点",
+          "ProCase 三つ折りスタンド ケースの利点：カラーバリエーションの好みに応じて選べる点"
+        ]
+      },
+      {
+        "name": "フクタマ iPad mini7/6 兼用ケース TPU 背面カバー",
+        "asin": "B0D848XXS1",
+        "priceComparison": "対象商品の半額程度と非常に安価。",
+        "featureComparison": [
+          "共通点：iPad mini 7/6対応、TPU素材",
+          "相違点：フクタマは背面カバーのみでフロントカバーやペン収納スロットがないシンプルな構造"
+        ],
+        "differentiators": [
+          "Maledan iPad mini ケースの利点：フロントカバーによる画面保護、スタンド機能、Pencil収納がある点",
+          "フクタマ 背面カバーの利点：とにかく安価で、シンプルに背面のみを保護したい場合に適している点"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "iPad miniを日常的に持ち運ぶ人",
+        "Apple Pencilを使用する人",
+        "コストパフォーマンスを重視する人"
+      ],
+      "pros": [
+        "手頃な価格",
+        "ペン収納と充電が同時に可能",
+        "スタンド機能による利便性"
+      ],
+      "cons": [
+        "背面が透明ではないため本体カラーは見えない"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (Apple Pencilの収納とワイヤレス充電に両対応する実用性)\n[加点: +5] (三つ折りスタンド、オートスリープなど十分な機能を備えつつ約1300円という高いコストパフォーマンス)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "201mm",
+        "width": "157mm",
+        "depth": "14mm"
+      },
+      "weight": "不明",
+      "material": "TPU",
+      "compatibleModels": "iPad mini 第7世代(A17 Pro: A2993, A2995, A2996) / 第6世代(A2567, A2568)",
+      "color": "ベビーピンク",
+      "other": [
+        "Apple Pencil 第2世代ワイヤレス充電対応",
+        "オートスリープ/ウェイク機能",
+        "三つ折りフロントカバー"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the completed investigation JSON for the Maledan iPad mini 7 case (ASIN: B09WR52Z3G), including dimensions converted to metric, competitive analysis against 6 alternative cases, and a comprehensive recommendation score and rationale following the required guidelines.

---
*PR created automatically by Jules for task [9314519279497691660](https://jules.google.com/task/9314519279497691660) started by @aegisfleet*