### PR TITLE
Add investigation data for Moondrop DawnPro 2 (B0GFD3CV9N)

### DIFF
--- a/data/investigations/B0GFD3CV9N.json
+++ b/data/investigations/B0GFD3CV9N.json
@@ -1,124 +1,168 @@
 {
   "analysis": {
-    "productName": "水月雨 Moondrop 破暁 – DawnPro 2",
+    "productName": "水月雨 Moondrop DawnPro 2 ポータブルDAC/AMP",
     "parentAsin": "B0GFD3CV9N",
-    "productDescription": "デュアルCS43198 DACチップと独立した3つのLDO電源チップを搭載した、ハイレゾ対応ポータブルDAC/AMP。100段階の精密な音量調整が可能で、4.4mmバランス接続と3.5mmシングルエンド接続の両方に対応しています。",
+    "productDescription": "Cirrus Logic社のフラッグシップDACチップ「CS43198」をデュアル搭載したコンパクトなポータブルヘッドホンアンプ。航空グレードのアルミニウム合金筐体を採用し、3.5mmシングルエンドと4.4mmバランス出力に対応。",
     "productUsage": [
-      "スマートフォンでの高音質音楽再生（Apple Music, Amazon Music HDなど）",
-      "PC/ラップトップに接続してのハイレゾ再生",
-      "高感度イヤホン（IEM）からヘッドホンまでの駆動"
+      "スマートフォンやPCに接続して音質を向上",
+      "高感度なイヤホン・ヘッドホンの駆動",
+      "Line Out経由でアクティブスピーカーと接続"
     ],
     "positivePoints": [
-      "デュアルCS43198搭載による高い解像度と低歪み",
-      "スマホから独立した100段階のハードウェアボリューム調整",
-      "放熱性を考慮したエアフロー孔付きアルミニウム合金筐体",
-      "3つの独立LDO電源チップによる安定した電源供給",
-      "コストパフォーマンスの高さ"
+      "CS43198を2基搭載し、低消費電力でありながら優れた駆動力と低歪みを実現",
+      "スマホから分離された100段階の細かい音量調整が可能",
+      "航空グレードのアルミニウム合金筐体で質感と耐久性に優れ、放熱性も考慮された設計",
+      "3.5mmステレオミニと4.4mmバランスの両出力に対応",
+      "10,800円という価格設定で非常に高いコストパフォーマンス"
     ],
     "negativePoints": [
-      "高負荷時の発熱の可能性（エアフローで改善されているとはいえ注意が必要）",
-      "専用アプリ（Moondrop Link）の接続性や使い勝手に改善の余地がある場合がある",
-      "ケーブル接続部に負荷がかかりやすいため、丁寧な取り扱いが必要"
+      "機能や仕様上の大きな欠点は見当たらないが、競合製品に比べると独自のアプリ連携などの付加機能に関する言及が少ない"
     ],
     "useCases": [
-      "通勤・通学時のスマートフォンでの音楽鑑賞",
-      "カフェやオフィスでのPC作業中の高音質リスニング",
-      "ゲーミング用途（高解像度による定位感の向上）"
+      "外出先でのスマホでの高音質リスニング",
+      "PCやタブレットでの音楽鑑賞・動画視聴",
+      "有線イヤホンのアップグレード環境構築"
     ],
-    "userStories": [
-      {
-        "userType": "オーディオファン",
-        "scenario": "高感度IEMでの音楽鑑賞",
-        "experience": "（推測）前作Dawn Proで好評だった独立ボリューム調整が継承されており、100段階の調整により、能率の高いイヤホンでも最適な音量を得やすい。CS43198デュアル構成によるS/N比の高さが、静寂時のノイズレスな背景を実現しているだろう。",
-        "sentiment": "positive"
-      },
-      {
-        "userType": "スマホユーザー",
-        "scenario": "外出先でのハイレゾストリーミング",
-        "experience": "（推測）軽量なアルミニウム筐体は持ち運びに負担にならず、USB Type-C接続で手軽にスマホの音質を向上できる。新しいエアフロー設計により、長時間使用時の熱ごもりが軽減されていることが期待できる。",
-        "sentiment": "positive"
-      }
-    ],
-    "userImpression": "1万円台前半という価格帯ながら、デュアルDAC、バランス接続、独立ボリューム制御を備えた極めてコストパフォーマンスの高い製品。前作からの正統進化として、音質と使い勝手の両立が評価される。",
+    "userStories": [],
+    "userImpression": "コンパクトな筐体にデュアルDACを搭載し、細かな音量調整や放熱設計など実用性に優れたハイコスパなポータブルDAC/AMPとして評価できる。",
     "sources": [
       {
-        "name": "Amazon Product Page Features",
-        "url": "https://www.amazon.co.jp/dp/B0GFD3CV9N",
-        "credibility": "High"
+        "id": "src-amazon-B0GFD3CV9N",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0GFD3CV9N?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-22",
+        "author": "Moondrop",
+        "conflictOfInterest": "none",
+        "notes": "スペック、価格、製品特徴の確認"
       }
     ],
-    "lastInvestigated": "2026-01-31",
-    "competitiveAnalysis": [
+    "claims": [
       {
-        "name": "QDC QD1",
-        "asin": "B0DHCVHXG7",
-        "priceComparison": "約8,000円と本製品より安価",
-        "featureComparison": [
-          "同じくCS43198デュアルDAC搭載",
-          "2段階ゲイン切替",
-          "よりシンプルなデザイン"
-        ],
-        "differentiators": [
-          "価格の安さではQDC QD1が優位",
-          "DawnPro 2は100段階ボリュームや放熱設計で機能的に差別化"
-        ]
+        "claim": "CS43198を2基搭載し高音質と低消費電力を両立",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon-B0GFD3CV9N"],
+        "crossChecked": false,
+        "notes": "商品仕様に明記"
       },
+      {
+        "claim": "100段階の音量調整が可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon-B0GFD3CV9N"],
+        "crossChecked": false,
+        "notes": "商品仕様に明記"
+      }
+    ],
+    "lastInvestigated": "2026-04-22",
+    "competitiveAnalysis": [
       {
         "name": "TRN TE Pro",
         "asin": "B0DDXPYG8P",
-        "priceComparison": "約12,950円と本製品より若干高価",
+        "priceComparison": "対象商品よりやや高い（約13,000円）が、同等のCS43198チップを搭載。",
         "featureComparison": [
-          "CS43198チップ搭載",
-          "32bit/768kHz対応（DawnPro 2は384kHzまで記載）",
-          "出力端子は同等"
+          "共通点：CS43198搭載、3.5mm/4.4mmデュアル出力対応。",
+          "相違点：DawnPro 2は100段階の独立音量調整や独自の筐体放熱設計を持つ。"
         ],
         "differentiators": [
-          "DawnPro 2の方が安価で入手しやすい可能性がある",
-          "ブランド認知度ではMoondropが優勢な場合がある"
+          "水月雨 Moondrop DawnPro 2の利点：価格が安く、細かな音量調整や質感の高いアルミニウム合金筐体を採用している点。",
+          "TRN TE Proの利点：特定のデザインやTRNブランドの音作りを好む場合。"
         ]
       },
       {
-        "name": "SHANLING UA4",
-        "asin": "B0DTTLZ9BD",
-        "priceComparison": "約16,830円と高価",
+        "name": "LAMSCAT LC7100",
+        "asin": "B0DWXLJFT8",
+        "priceComparison": "対象商品と同程度の価格帯（約10,600円）。",
         "featureComparison": [
-          "ESS ES9069Q DAC搭載",
-          "ディスプレイ搭載でステータス確認が可能",
-          "物理ボタンによる操作性"
+          "共通点：CS43198デュアル搭載、3.5mm/4.4mm出力対応。",
+          "相違点：LC7100はアプリによるEQ調音・個性化機能を持つ。"
         ],
         "differentiators": [
-          "ディスプレイの有無が大きな違い",
-          "音質の傾向（ESS系 vs Cirrus Logic系）で好みが分かれる"
+          "水月雨 Moondrop DawnPro 2の利点：アルミニウム合金の筐体品質や、独立したLDO電源チップによる安定した回路設計。",
+          "LAMSCAT LC7100の利点：アプリによるEQ機能など、ソフトウェア的なカスタマイズ性を求める場合。"
+        ]
+      },
+      {
+        "name": "SHANLING H0",
+        "asin": "B0DDL23DZ1",
+        "priceComparison": "対象商品より高い（約16,000円）。",
+        "featureComparison": [
+          "共通点：CS43198搭載。",
+          "相違点：H0はデュアルSGM8262アンプを搭載し690mW@32Ωの高出力や、SPDIFデジタル出力などの機能を持つ。"
+        ],
+        "differentiators": [
+          "水月雨 Moondrop DawnPro 2の利点：より安価で軽量・コンパクトであり、手軽なポータブル運用に適している点。",
+          "SHANLING H0の利点：より高い出力が必要な場合や、デジタル出力機能を活用したい場合。"
+        ]
+      },
+      {
+        "name": "TANCHJIM LUNA",
+        "asin": "B0DSJ9QFN7",
+        "priceComparison": "対象商品よりかなり高い（約22,000円）。",
+        "featureComparison": [
+          "共通点：デュアルCS43198搭載、3.5mm/4.4mm出力対応。",
+          "相違点：価格帯が大きく異なり、筐体設計やブランドの音作りが異なる。"
+        ],
+        "differentiators": [
+          "水月雨 Moondrop DawnPro 2の利点：半額以下の価格で同等の主要DACチップ（デュアルCS43198）を搭載しており、圧倒的にコスパが良い点。",
+          "TANCHJIM LUNAの利点：TANCHJIM独自のチューニングやデザインに強いこだわりがある場合。"
+        ]
+      },
+      {
+        "name": "SHANLING H2",
+        "asin": "B0CTN266BD",
+        "priceComparison": "対象商品の約2倍の価格（約21,000円）。",
+        "featureComparison": [
+          "共通点：CS43198搭載、3.5mm/4.4mm出力。",
+          "相違点：H2はSDローカル再生やBluetooth受信機能を持つオールインワンプレーヤーに近い設計。"
+        ],
+        "differentiators": [
+          "水月雨 Moondrop DawnPro 2の利点：安価で小型軽量な純粋なUSB DAC/AMPとして使いやすい点。",
+          "SHANLING H2の利点：スマホに依存せずローカル再生機能やBluetooth機能を使いたい場合。"
+        ]
+      },
+      {
+        "name": "iBasso Audio DC04U",
+        "asin": "B0GBTB2JS3",
+        "priceComparison": "対象商品より高い（約19,800円）。",
+        "featureComparison": [
+          "共通点：CS43198デュアル搭載、3.5mm/4.4mm出力対応。",
+          "相違点：DC04UはFPGA搭載による低ジッター化や、専用アプリによる10バンドPEQなど高度な機能を持つ。"
+        ],
+        "differentiators": [
+          "水月雨 Moondrop DawnPro 2の利点：より安価でコンパクトであり、細かな音量調整機能を備えている点。",
+          "iBasso Audio DC04Uの利点：PEQなどの高度なカスタマイズ機能や、FPGA等による徹底した音質設計を求める場合。"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "スマホで手軽に高音質を楽しみたいユーザー",
-        "4.4mmバランス接続を試してみたい初心者〜中級者",
-        "コストパフォーマンス重視のオーディオファン"
+        "手頃な価格で高音質なポータブルDACを探している人",
+        "細かく音量調整をしたい人",
+        "3.5mmと4.4mmバランスの両方を使いたい人"
       ],
       "pros": [
-        "価格以上の高スペック（CS43198 Dual, バランス出力）",
-        "微調整可能なハードウェアボリューム",
-        "放熱を考慮した設計"
+        "デュアルCS43198搭載で高音質",
+        "100段階の独立した音量調整機能",
+        "優れた筐体品質と放熱設計",
+        "非常に高いコストパフォーマンス"
       ],
       "cons": [
-        "PC接続時にドライバインストールが必要な場合がある",
-        "付属ケーブルの耐久性に注意"
+        "独自のEQアプリなどのソフトウェアカスタマイズ機能は持たない"
       ],
-      "score": 90,
-      "scoreRationale": "[基本点: 70]\n[性能・機能: +8] (CS43198 Dual, 独立ボリューム, エアフロー設計)\n[コストパフォーマンス: +10] (1万円強でこのスペックは非常に高い)\n[品質・デザイン: +2] (アルミ合金、放熱考慮のデザイン)\n[合計: 90]"
+      "score": 93,
+      "scoreRationale": "[基本点: 70] (固定)\n[加点: +10] (同価格帯でデュアルCS43198搭載など非常に高いコストパフォーマンス)\n[加点: +5] (100段階の細かな音量調整機能の利便性)\n[加点: +5] (アルミニウム合金採用の質感の高さと熱対策設計)\n[加点: +3] (3基のLDO電源チップ独立供給など優れた回路設計)\n[合計: 93]"
     },
     "technicalSpecs": {
-      "dac": "Cirrus Logic CS43198 x2",
-      "decoding": "PCM 32bit/384kHz, DSD256",
-      "outputs": "3.5mm Single-ended, 4.4mm Balanced",
-      "volumeControl": "100 steps hardware volume (independent)",
-      "powerSupply": "3 Independent LDO chips",
-      "interface": "USB Type-C",
-      "body": "Aluminum Alloy with Airflow Vents",
-      "dimensions": null
+      "material": "航空グレードアルミニウム合金",
+      "dacChip": "デュアル CS43198",
+      "decoding": "PCM 32bit/384kHz, DSD256 (ハードウェアデコード)",
+      "outputPorts": "3.5mmステレオミニ, 4.4mmバランス",
+      "inputPort": "USB Type-C",
+      "volumeControl": "100段階独立音量調整",
+      "powerSupply": "3基のLDO電源チップによる独立供給"
     }
   }
 }


### PR DESCRIPTION
- Created JSON investigation data for Moondrop DawnPro 2 (B0GFD3CV9N)
- Added competitive analysis with 6 similar products (CS43198 DAC amps)
- Added specific product features based on Amazon data
- Completed pre-commit checks and validated artifact format

---
*PR created automatically by Jules for task [6013170243632743135](https://jules.google.com/task/6013170243632743135) started by @aegisfleet*