### PR TITLE
Investigation data for VARNIC suitcase

### DIFF
--- a/data/investigations/B08XXQPVQZ.json
+++ b/data/investigations/B08XXQPVQZ.json
@@ -1,0 +1,176 @@
+{
+  "analysis": {
+    "productName": "VARNIC スーツケース 機内持込 Sサイズ 40.5L",
+    "parentAsin": "B08XXQ684G",
+    "productDescription": "軽量かつ頑丈なABS+PC素材を採用し、耐衝撃性と静音性に優れたSサイズ（40.5L）の機内持ち込み可能スーツケースです。",
+    "productUsage": [
+      "1〜3泊の小旅行",
+      "出張"
+    ],
+    "positivePoints": [
+      "ABS樹脂とPCの混合素材で軽量かつ耐衝撃性に優れている",
+      "高弾性TPE素材の静音ダブルキャスターで360度スムーズに移動可能",
+      "TSAダイヤル式ロック搭載で鍵紛失のリスクがなく安全"
+    ],
+    "negativePoints": [
+      "USB充電ポートやドリンクホルダーなど、最新の多機能性（他社製品に見られる機能）は搭載されていない",
+      "フロントオープンではないため、移動中の荷物の出し入れには不便"
+    ],
+    "useCases": [
+      "LCCなどの機内持ち込み制限があるフライトでの利用",
+      "荷物を最小限に抑えたい短期出張や週末の旅行"
+    ],
+    "userStories": [],
+    "userImpression": "シンプルで軽量、かつ基本性能（静音キャスター、頑丈なボディ、TSAロック）をしっかり備えた、コストパフォーマンスの高いスーツケースとして評価されています。特にキャスターの滑らかさや軽さが好評です。",
+    "sources": [
+      {
+        "id": "src-amazon-varnic",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B08XXQPVQZ",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-23",
+        "author": "VARNIC",
+        "conflictOfInterest": "possible",
+        "notes": "商品仕様、特徴（ABS+PC素材、静音キャスター、TSAロックなど）を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "ABS樹脂とPCの混合素材で耐衝撃性と軽量性を両立",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon-varnic"
+        ],
+        "crossChecked": false,
+        "notes": "公式スペックとして確認"
+      },
+      {
+        "claim": "高弾性TPE衝撃軽減素材のダブルキャスターにより静音でスムーズな移動が可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon-varnic"
+        ],
+        "crossChecked": false,
+        "notes": "公式スペックとして確認"
+      }
+    ],
+    "lastInvestigated": "2026-04-23",
+    "competitiveAnalysis": [
+      {
+        "name": "SUPBOX スーツケース 39L",
+        "asin": "B0CKT17FB3",
+        "priceComparison": "対象商品とほぼ同価格帯ですが、SUPBOXはUSBポートやカップホルダーなどの付加機能を多く備えています。",
+        "featureComparison": [
+          "共通点：ABS+PC素材、機内持ち込み可能、静音ダブルキャスター搭載",
+          "相違点：SUPBOXはUSBポート、カップホルダー、隠しフックを備えているが、VARNICはシンプルな構造。"
+        ],
+        "differentiators": [
+          "VARNIC スーツケース 機内持込 Sサイズ 40.5Lの利点：シンプルな構造で40.5Lとわずかに容量が大きい（SUPBOXは39L）。",
+          "SUPBOX スーツケース 39Lの利点：USBポートやカップホルダーなど、移動中の利便性を高める多機能が充実している。"
+        ]
+      },
+      {
+        "name": "Wozwe 最軽量 キャリーケース 42L",
+        "asin": "B0GWQCL2NC",
+        "priceComparison": "対象商品と同価格帯ですが、Wozweは多機能性に加え、容量がわずかに大きいです。",
+        "featureComparison": [
+          "共通点：機内持ち込み可能、静音キャスター、TSAロック搭載",
+          "相違点：Wozweは100%PC素材を謳い、携帯スタンド、USBポート、カップホルダーなどの多機能を持つ。"
+        ],
+        "differentiators": [
+          "VARNIC スーツケース 機内持込 Sサイズ 40.5Lの利点：ABS+PC混合素材によるバランスの取れた剛性。",
+          "Wozwe 最軽量 キャリーケース 42Lの利点：42Lという大容量と、スマホスタンドなどの豊富な付加機能。"
+        ]
+      },
+      {
+        "name": "meer スーツケース 40L",
+        "asin": "B0F9NZRD5G",
+        "priceComparison": "対象商品とほぼ同価格帯ですが、meerはキャスターストッパーや充電ポートなど機能が豊富です。",
+        "featureComparison": [
+          "共通点：ABS+PC素材、機内持ち込み可能、静音キャスター",
+          "相違点：meerはブレーキ機能（ストッパー）やType-C&USB充電ポートを備えている。"
+        ],
+        "differentiators": [
+          "VARNIC スーツケース 機内持込 Sサイズ 40.5Lの利点：シンプルなデザインと構造で、故障リスクが少ない。",
+          "meer スーツケース 40Lの利点：電車内などで便利なキャスターストッパーや、充実した充電ポートを備えている。"
+        ]
+      },
+      {
+        "name": "SupTrip スーツケース アルミフレーム 40L",
+        "asin": "B0F5B747T9",
+        "priceComparison": "対象商品より価格が高いです。アルミフレームを採用しているため、より堅牢な作りになっています。",
+        "featureComparison": [
+          "共通点：機内持ち込み可能、静音キャスター搭載",
+          "相違点：対象商品がファスナータイプ（ABS+PC）であるのに対し、SupTripはアルミフレームを採用しており、重量と堅牢性が異なる。"
+        ],
+        "differentiators": [
+          "VARNIC スーツケース 機内持込 Sサイズ 40.5Lの利点：ファスナータイプで軽量（約2.7kg）であり、価格が手頃。",
+          "SupTrip スーツケース アルミフレーム 40Lの利点：アルミフレームによる高い堅牢性と防犯性、高級感のあるデザイン。"
+        ]
+      },
+      {
+        "name": "New Trip スーツケース 拡張機能付き 40L",
+        "asin": "B0BQ3QPKWC",
+        "priceComparison": "対象商品より価格が高いです。拡張機能とYKKファスナーを採用しており、品質と機能性に優れています。",
+        "featureComparison": [
+          "共通点：ABS+PC素材、機内持ち込み可能",
+          "相違点：New Tripはマチ幅を5cm拡張でき、メインファスナーにYKKを採用している。"
+        ],
+        "differentiators": [
+          "VARNIC スーツケース 機内持込 Sサイズ 40.5Lの利点：コストパフォーマンスに優れ、手軽に購入できる。",
+          "New Trip スーツケース 拡張機能付き 40Lの利点：荷物が増えた際に対応できる拡張機能と、信頼性の高いYKKファスナーによる耐久性。"
+        ]
+      },
+      {
+        "name": "BARGOHOY フロントオープン スーツケース 42L",
+        "asin": "B0DQSMJLPQ",
+        "priceComparison": "対象商品より価格が高いです。フロントオープン機能を備えており、荷物の出し入れに特化しています。",
+        "featureComparison": [
+          "共通点：ABS+PC素材、機内持ち込み可能",
+          "相違点：BARGOHOYはフロントオープンデザインを採用し、PCやタブレットなどをサッと取り出せる。"
+        ],
+        "differentiators": [
+          "VARNIC スーツケース 機内持込 Sサイズ 40.5Lの利点：シンプルな構造による低価格と軽さ。",
+          "BARGOHOY フロントオープン スーツケース 42Lの利点：フロントポケットによる圧倒的な小物の出し入れのしやすさと多機能性。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "コスパ重視でシンプルなスーツケースを探している方",
+        "短期の旅行や出張で、機内持ち込みサイズの軽量なキャリーが必要な方"
+      ],
+      "pros": [
+        "ABS+PC素材で軽量かつ丈夫",
+        "高弾性TPEキャスターによる静音性",
+        "価格が手頃でコスパが高い"
+      ],
+      "cons": [
+        "USBポートやドリンクホルダーなどの多機能はない",
+        "フロントオープンではないため、移動中の荷物アクセスはやや不便"
+      ],
+      "score": 83,
+      "scoreRationale": "[基本点: 70]\n[加点: +8] (ABS+PC素材と静音キャスターによる基本性能の高さ)\n[加点: +5] (5000円以下の価格帯による高いコストパフォーマンス)\n[合計: 83]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "550mm",
+        "width": "230mm",
+        "depth": "370mm"
+      },
+      "weight": "2.7kg",
+      "capacity": "40.5L",
+      "material": "ABS樹脂、PC（ポリカーボネート）",
+      "origin": "不明",
+      "other": [
+        "TSAダイヤル式ロック搭載",
+        "高弾性TPE衝撃軽減素材のダブルキャスター",
+        "三段調節可能アルミニウム製キャリバー",
+        "X型ベルト付き内装"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This change adds the required JSON investigation file for the VARNIC suitcase (ASIN: B08XXQPVQZ) adhering to the given formatting constraints.
The dimensions were converted to metric units.
Competitor items were retrieved and cross-referenced.

---
*PR created automatically by Jules for task [12228687472108394241](https://jules.google.com/task/12228687472108394241) started by @aegisfleet*