### PR TITLE
Add comprehensive investigation data for UGREEN USB-C hub B0D9Q9WCLX

### DIFF
--- a/data/investigations/B0D9Q9WCLX.json
+++ b/data/investigations/B0D9Q9WCLX.json
@@ -1,116 +1,202 @@
 {
   "analysis": {
-    "productName": "UGREEN USB-C ハブ 10Gbps 5-in-1 (4x USB-Cデータ + PD 100W)",
+    "productName": "UGREEN 5-in-1 USB-C ハブ 10Gbps (PD 100W)",
     "parentAsin": "B0D9Q9WCLX",
-    "productDescription": "4つのUSB-C 3.2 Gen 2データポート（最大10Gbps）と1つの100W PD充電ポートを搭載した、USB-C特化型の拡張ハブ。",
+    "productDescription": "10Gbpsの高速データ転送と最大100WのPDパススルー充電に対応した、USB Type-C×4ポート増設用のコンパクトハブ。",
     "productUsage": [
-      "MacBook Air/ProなどのUSB-Cポート不足を解消し、4台のUSB-C機器を同時接続",
-      "外付けSSDやUSBメモリ間での最大10Gbpsの高速データ転送",
-      "PC本体を最大100Wで急速充電しながらの周辺機器利用（パススルー充電）",
-      "スマートフォンやタブレット（iPad/Galaxy）への周辺機器接続"
+      "ノートPCやタブレットのUSB-Cポート増設",
+      "大容量データの高速転送",
+      "充電しながらの周辺機器利用"
     ],
     "positivePoints": [
-      "圧倒的なコストパフォーマンス（同等スペックの競合他社製品の半額以下）",
-      "全データポートがUSB-Cかつ10Gbps対応という先進的な構成",
-      "100W PD充電ポートを搭載しており、ハブ利用中もPCへの給電が可能",
-      "コンパクトで軽量（約50g）、持ち運びに適したデザイン"
+      "10Gbps（USB 3.2 Gen 2）対応のUSB-Cポートを4つも搭載しており、高速データ転送が可能",
+      "最大100WのPD充電専用ポートを備え、ホストデバイスの充電を妨げない",
+      "重量約50g、厚さ1.2cm（0.47インチ）の超小型・軽量設計で持ち運びに最適"
     ],
     "negativePoints": [
-      "HDMIやDisplayPortなどの映像出力ポートは非搭載",
-      "USB-Aポートがないため、旧来のUSB機器を使用するには変換が必要",
-      "データポートは映像出力や充電（給電）には非対応（データ転送のみ）"
+      "映像出力（Alt Mode）には非対応",
+      "USB-Aポートがなく、従来のType-A機器を接続するには変換アダプタが必要",
+      "100W PDポートは充電専用でデータ転送には使えない"
     ],
     "useCases": [
-      "USB-C端子の外付けSSDを複数台接続して動画データを整理するクリエイター",
-      "MacBook Airのポートを塞がずに充電しながら、スマホとタブレットを同期したいユーザー",
-      "USB-C周辺機器でデスク環境を統一しているミニマリスト"
+      "外出先でのノートPCのポート拡張",
+      "外付けSSDや高速USBメモリとのデータやり取り",
+      "デスク周りのType-C機器の集約"
     ],
     "userStories": [
       {
-        "userType": "動画クリエイター（30代男性）",
-        "scenario": "外出先での動画編集作業",
-        "experience": "MacBook Airのポートが2つしかなく、充電とSSD接続で埋まってしまうのが悩みだった。このハブなら充電しながら複数のSSDやカードリーダー（USB-C接続）を繋げられ、しかも転送速度が10Gbpsと速いので大容量ファイルの移動もストレスがない。何より2000円以下で買えるのは驚き。",
+        "userType": "MacBookユーザー",
+        "scenario": "外出先で外付けSSDを使って動画編集",
+        "experience": "10Gbpsの転送速度により、大容量の動画ファイルもストレスなく読み書きできた。\nPD充電対応でバッテリー残量を気にせず作業に集中できる点も素晴らしい。\n非常に軽量コンパクトで、カフェなどの狭い机でも邪魔にならずに使えるのがありがたい。",
+        "supportingSourceIds": [
+          "src-1"
+        ],
         "sentiment": "positive"
       },
       {
-        "userType": "大学生（20代女性）",
-        "scenario": "大学でのレポート作成とスマホ充電",
-        "experience": "iPad Proで作業する際、充電しながらUSB-Cメモリを使いたくて購入。純正や有名メーカー品は高いが、これは非常に安くて機能も十分。ただ、たまに持っているUSB-Aのメモリを使いたい時に変換が必要なのが少し不便だと気づいた。",
+        "userType": "Windows PCユーザー",
+        "scenario": "デスクで周辺機器を接続",
+        "experience": "Type-C機器が増えてきたので購入。\nコンパクトで邪魔にならないが、古いUSB-Aのマウスを繋ぐために別途変換アダプタが必要になったのは少し不便だった。\nとはいえ、この価格で10Gbps対応ポートが4つも増設できるのはコストパフォーマンスが良いと思う。",
+        "supportingSourceIds": [
+          "src-1"
+        ],
         "sentiment": "mixed"
       }
     ],
-    "userImpression": "「USB-Cポートだけを増やしたい」という明確なニーズを持つユーザーにとっての最適解。映像出力やUSB-Aを排除した割り切った仕様により、驚異的な低価格と小型化を実現しており、サブのハブとしても非常に優秀と評価できる。",
+    "userImpression": "Type-Cに特化した割り切った構成と10Gbpsの高速転送が、最新のデバイス環境にマッチしていると高評価。映像出力やUSB-Aが不要なユーザーにとって、非常にコスパが高く使い勝手の良いハブ。",
     "sources": [
       {
-        "name": "UGREEN Official Product Page (Amazon)",
+        "id": "src-1",
+        "name": "Amazon.co.jp商品ページおよびカスタマーレビュー",
         "url": "https://www.amazon.co.jp/dp/B0D9Q9WCLX",
-        "credibility": "high"
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-07-19",
+        "author": "Amazon.co.jp",
+        "conflictOfInterest": "none",
+        "notes": "商品仕様、互換性、ユーザーレビューから使用感や評価を抽出"
       }
     ],
-    "lastInvestigated": "2026-01-31",
+    "claims": [
+      {
+        "claim": "10Gbpsの高速データ転送",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "メーカー公式仕様。USB 3.2 Gen 2対応"
+      },
+      {
+        "claim": "最大100WのPDパススルー充電",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "メーカー公式仕様。充電専用ポート"
+      }
+    ],
+    "lastInvestigated": "2026-04-19",
     "competitiveAnalysis": [
       {
-        "name": "Selore USB Cハブ 5ポート (4xUSB-C + PD)",
-        "asin": "B0DLB7L8M6",
-        "priceComparison": "約3,700円前後。UGREENの約2倍の価格。",
+        "name": "UGREEN Revodok USB-C ハブ 6in1",
+        "asin": "B0D1XLNWP2",
+        "priceComparison": "対象商品よりやや安いが、ポート構成が異なる（HDMIやUSB-A搭載）。",
         "featureComparison": [
-          "ポート構成はほぼ同じ（4x Data + 1x PD）",
-          "どちらも10Gbps対応"
+          "共通点：UGREEN製、100W PD充電対応、一部ポートが10Gbps対応。",
+          "相違点：競合はHDMI（4K 60Hz）とUSB-Aポートを搭載しているが、対象商品はUSB-Cポートのみ（4ポート）で映像出力は非対応。"
         ],
         "differentiators": [
-          "機能差はほとんどないが、価格差が大きい",
-          "ブランド認知度はUGREENの方が高い傾向"
+          "対象商品の利点：Type-Cポートが4つあり、Type-C機器を複数同時に繋ぎたい場合に最適。よりコンパクト。",
+          "競合商品の利点：外部モニター出力や従来のUSB-A機器も接続できる汎用性の高さ。"
         ]
       },
       {
-        "name": "UGREEN 4-in-1 USB-Cハブ (B0C4DFB8RH)",
-        "asin": "B0C4DFB8RH",
-        "priceComparison": "約3,800円前後。本製品より高い。",
+        "name": "Qeefun USB C ハブ 10Gbps 5ポート",
+        "asin": "B0GHR5KSS8",
+        "priceComparison": "対象商品より安価。",
         "featureComparison": [
-          "こちらは4ポート（データのみの場合や構成違いあり）",
-          "本製品（B0D9Q9WCLX）の方がポート数が多く安い"
+          "共通点：10Gbpsデータ転送対応、100W PD充電対応の5ポート構成。",
+          "相違点：競合はUSB-C×2＋USB-A×2のハイブリッド構成でケーブル長が120cm。対象商品はUSB-C×4で直付けの短いケーブル。"
         ],
         "differentiators": [
-          "本製品は新モデルまたはWeb限定等の理由で戦略的な低価格設定になっている可能性がある"
+          "対象商品の利点：Type-C機器の接続に特化。持ち運びに便利な超コンパクト設計。",
+          "競合商品の利点：USB-Aも使える汎用性と、デスクトップ用途に向く長いケーブル。"
         ]
       },
       {
-        "name": "Aceele USB Cハブ 4ポート (B0FQNP3NHQ)",
-        "asin": "B0FQNP3NHQ",
-        "priceComparison": "約2,100円前後。近い価格帯。",
+        "name": "UGREEN Revodok Pro Type-c 8-in-1",
+        "asin": "B0DY1BD3T2",
+        "priceComparison": "対象商品と同程度の価格帯だが、多機能。",
         "featureComparison": [
-          "データポートのみでPD充電ポートがない（または明確な記載が弱い）",
-          "ケーブル長が選べるモデルがある"
+          "共通点：UGREEN製、100W PD充電対応、10Gbpsデータ転送対応。",
+          "相違点：競合はSD/microSDカードリーダーやHDMI、USB-Aを搭載する多機能型。対象商品はType-Cポート増設特化型。"
         ],
         "differentiators": [
-          "PD充電（100W）の有無が決定的違い。充電しながら使いたいならUGREEN一択"
+          "対象商品の利点：Type-Cポートの数が多い（4つ）。非常に軽量・コンパクト。",
+          "競合商品の利点：カードリーダーや映像出力など、1台で多様なニーズに対応できる。"
+        ]
+      },
+      {
+        "name": "エレコム USB Type-C ハブ DST-C26SV",
+        "asin": "B0CQYLWNPV",
+        "priceComparison": "対象商品と同価格帯。",
+        "featureComparison": [
+          "共通点：100W PD充電対応、10GbpsのUSB-Cポートを複数搭載（競合は3つ、対象商品は4つ）。",
+          "相違点：競合は4K60Hz対応のHDMIポートを搭載。対象商品はHDMIがない代わりにデータ用Type-Cポートが1つ多い。"
+        ],
+        "differentiators": [
+          "対象商品の利点：Type-Cポートが多く、Type-C機器を多数繋ぎたい場合に有利。",
+          "競合商品の利点：HDMI出力が可能で、国内メーカー(エレコム)のサポート・信頼感がある。"
+        ]
+      },
+      {
+        "name": "Anker PowerExpand 8-in-1",
+        "asin": "B087TB7YM7",
+        "priceComparison": "対象商品よりも高価。",
+        "featureComparison": [
+          "共通点：100W PD充電、10Gbpsデータ転送対応。",
+          "相違点：競合はHDMI、有線LAN、SDカードリーダー、USB-Aを備える本格的なドッキングステーション。対象商品はシンプルなUSB-Cハブ。"
+        ],
+        "differentiators": [
+          "対象商品の利点：圧倒的に安価でコンパクト。Type-Cポートの増設に特化している。",
+          "競合商品の利点：LANポートやカードリーダーなど、あらゆる拡張機能を1台で網羅できる。"
+        ]
+      },
+      {
+        "name": "UGREEN Revodok 10 in 1 ドッキングステーション",
+        "asin": "B0D1XK8H21",
+        "priceComparison": "対象商品の2倍以上の価格。",
+        "featureComparison": [
+          "共通点：UGREEN製、10Gbpsデータ転送、100W PD充電。",
+          "相違点：競合はデュアルHDMI（最大8K対応）や有線LANなど豊富なポートを持つ。対象商品はコンパクトなUSB-Cハブ。"
+        ],
+        "differentiators": [
+          "対象商品の利点：安価で手軽に持ち運べる。",
+          "競合商品の利点：マルチモニター環境の構築など、据え置きでの高度な拡張性が高い。"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "USB-C接続の周辺機器（SSD、スマホ等）が多いユーザー",
-        "MacBook Airなどポート数の少ないPCを使用している人",
-        "安価に高速なポート拡張を行いたい人"
+        "Type-C接続の周辺機器（外付けSSDなど）を多く持っている人",
+        "映像出力やUSB-Aポートは不要で、純粋にType-Cポートを増やしたい人",
+        "持ち運びに便利な軽量・コンパクトなハブを探している人"
       ],
       "pros": [
-        "市場破壊的な低価格（1000円台後半）",
-        "全ポートUSB-Cかつ10Gbps対応の高性能",
-        "100W PDパススルー充電対応"
+        "10Gbpsの高速データ転送対応Type-Cポートを4つ搭載",
+        "最大100WのPDパススルー充電対応",
+        "50gと超軽量でコンパクト"
       ],
       "cons": [
-        "USB-A機器やHDMI出力は使えない（割り切りが必要）",
-        "データポートからの映像出力は不可"
+        "映像出力機能（HDMI/DisplayPort）なし",
+        "USB-Aポートがなく、従来の機器には変換が必要"
       ],
-      "score": 93,
-      "scoreRationale": "[基本点: 70]\n[コストパフォーマンス: +15] (10Gbps対応でPD付きかつ1800円台は競合の半額以下であり、極めて高いコスパ)\n[性能・機能: +3] (映像出力はないが、USB-C x4 + PDという構成は需要に対して適切かつ高性能)\n[独自の強み: +5] (USB-Aを完全に廃したフルUSB-C構成という先進性)\n[品質・デザイン: +0] (標準的なUGREEN品質)\n[合計: 93]"
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (10Gbps対応のType-Cポートを4つも搭載し、最新機器の拡張性に優れる)\n[加点: +5] (50gという超軽量・コンパクトな設計で携帯性が非常に高い)\n[加点: +5] (100W PD対応でホストの充電を妨げない)\n[減点: -5] (映像出力やUSB-A非搭載など用途が限定的である点)\n[合計: 85]"
     },
     "technicalSpecs": {
-      "dimensions": { "height": "1.3cm", "width": "10.4cm", "depth": "3.8cm", "weight": "50g" },
-      "connectivity": ["USB-C 3.2 Gen 2 (10Gbps) x 4", "USB-C PD 3.0 (100W Input) x 1"],
-      "power": "100W PD Pass-through Charging",
-      "compatibility": ["Windows", "macOS", "Linux", "iPadOS", "Android", "iOS"],
-      "other": ["Driver-free (Plug & Play)", "OTG Support"]
+      "dimensions": {
+        "height": "12mm",
+        "width": "104mm",
+        "depth": "39mm"
+      },
+      "weight": "50g",
+      "material": "アルミニウム合金（推定）等",
+      "ports": [
+        "1 x USB-C (PD 3.0 最大100W入力、充電専用)",
+        "4 x USB-C 3.2 Gen 2 (最大10Gbps データ転送専用)"
+      ],
+      "hostInterface": "USB Type-C",
+      "compatibility": "Windows 11/10/8.1/8/7, macOS, Linux, iPadOS, iOS, Android (MacBook Pro/Air, iPad Pro, iPhone 15/16シリーズ等)",
+      "other": [
+        "映像出力非対応",
+        "プラグ＆プレイ（ドライバ不要）",
+        "24ヶ月保証"
+      ]
     }
   }
 }


### PR DESCRIPTION
Added detailed analysis data for the UGREEN 5-in-1 USB-C Hub (ASIN: B0D9Q9WCLX) including technical specs, competitive analysis, user stories, and a calculated recommendation score. Data conforms to the requested schema.

---
*PR created automatically by Jules for task [3489349713296506231](https://jules.google.com/task/3489349713296506231) started by @aegisfleet*