### PR TITLE
Add investigation JSON for B0FVL59RT5

### DIFF
--- a/data/investigations/B0FVL59RT5.json
+++ b/data/investigations/B0FVL59RT5.json
@@ -1,134 +1,189 @@
 {
   "analysis": {
     "productName": "ORICO 20-in-1 USB-C ドッキングステーション",
-    "parentAsin": "B0FVL59RT5",
-    "productDescription": "WindowsノートPCの機能を極限まで拡張する、20ポート搭載の多機能ドッキングステーションです。最大4台の外部モニターへの同時出力が可能で、デスクトップ並みの作業環境を構築できます。",
+    "parentAsin": "B0GMH4WZB3",
+    "productDescription": "最大4画面拡張が可能な20-in-1の万能USB-Cドッキングステーション。HDMI、DP、VGAを搭載し、10Gbpsの高速データ転送や90W PD入力、有線LAN、音声出力など多様な接続ニーズに対応します。",
     "productUsage": [
-      "WindowsノートPCでの最大4画面マルチモニター環境の構築",
-      "多数のUSB機器（マウス、キーボード、HDDなど）の一括接続",
-      "有線LANによる安定したネットワーク接続とSD/TFカードの読み書き"
+      "マルチモニター環境の構築（最大4画面）",
+      "多数の周辺機器（USB機器、SD/TFカード、オーディオ）の一括接続",
+      "ノートPCへの給電と高速データ転送の同時実行"
     ],
     "positivePoints": [
-      "圧倒的なコストパフォーマンス（1.2万円台で4画面出力・20ポート）",
-      "HDMI、DisplayPort、VGAを含む多彩な映像出力端子",
-      "合計6つのUSB-Aポートと2つのUSB-Cポートで周辺機器を大量に接続可能"
+      "20個もの豊富なポート（HDMI, DP×2, VGA, USB-C 3.2×2, USB-A×6, オーディオ×3等）を備え、あらゆる拡張ニーズに対応できる",
+      "HDMIおよびDPポート経由で最大4K解像度、最大4画面の同時出力が可能（Windows環境）",
+      "USB-Cポートは10Gbpsの超高速データ転送に対応し、大容量ファイルの転送が快適",
+      "90W PD入力により、ノートパソコンに最大60Wのパススルー充電が可能"
     ],
     "negativePoints": [
-      "macOSではMST非対応のため、複数画面への拡張（個別の画面表示）ができない（ミラーリングのみ）",
-      "電源アダプターが付属しておらず、別途PD充電器やケーブルの用意が必要",
-      "VGA端子は現代の環境では使用頻度が低く、スペースを占有している"
+      "macOSはマルチスクリーン機能（MST）に非対応で、拡張モードは外部モニター1台のみとなる",
+      "電源アダプターやケーブルが別売りであり、60W充電を利用するには別途65W以上（推奨90W）のPDアダプターを用意する必要がある"
     ],
     "useCases": [
-      "金融トレーダーやプログラマーによる多画面環境の構築（Windows）",
-      "旧型のプロジェクター（VGA）を使用するオフィス環境でのプレゼンテーション"
+      "多数のモニターや周辺機器を使用するクリエイターのデスク環境",
+      "ライブ配信や動画編集など、複数画面と安定した高速データ転送が必要な作業",
+      "ノートPCのポート不足を解消し、デスクトップ化する自宅作業環境"
     ],
-    "userStories": [
-      {
-        "userType": "Windowsユーザー（在宅ワーク）",
-        "scenario": "ノートPC 1台でデスクトップ並みの作業効率を求めて購入",
-        "experience": "1万円台でトリプルディスプレイ環境が構築でき、作業効率が劇的に向上した。USBポートも多いのでハブを買い足す必要がない。（スペックに基づく推測）",
-        "sentiment": "positive"
-      },
-      {
-        "userType": "MacBookユーザー",
-        "scenario": "M1/M2 MacBookでのマルチモニター化を期待して購入",
-        "experience": "Macではすべての外部モニターが同じ画面（ミラーリング）になってしまい、期待した拡張デスクトップ環境が作れなかった。DisplayLink対応機を買うべきだった。（スペックに基づく推測）",
-        "sentiment": "negative"
-      }
-    ],
-    "userImpression": "Windowsユーザーにとっては「コスパ最強の多画面ドック」となり得るが、Macユーザーにとっては仕様制限（MST）により期待外れとなる可能性が高い商品。電源アダプター別売りには注意が必要。",
+    "userStories": [],
+    "userImpression": "豊富なポート数と最大4画面の拡張機能により、ケーブルの抜き差しの手間が省けデスク周りがすっきりするとの評価が予想される。一方でMacユーザーには拡張画面の制限がある点や、PDアダプターが別途必要である点に留意が必要。",
     "sources": [
       {
-        "name": "Amazon Product Specifications (B0FVL59RT5)",
+        "id": "src-1",
+        "name": "Amazon商品ページ",
         "url": "https://www.amazon.co.jp/dp/B0FVL59RT5",
-        "credibility": "high"
-      },
-      {
-        "name": "Anker 564 Product Page (Comparison)",
-        "url": "https://www.amazon.co.jp/dp/B0BP69VJPZ",
-        "credibility": "high"
+        "tier": "medium",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-21",
+        "author": "ORICO専門店",
+        "conflictOfInterest": "possible",
+        "notes": "商品の仕様、特徴、価格情報を取得。"
       }
     ],
-    "lastInvestigated": "2026-01-31",
+    "claims": [
+      {
+        "claim": "最大4台のモニターに同時接続可能（HDMI×1、DP×2、VGA×1）",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "商品情報の特徴欄に明記されているが、macOSではマルチ画面拡張に非対応との注記あり。"
+      },
+      {
+        "claim": "10Gbps対応のUSB-Cポートを2つ搭載",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "商品情報の特徴欄より。"
+      }
+    ],
+    "lastInvestigated": "2026-04-21",
     "competitiveAnalysis": [
       {
-        "name": "Anker 564 USB-C Docking Station",
-        "asin": "B0BP69VJPZ",
-        "priceComparison": "約3.2万円（ORICOの約2.5倍）",
-        "featureComparison": [
-          "DisplayLink搭載でMacでも4画面拡張可能",
-          "180W ACアダプタ付属"
-        ],
-        "differentiators": [
-          "Mac対応",
-          "充実した付属品",
-          "信頼性の高いブランド"
-        ]
-      },
-      {
-        "name": "UGREEN Revodok Pro 314",
+        "name": "UGREEN Revodok Pro 314 14-in-1",
         "asin": "B0DYTVVLH4",
-        "priceComparison": "約1.4万円（ORICOと同価格帯）",
+        "priceComparison": "UGREENは通常価格が約22,000円、セール等で約12,500円。ORICOよりポート数が少なく（14ポート）、拡張画面数も3画面までだが、8K出力やノートPCへの100W給電に対応しており性能が高い。価格を抑えてポート数を重視するか、解像度や給電能力を重視するかで選択が分かれる。",
         "featureComparison": [
-          "3画面出力",
-          "DisplayLink非搭載（推定）"
+          "共通点：マルチモニター拡張（HDMI/DP搭載）、10Gbps高速データ転送、有線LAN、SD/TFカードリーダー搭載",
+          "相違点：ORICOは20ポート搭載で最大4画面対応だが給電は最大60W。UGREENは14ポートで最大3画面だが、最大8K出力に対応しノートPCへの給電も100Wと強力。"
         ],
         "differentiators": [
-          "バランスの良いスペックだがポート数はORICOに劣る"
+          "ORICO 20-in-1 USB-C ドッキングステーションの利点：VGAや複数のオーディオジャックを含む20個の圧倒的なポート数と、最大4画面の拡張性。",
+          "UGREEN Revodok Pro 314 14-in-1の利点：DPポートでの最大8K出力と、ノートPCへの最大100W給電能力。"
         ]
       },
       {
-        "name": "WAVLINK DisplayLink Dock",
-        "asin": "B0FYNHHVXN",
-        "priceComparison": "約2.4万円（ORICOの約2倍）",
+        "name": "UGREEN 14-in-1 ドッキングステーション",
+        "asin": "B0FGHX59G2",
+        "priceComparison": "UGREENは約12,500円（参考価格20,990円）。ORICOより安価で100W給電と27W出力の2つのPDポートを備えるが、ポート数は14個に留まる。給電性能やコスパを求める場合はUGREENが有利。",
         "featureComparison": [
-          "DisplayLink搭載",
-          "トリプル4K対応"
+          "共通点：複数画面出力、10Gbps高速データ転送、RJ45有線LAN搭載",
+          "相違点：ORICOは20ポートでVGAや多数のUSB-Aを搭載。UGREENは14ポートで、ノートPCへの100W給電とスマホへの27W給電を同時に行えるPDポート構成。"
         ],
         "differentiators": [
-          "Mac対応",
-          "Intel/M1/M2チップ正式対応"
+          "ORICO 20-in-1 USB-C ドッキングステーションの利点：古いモニターに繋げるVGA端子や計6つのUSB-Aポートなど、ポートの多様性と数。",
+          "UGREEN 14-in-1 ドッキングステーションの利点：ノートPC(100W)とスマホ(27W)を同時に充電できる強力な給電機能。"
+        ]
+      },
+      {
+        "name": "UGREEN Revodok Pro 12-in-1",
+        "asin": "B0DRP1F6R7",
+        "priceComparison": "UGREENは約7,500円とORICOの半額以下。ORICOは17,000円弱で20ポート搭載。予算重視ならUGREENだが、接続機器が多い場合はORICOの価値がある。",
+        "featureComparison": [
+          "共通点：HDMI/DPによる複数画面出力、10Gbpsデータ転送、PD充電対応",
+          "相違点：ORICOは20ポートで最大4画面出力。UGREENは12ポートで最大3画面出力、給電は最大85W。"
+        ],
+        "differentiators": [
+          "ORICO 20-in-1 USB-C ドッキングステーションの利点：圧倒的なポート数（20個）と4画面拡張機能。",
+          "UGREEN Revodok Pro 12-in-1の利点：価格が非常に安く、手軽にトリプルモニター環境を構築できるコストパフォーマンス。"
+        ]
+      },
+      {
+        "name": "WAVLINK 13-in-1 ドッキングステーション",
+        "asin": "B0GJ3F2Q18",
+        "priceComparison": "WAVLINKは約10,500円。ORICOより安価だがポート数は13個。M1/M2/M3 Macでのトリプルディスプレイに対応するDisplayLink技術を搭載している点が特徴。",
+        "featureComparison": [
+          "共通点：マルチモニター拡張、複数のUSBポート、有線LAN搭載",
+          "相違点：ORICOは20ポート搭載でWindows向け（Macは1画面のみ）。WAVLINKはDisplayLink技術によりMacBookでもトリプルディスプレイが可能。"
+        ],
+        "differentiators": [
+          "ORICO 20-in-1 USB-C ドッキングステーションの利点：Windows環境における最大4画面出力と、20個の豊富なポート。",
+          "WAVLINK 13-in-1 ドッキングステーションの利点：DisplayLink技術による、MシリーズMacBookでのトリプルディスプレイ対応。"
+        ]
+      },
+      {
+        "name": "WAVLINK 12-In-1 USB Cドッキングステーション (SSDエンクロージャー付き)",
+        "asin": "B0DXZ9FGRJ",
+        "priceComparison": "WAVLINKは約13,000円。ORICOより少し安く、M.2 SSDエンクロージャーを内蔵しているのが最大の違い。外部ストレージをスマートに追加したい場合はWAVLINKが適している。",
+        "featureComparison": [
+          "共通点：複数画面出力、10Gbpsデータ転送、有線LAN、SDカードリーダー搭載",
+          "相違点：ORICOは20ポートで画面出力端子が豊富。WAVLINKは12ポートだがM.2 PCIe/SATA SSDエンクロージャーを内蔵している。"
+        ],
+        "differentiators": [
+          "ORICO 20-in-1 USB-C ドッキングステーションの利点：VGA含む多様な映像出力端子と、計6個のUSB-Aポートを備える拡張性。",
+          "WAVLINK 12-In-1 USB Cドッキングステーションの利点：M.2 SSDを内蔵でき、高速な外部ストレージ一体型のドックとして利用できる点。"
+        ]
+      },
+      {
+        "name": "RayCue USB-C ドッキングステーション 15-in-1",
+        "asin": "B0FZGN7SKV",
+        "priceComparison": "RayCueは約15,000円でORICOと近い価格帯。RayCueは15ポートで5つのショートカットボタンやLEDディスプレイを搭載。利便性重視かポート数重視かで選択が変わる。",
+        "featureComparison": [
+          "共通点：トリプルディスプレイ以上の拡張性、10Gbps転送、100W PD入力対応",
+          "相違点：ORICOは20ポートを搭載。RayCueは15ポートだが、画面のスクショやロックなどが可能なショートカットボタンと、状態を確認できるLEDディスプレイを搭載。"
+        ],
+        "differentiators": [
+          "ORICO 20-in-1 USB-C ドッキングステーションの利点：20個の豊富なポートと、古い機器にも対応するVGAポートの搭載。",
+          "RayCue USB-C ドッキングステーション 15-in-1の利点：ワンタッチで操作できるショートカットボタンと、視覚的に状態がわかるLEDディスプレイ。"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "コストを抑えて多画面環境を作りたいWindowsユーザー",
-        "大量のUSB周辺機器を使用するユーザー"
+        "大量のUSB機器やモニターを接続するWindowsユーザー",
+        "VGAや複数のオーディオジャックなど、多様な規格のポートを必要とする人"
       ],
       "pros": [
-        "圧倒的な低価格",
-        "20-in-1の豊富なポート数",
-        "Windowsでの柔軟な画面出力"
+        "20個ものポートを搭載し、これ1台でほとんどの接続が完結する",
+        "Windows環境において最大4画面の拡張が可能",
+        "10Gbpsの高速データ転送ポートを複数搭載"
       ],
       "cons": [
-        "Macではマルチ画面拡張不可",
-        "電源アダプター別売り"
+        "macOSでは複数画面の拡張モードに制限がある（1画面のみ）",
+        "PC給電を利用するには別途高出力の電源アダプターが必要"
       ],
-      "score": 79,
-      "scoreRationale": "[基本点: 70]\n[コストパフォーマンス: +12] (競合の半額近くで20ポート・4画面対応は破格)\n[機能・性能: +5] (ポート数の多さと多画面対応)\n[機能・性能(減点): -8] (MacでのMST制限とACアダプタ別売りは大きなマイナス)\n[合計: 79]"
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (20ポートという圧倒的な拡張性と多様性)\n[減点: -5] (給電用のアダプターが別売りであり、追加コストがかかる点)\n[合計: 75]"
     },
     "technicalSpecs": {
       "dimensions": {
-        "height": "3.8cm",
-        "width": "21cm",
-        "depth": "8.6cm"
+        "height": "38.0mm",
+        "width": "86.0mm",
+        "depth": "209.9mm"
       },
-      "power": "90W DC入力 (60W PD出力パススルー対応)",
-      "connectivity": [
-        "USB-C 3.2 Gen2 x2",
-        "USB-A 3.0 x3",
-        "USB-A 2.0 x3",
-        "HDMI x1",
-        "DP x2",
-        "VGA x1",
-        "Ethernet (RJ45)",
-        "SD/TF Card Slot",
-        "Audio Jack x3"
-      ],
+      "weight": "不明",
+      "capacity": "不明",
+      "material": "不明",
+      "origin": "不明",
       "other": [
-        "MST (Multi-Stream Transport) 対応",
-        "Kensington Lock Slot"
+        "HDMI ×1",
+        "DisplayPort ×2",
+        "VGA ×1",
+        "USB-C 3.2 Gen2 (10Gbps) ×2",
+        "USB-A 3.0 (5Gbps) ×3",
+        "USB-A 2.0 ×3",
+        "オーディオジャック ×3",
+        "SDカードスロット ×1",
+        "TF(MicroSD)カードスロット ×1",
+        "ギガビットイーサネット (RJ45) ×1",
+        "PD入力 (最大90W) ×1",
+        "PC接続用ポート ×1",
+        "PD入力90W対応（最大60Wパススルー充電）※アダプター別売",
+        "color: ブラック",
+        "compatibility: Windows、Mac(拡張モードは1画面のみ)、Dell、HP、Lenovo等"
       ]
     }
   }


### PR DESCRIPTION
This PR adds the investigation report for ASIN `B0FVL59RT5` (ORICO 20-in-1 USB-C Docking Station).
It uses the provided Amazon details and a detailed competitive analysis of 6 competing products to build out the specs, competitive analysis, uses cases, pros, cons, and scoring (with a score of 75).
It strictly follows the output schema requirements, using the fixed metric conversions, deleting old invalid user stories, and following the rigid score rationale format.

---
*PR created automatically by Jules for task [15042419739532577388](https://jules.google.com/task/15042419739532577388) started by @aegisfleet*