### PR TITLE
Potential fix for code scanning alert no. 35: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -6,6 +6,17 @@ function toYen(value, unit) {
     return num;
 }
 
+function sanitizeCategoryUrl(rawUrl) {
+    if (typeof rawUrl !== 'string' || rawUrl.trim() === '') return null;
+    try {
+        const parsed = new URL(rawUrl, window.location.origin);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+        return parsed.href;
+    } catch (e) {
+        return null;
+    }
+}
+
 function parseBudgetFromQuery(query) {
     const normalizedQuery = query.replaceAll(/\s+/g, '');
     const rangeMatch = normalizedQuery.match(/(\d+(?:\.\d+)?)([万千])?円?[~〜-](\d+(?:\.\d+)?)([万千])?円?/);
@@ -603,10 +614,10 @@ document.addEventListener('DOMContentLoaded', function () {
             const urlMap = urlDataScript ? JSON.parse(urlDataScript.textContent) : {};
 
             topCategories.forEach(([cat, count]) => {
-                const url = urlMap[cat];
-                if (url) {
+                const safeUrl = sanitizeCategoryUrl(urlMap[cat]);
+                if (safeUrl) {
                     const btn = document.createElement('a');
-                    btn.href = url;
+                    btn.href = safeUrl;
                     btn.className = 'suggestion-tag';
                     const catSpan = document.createElement('span');
                     catSpan.textContent = cat;


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/35](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/35)

General fix: never assign untrusted DOM-derived strings directly to URL-bearing sinks (`href`, `src`, navigation APIs) without strict validation/sanitization. Parse with `URL`, enforce allowed protocols (`http:`/`https:`), and optionally constrain to same-origin or approved hosts. Skip invalid values.

Best fix here (without changing intended functionality): in `static/js/search.js` near lines 602–610, validate each `url` before setting `btn.href`. Add a small helper (or inline logic) that:
- returns `null` for non-strings/empty values,
- resolves via `new URL(raw, window.location.origin)`,
- allows only `http:` and `https:`,
- returns safe normalized `href`, else `null`.

Then only create/append button when a safe URL is returned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カテゴリーサジェスト機能のURL検証を強化しました。無効または不正なURLを持つリンクは表示されなくなり、ユーザーの安全性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->