### PR TITLE
Add investigation data for Speiow T1 tablet B0GV35WHYZ

### DIFF
--- a/data/investigations/B0GV35WHYZ.json
+++ b/data/investigations/B0GV35WHYZ.json
@@ -1,0 +1,139 @@
+{
+  "analysis": {
+    "productName": "Speiow T1 25.6cm Android 15 タブレット",
+    "parentAsin": "B0GW7BJHVC",
+    "productDescription": "最新のAndroid 15を搭載し、AI最適化による滑らかなパフォーマンスを実現した25.6cmタブレットです。24GB(12GB+拡張12GB)メモリと128GBストレージを備え、Widevine L1対応で高画質な動画視聴が可能です。",
+    "productUsage": ["動画視聴", "ウェブブラウジング", "電子書籍の閲覧", "オンライン学習", "軽いゲーム"],
+    "positivePoints": [
+      "最新のAndroid 15 OSによるAI最適化とプライベートスペース機能",
+      "Widevine L1認証取得で、Amazon Prime Videoなどの高画質再生に対応",
+      "最大24GB(12GB内蔵+12GB仮想)のメモリによるマルチタスクの快適さ"
+    ],
+    "negativePoints": [
+      "解像度が1280x800(HD)であり、FHD以上の高精細モデルと比較すると画質に劣る",
+      "プロセッサ(T606)はエントリークラスのため、重い3Dゲームには不向き"
+    ],
+    "useCases": ["自宅でのリラックスタイムに動画や映画を視聴する", "子供の学習用タブレットとして活用する"],
+    "userStories": [],
+    "userImpression": "手頃な価格ながら最新OSと大容量メモリを搭載しており、日常的なブラウジングや動画視聴には十分な性能を持つコストパフォーマンスに優れたタブレットとして評価されています。",
+    "sources": [],
+    "claims": [],
+    "lastInvestigated": "2026-04-20",
+    "competitiveAnalysis": [
+      {
+        "name": "TechZen 25.4cm タブレット (B0GJ64YL6X)",
+        "asin": "B0GJ64YL6X",
+        "priceComparison": "対象商品よりやや高いが、バッテリー容量が8000mAhと大きい。",
+        "featureComparison": [
+          "共通点：25.4cmディスプレイ、24GBメモリ(拡張含む)、128GBストレージ搭載",
+          "相違点：TechZenはバッテリーが8000mAhと大容量であり、OSはAndroid 16を謳っている。"
+        ],
+        "differentiators": [
+          "Speiow T1 25.6cm Android 15 タブレットの利点：価格がより手頃であり、Android 15のAI最適化機能が明記されている点",
+          "TechZen 25.4cm タブレットの利点：バッテリー容量が大きく、長時間の使用に向いている点"
+        ]
+      },
+      {
+        "name": "JETAKu 25.4cm タブレット (B0GDDXLV31)",
+        "asin": "B0GDDXLV31",
+        "priceComparison": "対象商品とほぼ同価格帯だが、CPUがA523を搭載している。",
+        "featureComparison": [
+          "共通点：Android 15搭載、24GBメモリ(拡張含む)、128GBストレージ、Widevine L1対応",
+          "相違点：JETAKuはCPUがA523であり、Bluetooth 5.4に対応している。"
+        ],
+        "differentiators": [
+          "Speiow T1 25.6cm Android 15 タブレットの利点：T606プロセッサにより、安定した日常用途のパフォーマンスが期待できる点",
+          "JETAKu 25.4cm タブレットの利点：Bluetooth 5.4に対応し、より新しい無線接続規格を利用できる点"
+        ]
+      },
+      {
+        "name": "FUNSEDY 25.4cm タブレット (B0GSTZSSJ6)",
+        "asin": "B0GSTZSSJ6",
+        "priceComparison": "対象商品よりやや高い。",
+        "featureComparison": [
+          "共通点：Android 15搭載、24GBメモリ(拡張含む)、128GBストレージ、Widevine L1対応",
+          "相違点：FUNSEDYはCPUがA523であり、Bluetooth 5.4に対応。保護ケースが付属している場合がある。"
+        ],
+        "differentiators": [
+          "Speiow T1 25.6cm Android 15 タブレットの利点：価格が抑えられており、コストパフォーマンスに優れる点",
+          "FUNSEDY 25.4cm タブレットの利点：Bluetoothの規格が新しく、より安定したワイヤレス接続が期待できる点"
+        ]
+      },
+      {
+        "name": "Android 16 タブレット 星の輝き (B0FSRY5ZRW)",
+        "asin": "B0FSRY5ZRW",
+        "priceComparison": "対象商品より大幅に安く、ストレージが64GBと少ない。",
+        "featureComparison": [
+          "共通点：25.6cmディスプレイ、Wi-Fiモデル",
+          "相違点：星の輝きはストレージが64GBと少なく、価格が非常に安い。またAndroid 16を謳っている。"
+        ],
+        "differentiators": [
+          "Speiow T1 25.6cm Android 15 タブレットの利点：ストレージが128GBあり、より多くのアプリやデータを保存できる点",
+          "Android 16 タブレット 星の輝きの利点：価格が非常に安く、初期費用を抑えたい場合に適している点"
+        ]
+      },
+      {
+        "name": "Gemini AI 3.1搭載 タブレット (B0G5PQD5MK)",
+        "asin": "B0G5PQD5MK",
+        "priceComparison": "対象商品よりやや安く、ストレージが64GB。",
+        "featureComparison": [
+          "共通点：25.4cmディスプレイ、24GBメモリ(拡張含む)",
+          "相違点：Gemini AI搭載タブレットはストレージが64GBであり、Gemini AI機能を強調している。"
+        ],
+        "differentiators": [
+          "Speiow T1 25.6cm Android 15 タブレットの利点：128GBのストレージを備えており、データ容量に余裕がある点",
+          "Gemini AI 3.1搭載 タブレットの利点：Gemini AIによる機能が利用でき、価格がやや安い点"
+        ]
+      },
+      {
+        "name": "Wpawa Android 16 タブレット (B0G7F8WJV6)",
+        "asin": "B0G7F8WJV6",
+        "priceComparison": "対象商品より高価である。",
+        "featureComparison": [
+          "共通点：25.6cmディスプレイ、24GBメモリ(拡張含む)、128GBストレージ",
+          "相違点：Wpawaはバッテリーが7000mAhと大きく、18WのPD急速充電に対応している。"
+        ],
+        "differentiators": [
+          "Speiow T1 25.6cm Android 15 タブレットの利点：価格が安く、コストパフォーマンスが高い点",
+          "Wpawa Android 16 タブレットの利点：PD急速充電に対応し、バッテリー容量も大きいため使い勝手が良い点"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "手頃な価格で動画視聴用のタブレットを探している人",
+        "最新のAndroid OSを試してみたい人",
+        "子供用やサブ機として手軽なタブレットが欲しい人"
+      ],
+      "pros": [
+        "安価ながらメモリやストレージ容量に余裕がある",
+        "Widevine L1対応で高画質ストリーミングが可能"
+      ],
+      "cons": [
+        "画面解像度がHD(1280x800)と粗め",
+        "処理性能はエントリークラスのため重い作業には不向き"
+      ],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (1万3千円台という手頃な価格で24GBメモリやWidevine L1など基本機能が充実しているコストパフォーマンスの高さ)\n[加点: +3] (最新のAndroid 15を搭載し、プライバシー保護などの機能が強化されている点)\n[減点: -3] (解像度が1280x800であり、昨今の基準としては物足りない点)\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "weight": "480g",
+      "thickness": "7.5mm",
+      "display": "25.6cm IPS Incell",
+      "resolution": "1280x800",
+      "cpu": "Unisoc T606 オクタコア",
+      "gpu": "Mali G57",
+      "ram": "24GB (12GB内蔵 + 12GB拡張)",
+      "storage": "128GB (最大1TBのmicroSDカード拡張対応)",
+      "battery": "6000mAh",
+      "camera": "リア13MP / フロント5MP",
+      "os": "Android 15",
+      "connectivity": "Wi-Fi 6 (2.4GHz/5GHz), Bluetooth",
+      "ports": "USB Type-C (OTG対応)",
+      "features": ["Widevine L1対応", "GMS認証済", "顔認証対応"],
+      "color": "グレー",
+      "model": "T1",
+      "warranty": "1年間メーカー保証"
+    }
+  }
+}


### PR DESCRIPTION
Added comprehensive investigation data for Speiow T1 25.6cm Android 15 tablet (ASIN B0GV35WHYZ).
Converted imperial measurements (inches) to metric (cm) as required.
Created competitive analysis comparing against 6 competitors found.
Evaluated score and added recommendations based on standard pricing and specs.
All automated checks successfully passed.

---
*PR created automatically by Jules for task [7391086902887559896](https://jules.google.com/task/7391086902887559896) started by @aegisfleet*