### PR TITLE
Add investigation data for B0C3BSZ56D (HyperX Cloud III)

### DIFF
--- a/data/investigations/B0C3BSZ56D.json
+++ b/data/investigations/B0C3BSZ56D.json
@@ -1,0 +1,169 @@
+{
+  "analysis": {
+    "productName": "HyperX Cloud III ゲーミングヘッドセット",
+    "parentAsin": "B0FGCLSFSJ",
+    "productDescription": "耐久性のあるアルミフレームと、高い快適性を提供する低反発素材を採用した有線ゲーミングヘッドセットです。斜め配置の53mmドライバーによる優れた定位感と、クリアな音質のノイズキャンセリングマイクを備えています。",
+    "productUsage": ["PCゲーム、コンシューマーゲーム（PS5/PS4、Switch、Xbox等）での音声チャットやプレイ", "テレワークでのWeb会議や通話"],
+    "positivePoints": [
+      "低反発素材のイヤーパッドとヘッドバンドによる圧倒的な装着感で、長時間の使用でも疲れにくい。",
+      "3.5mm端子、USB Type-A、USB Type-Cの3種類の接続に対応しており、PCから各種ゲーム機、スマホまでマルチに使える取り回しの良さ。",
+      "FPSゲームにおける足音の定位感に優れており、音の方向や距離を正確に把握しやすい。",
+      "ノイズキャンセリング機能付きのクリアなマイクを搭載し、取り外しも可能。"
+    ],
+    "negativePoints": [
+      "密閉型のレザーレット素材を使用しているため、夏場や長時間の使用では蒸れやすい。",
+      "低音域はそれほど強くなく、ドンシャリ音を好むユーザーには迫力不足に感じられる場合がある。",
+      "マイクのミュートボタンが小さく押しづらく、ミュート状態が視覚的に分かりにくい。"
+    ],
+    "useCases": [
+      "長時間のFPSゲームプレイで、正確な足音の定位が必要な場面",
+      "複数のゲーム機（PC、PS5、Switchなど）を使い分け、その都度接続を素早く切り替えて遊びたい場面",
+      "ゲームプレイだけでなく、リモートワークでのオンライン会議などでもクリアな音声を届けたい場面"
+    ],
+    "userStories": [
+      {
+        "userType": "ゲーマー・レビューワー",
+        "scenario": "FPSゲーム（VALORANTなど）のプレイ",
+        "experience": "音が過度にドンシャリではないため環境音が埋もれず、足音や銃声の定位感がとても自然です。DTS Headphone:Xを有効にすると位置関係がさらに立体的になり、敵の正確な位置を把握しやすくなりました。",
+        "supportingSourceIds": ["src-note", "src-realsound"],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "マルチプラットフォームのゲーマー",
+        "scenario": "複数のゲーム機とPCを行き来する日常",
+        "experience": "USB Type-A、Type-C、3.5mmの3種類の端子が使えるため、仕事中はPC、遊ぶ時はPS5やSwitchにと、複数のハードで物理的に差し替えるだけで快適に取り回すことができる点が非常に便利でした。",
+        "supportingSourceIds": ["src-ascii"],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "長時間ゲーマー",
+        "scenario": "夏の長時間のゲームプレイ",
+        "experience": "装着感は素晴らしく頭が痛くなることはありませんが、密閉型のレザーレット素材なので夏場に数時間プレイしているとさすがに蒸れが気になり、定期的に外して休憩したくなりました。",
+        "supportingSourceIds": ["src-ascii", "src-realsound"],
+        "sentiment": "negative"
+      }
+    ],
+    "userImpression": "前モデルからの正統進化として、特に「快適な装着感」と「競技シーンでも使える定位感の良さ」、「複数の接続端子による取り回しの良さ」が高く評価されています。低音が控えめな点や蒸れやすさはあるものの、マイク音質もクリアで、長時間のゲームプレイやボイスチャットを快適に行いたいユーザーにとって非常に満足度の高いヘッドセットです。",
+    "sources": [
+      {
+        "id": "src-ascii",
+        "name": "ASCII.jp / 「取り回し」と「快適性」に全振り 数か月使って感じたゲーミングヘッドセット「Cloud III」の素晴らしさ",
+        "url": "https://ascii.jp/elem/000/004/147/4147634/",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2023-09-20",
+        "author": "ASCII",
+        "conflictOfInterest": "none",
+        "notes": "装着感の良さ、3種の端子による取り回しの良さ、夏場の蒸れやすさについての言及を確認。"
+      },
+      {
+        "id": "src-realsound",
+        "name": "Real Sound｜リアルサウンド テック / コスパと高級感を両立した 『HyperX Cloud Ⅲ ゲーミングヘッドセット』",
+        "url": "https://realsound.jp/tech/2023/08/post-1407247.html",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2023-08-22",
+        "author": "Real Sound",
+        "conflictOfInterest": "none",
+        "notes": "高級感のあるアルミ素材と低反発クッション、FPSにおける定位感の良さ、ミュートボタンの使いにくさについてのレビューを確認。"
+      },
+      {
+        "id": "src-note",
+        "name": "note / 【公式】ボンビーのイヤホンブログ｜HyperX Cloud IIIレビュー",
+        "url": "https://note.com/bright_llama373/n/ncea3da5f4c10",
+        "tier": "medium",
+        "evidenceType": "secondary",
+        "publishedAt": "2026-02-19",
+        "author": "note",
+        "conflictOfInterest": "possible",
+        "notes": "アフィリエイトリンクあり。過度なドンシャリを抑えた足音の聞き取りやすさとマイク性能の高さ、長時間の装着感についての評価。"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "低反発クッションと軽量設計により圧倒的に快適な装着感を実現している",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": ["src-ascii", "src-realsound", "src-note"],
+        "crossChecked": true,
+        "notes": "3つのレビューすべてで長時間でも疲れにくい装着感の良さが評価されている。"
+      },
+      {
+        "claim": "FPSゲームで重要な足音の定位感が良く、環境音が埋もれにくいバランスの取れた音質である",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-realsound", "src-note"],
+        "crossChecked": true,
+        "notes": "過度な低音を抑え、足音などの聞き分けがしやすいという点が共通して指摘されている。"
+      },
+      {
+        "claim": "3.5mm、USB Type-A、Type-Cの3種類の接続に対応し、多くのデバイスで使い回せる",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": ["src-ascii"],
+        "crossChecked": true,
+        "notes": "レビュー内でマルチプラットフォーム対応の取り回しの良さとして強調されている。"
+      }
+    ],
+    "lastInvestigated": "2026-04-17",
+    "competitiveAnalysis": [
+      {
+        "name": "Razer BlackShark V2",
+        "asin": "B08F7V9T3K",
+        "priceComparison": "価格帯はほぼ同じ（12,900円台）であり、直接的な競合となる。重量はRazer BlackShark V2の方が軽量（約262g）であるため、軽さを重視する場合は競合に利点がある。",
+        "featureComparison": [
+          "共通点：有線接続、50mmクラスのドライバー（HyperXは53mm、Razerは50mm）を搭載し、PC・コンソール機に対応する点。立体音響（DTS/THX）に対応している点。",
+          "相違点：重量（HyperXは約308g、Razerは約262g）。HyperXは3種類の接続端子（USB-A/C/3.5mm）を標準でサポートし、耐久性のあるアルミフレームを採用しているのに対し、Razerは軽量性に特化している。"
+        ],
+        "differentiators": [
+          "HyperX Cloud III ゲーミングヘッドセットの利点：アルミフレームによる耐久性と、3種の接続端子が使える取り回しの良さ。低反発素材による極上の装着感。",
+          "Razer BlackShark V2の利点：本体が約262gと非常に軽量であるため、絶対的な軽さを重視するケースに適している。"
+        ]
+      },
+      {
+        "name": "JBL QUANTUM 100M2",
+        "asin": "B0DCG2DBDL",
+        "priceComparison": "JBL QUANTUM 100M2は価格が5,500円と本商品（約13,000円）の半額以下であり、エントリーモデルに位置づけられる。素材の高級感や耐久性、空間オーディオなどの付加機能においては本商品に優位性がある。",
+        "featureComparison": [
+          "共通点：3.5mmアナログ接続に対応した有線ゲーミングヘッドセットである点。マイクを搭載している点。",
+          "相違点：価格帯。JBLはエントリー向けでシンプルな機能構成だが、HyperXはアルミフレームによる高い質感、DTS Headphone:X空間オーディオ対応、53mmドライバー、USB接続用アダプターの付属など上位の性能を持つ。"
+        ],
+        "differentiators": [
+          "HyperX Cloud III ゲーミングヘッドセットの利点：USB接続を含めたマルチプラットフォームへの対応、高い耐久性、クリアなノイズキャンセリングマイク、より高解像度な音質と定位感。",
+          "JBL QUANTUM 100M2の利点：圧倒的な安さであり、コストを極力抑えてヘッドセットを導入したい初心者やライトユーザーに適している。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "FPSなど競技性の高いゲームをプレイするユーザー",
+        "PC、PS5、Switchなど複数のプラットフォームでゲームを遊ぶユーザー",
+        "長時間のゲームプレイでも耳や頭が痛くならない装着感を重視するユーザー"
+      ],
+      "pros": [
+        "長時間でも疲れにくい優れた装着感",
+        "USB-A/C、3.5mm対応で複数のデバイスでの取り回しが良い",
+        "過度な低音を抑えた自然で定位の良い音質",
+        "ノイズが少なくクリアな着脱式マイク"
+      ],
+      "cons": [
+        "密閉型かつレザーレット素材のため夏場は蒸れやすい",
+        "低音の迫力を求める人にはやや物足りない音質",
+        "マイクのミュートボタンが小さく操作性に難がある"
+      ],
+      "score": 88,
+      "scoreRationale": "[基本点: 70]\n[加点: +8] (長時間の使用でも疲れにくい圧倒的な装着感)\n[加点: +7] (過度な低音を抑え、FPSでの足音などを正確に把握できる優れた定位感)\n[加点: +5] (USB-A/C、3.5mmの3種の接続に対応し、複数ハードでの取り回しが非常に良い)\n[加点: +3] (アルミフレームの採用など、1万円台前半の価格に見合う高い質感と耐久性)\n[減点: -3] (レザーレット素材のため、長時間の使用や夏場において蒸れやすい点)\n[減点: -2] (ミュートボタンが小さく操作しづらい、状態が分かりにくい点)\n[合計: 88]"
+    },
+    "technicalSpecs": {
+      "// 注意": "調査で判明した仕様情報をここに網羅的に記載する（サイズはメートル法のみ、インチ不要）",
+      "dimensions": { "height": "190mm", "width": "155mm", "depth": "87mm" },
+      "weight": "308g",
+      "driver": "53mmダイナミックドライバー",
+      "connection": "3.5mmプラグ, USB Type-A, USB Type-C",
+      "compatibility": "PC, PS5, PS4, Xbox Series X|S, Xbox One, Nintendo Switch, モバイル",
+      "audioFeatures": "DTS Headphone:X 空間オーディオ対応",
+      "microphone": "ノイズキャンセリング対応、LEDミュートインジケーター付き、着脱可能",
+      "material": "アルミフレーム、低反発クッション、レザーレット素材"
+    }
+  }
+}


### PR DESCRIPTION
HyperX Cloud III ゲーミングヘッドセットに関する調査を行い、要件とルールに従って `data/investigations/B0C3BSZ56D.json` を作成しました。
- 単位をすべてメートル法に変換（インチ・ポンドを除外）。
- 外部ソースのレビュー記事等から装着感、音質（定位感）、マイク性能、取り回しの良さなどの定性データを抽出し、ハルシネーションなく構成。
- 規定フォーマットに沿ったスコアリング（88点）と競合比較（Razer BlackShark V2, JBL QUANTUM 100M2）の記載。
- `validate_artifact.py` による検証をパスしました。

---
*PR created automatically by Jules for task [14851784438969196450](https://jules.google.com/task/14851784438969196450) started by @aegisfleet*