### PR TITLE
Update Today's Recommendations with Evidence

### DIFF
--- a/data/recommendations/today.json
+++ b/data/recommendations/today.json
@@ -1,201 +1,211 @@
 {
-  "date": "2026-04-25",
+  "date": "2026-04-26",
   "headline": "本日の厳選ピックアップ：確かな理由がある注目商品10選",
   "recommendations": [
     {
-      "asin": "B0GR698XPH",
-      "title": "Apple 2026 MacBook Neo A18 Proチップ搭載13インチ",
-      "price": "￥95,768",
-      "category": "PC・周辺機器",
-      "reason": "最新のA18 Proチップを搭載し、AI機能に特化した2026年モデルのMacBook Neo。高い処理能力とLiquid Retinaディスプレイで快適な作業環境を提供します。",
-      "whyBuyNow": "2026年最新モデルであり、発売直後で注目度が高いため。AI機能をフル活用したい方におすすめです。",
+      "asin": "B085HLVJYP",
+      "title": "GLEVIO ビジネスリュック 拡張機能付き",
+      "price": "￥6,180",
+      "category": "ファッション・バッグ",
+      "reason": "マチ幅を拡張できるため、普段の通勤から短期出張まで対応可能。PC専用ポケットや充実した小物収納が魅力。",
+      "whyBuyNow": "タイムセール中で参考価格￥9,800から37%OFFとなっており、新生活や出張の多いビジネスマンに今おすすめ。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0GR698XPH?tag=aegis-22"
+        "name": "Amazonタイムセール",
+        "url": "https://www.amazon.co.jp/dp/B085HLVJYP"
       },
       "highlights": [
-        "A18 Proチップ搭載",
-        "Liquid Retinaディスプレイ",
-        "1080p FaceTime HDカメラ"
+        "マチ幅最大22.5cmに拡張可能",
+        "15.6インチPC収納対応",
+        "撥水加工で雨の日も安心"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0GR698XPH?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B085HLVJYP",
+      "imageUrl": "https://m.media-amazon.com/images/I/41xZBLIz39L._SL500_.jpg"
     },
     {
-      "asin": "B0DYF82545",
-      "title": "Xiaomi Smart Band 10 スマートウォッチ",
-      "price": "￥6,280",
-      "category": "スマートウォッチ",
-      "reason": "1.72インチの大画面と21日間の連続使用が可能なバッテリーを搭載。24時間の健康管理機能も充実しています。",
-      "whyBuyNow": "最新のSmart Band 10が手頃な価格で購入可能。健康管理やスポーツ時の記録を始めたい方に最適なタイミングです。",
+      "asin": "B092ZS3LLB",
+      "title": "Wallfire ノンフライヤー 4.5L",
+      "price": "￥6,950",
+      "category": "キッチン家電",
+      "reason": "4.5Lの大容量で家族の料理にも対応。油を使わずヘルシーに揚げ物を作ることができ、お手入れも簡単。",
+      "whyBuyNow": "タイムセール開催中で45%OFFと大幅割引されており、健康的な食生活を始めたい方に最適なタイミング。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0DYF82545?tag=aegis-22"
+        "name": "Amazonタイムセール",
+        "url": "https://www.amazon.co.jp/dp/B092ZS3LLB"
       },
       "highlights": [
-        "1.72大画面体験",
-        "21日間連続使用",
-        "24時間健康管理"
+        "4.5Lの大容量で3〜5人分対応",
+        "油なしでヘルシー調理",
+        "8種類のプリセットメニュー搭載"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0DYF82545?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B092ZS3LLB",
+      "imageUrl": "https://m.media-amazon.com/images/I/41H-2L59m9L._SL500_.jpg"
     },
     {
-      "asin": "B0GNLZX2DJ",
-      "title": "ジーピー カタン スタンダード版 2026年版",
-      "price": "￥4,418",
-      "category": "ボードゲーム",
-      "reason": "世界中で愛される名作ボードゲーム「カタン」の2026年最新版。家族や友人と集まって楽しむのに最適です。",
-      "whyBuyNow": "2026年版が新発売。春の行楽シーズンやゴールデンウィークに向けて、みんなで遊べるゲームの準備におすすめです。",
+      "asin": "B0BBM6R6DR",
+      "title": "ティファール 電気圧力鍋 3L",
+      "price": "￥14,200",
+      "category": "調理器具",
+      "reason": "独自の球状煮込み鍋でムラなく熱が伝わり、多彩なモードで本格的な料理が時短で完成する優れた機能性。",
+      "whyBuyNow": "現在タイムセールで過去価格から10%OFFで提供されており、オンライン限定カラーのブラックが手に入るチャンス。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0GNLZX2DJ?tag=aegis-22"
+        "name": "Amazonタイムセール",
+        "url": "https://www.amazon.co.jp/dp/B0BBM6R6DR"
       },
       "highlights": [
-        "世界的人気ゲーム",
-        "2026年最新版",
-        "大人数で楽しめる"
+        "ムラなく熱が伝わる球状鍋",
+        "調理時間を最大1/3まで短縮",
+        "オンライン限定のブラック色"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0GNLZX2DJ?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B0BBM6R6DR",
+      "imageUrl": "https://m.media-amazon.com/images/I/41O8ZRZfK-L._SL500_.jpg"
     },
     {
-      "asin": "B0G4RR4DM7",
-      "title": "PlayStation 5 Pro(CFI-7100B01)",
-      "price": "￥127,570",
-      "category": "ゲーム機本体",
-      "reason": "さらに進化したグラフィックと処理能力を誇るPS5 Pro。最高品質のゲーム体験を求めるゲーマー必携のハードウェアです。",
-      "whyBuyNow": "人気商品で品薄が予想されるため、在庫がある今のうちに確保しておくのが賢明です。",
-      "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0G4RR4DM7?tag=aegis-22"
-      },
-      "highlights": [
-        "進化したグラフィック",
-        "高速ロード",
-        "没入感の高いゲーム体験"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0G4RR4DM7?tag=aegis-22"
-    },
-    {
-      "asin": "B0DTYLT6VW",
-      "title": "GREEN PLACE 観葉植物 本物 卓上 ミニ 3点セット",
-      "price": "￥3,990",
-      "category": "観葉植物",
-      "reason": "パキラ、ガジュマル、サンスベリアの人気のミニ観葉植物3点セット。ハイドロカルチャー仕様でお手入れも簡単です。",
-      "whyBuyNow": "新生活のスタートや、春のお部屋の模様替えにぴったりのインテリアグリーンです。",
-      "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0DTYLT6VW?tag=aegis-22"
-      },
-      "highlights": [
-        "人気品種の3点セット",
-        "お手入れ簡単なハイドロ",
-        "卓上サイズ"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0DTYLT6VW?tag=aegis-22"
-    },
-    {
-      "asin": "B0FNRS5WB2",
-      "title": "Anker Soundcore P31i",
-      "price": "￥5,990",
-      "category": "オーディオ",
-      "reason": "アクティブノイズキャンセリングを搭載し、最大50時間の長時間再生が可能な高コストパフォーマンスのワイヤレスイヤホンです。",
-      "whyBuyNow": "通勤・通学の新生活が本格化する時期。静かな環境で音楽や学習に集中したい方に最適です。",
-      "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0FNRS5WB2?tag=aegis-22"
-      },
-      "highlights": [
-        "ノイズキャンセリング",
-        "最大50時間再生",
-        "マルチポイント接続"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0FNRS5WB2?tag=aegis-22"
-    },
-    {
-      "asin": "B06Y69FKT2",
-      "title": "エクスプロージョン プロテイン 3kg ミルクチョコレート味",
-      "price": "￥10,780",
+      "asin": "B0CV4329W3",
+      "title": "睡眠グッスリEX GABA100mg",
+      "price": "￥1,630",
       "category": "サプリメント",
-      "reason": "高品質な日本製造のホエイプロテイン。大容量3kgでコストパフォーマンスが高く、毎日のトレーニングのサポートに最適です。",
-      "whyBuyNow": "大容量で1gあたりの単価が安く、継続的にプロテインを消費する方にとって非常にお得なため。",
+      "reason": "GABAを100mg配合し、睡眠の質向上と一時的な疲労感の緩和をサポートする機能性表示食品。",
+      "whyBuyNow": "期間限定のセール価格で18%OFFとなっており、睡眠に悩みを持つ方が手軽に試しやすいタイミング。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B06Y69FKT2?tag=aegis-22"
+        "name": "Amazonタイムセール",
+        "url": "https://www.amazon.co.jp/dp/B0CV4329W3"
       },
       "highlights": [
-        "大容量3kg",
-        "日本製造",
-        "美味しいチョコ味"
+        "睡眠の質を高めるGABA配合",
+        "11種類のビタミンをプラス",
+        "徹底した国内GMP工場製造"
       ],
-      "url": "https://www.amazon.co.jp/dp/B06Y69FKT2?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B0CV4329W3",
+      "imageUrl": "https://m.media-amazon.com/images/I/51+gUYTYdsL._SL500_.jpg"
     },
     {
-      "asin": "B0GRGKTVQK",
-      "title": "SK-II ジェノプティクス アドバンスド スポット エッセンス 30mL",
-      "price": "￥17,490",
-      "category": "スキンケア",
-      "reason": "SK-IIの最新美白美容液。ナイアシンアミドとピテラを配合し、シミやシワの改善に効果が期待できます。",
-      "whyBuyNow": "2026年4月5日に発売されたばかりの新商品。紫外線の強くなる春・夏に向けたケアのスタートにおすすめです。",
+      "asin": "B073W263CM",
+      "title": "オルナ オーガニック スキンケアセット",
+      "price": "￥5,800",
+      "category": "美容・スキンケア",
+      "reason": "化粧水・美容液・乳液が揃った保湿ケアの基本セット。無添加処方で敏感肌の方にも使いやすい。",
+      "whyBuyNow": "参考価格￥7,180から19%OFFの割引が適用されており、ギフトや自分へのご褒美として最適。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0GRGKTVQK?tag=aegis-22"
+        "name": "Amazon通常割引",
+        "url": "https://www.amazon.co.jp/dp/B073W263CM"
       },
       "highlights": [
-        "最新の美白美容液",
-        "ピテラ配合",
-        "医薬部外品"
+        "化粧水・乳液・美容液のセット",
+        "肌に優しい無添加処方",
+        "ビタミンC誘導体配合美容液"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0GRGKTVQK?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B073W263CM",
+      "imageUrl": "https://m.media-amazon.com/images/I/41Egu5WUSDL._SL500_.jpg"
     },
     {
-      "asin": "B0GQGFDQ1J",
-      "title": "Munyday 筋膜リリースガン",
-      "price": "￥4,999",
-      "category": "マッサージ機器",
-      "reason": "99段階の振動設定と8つのアタッチメントを備えた多機能な筋膜リリースガン。超軽量で携帯にも便利です。",
-      "whyBuyNow": "2026年の業界新定番モデルとして注目されており、日々の疲労回復や運動後のケアを手軽に始められます。",
+      "asin": "B0C8HK543G",
+      "title": "アンパンマン はじめてのキッズタブレット",
+      "price": "￥2,955",
+      "category": "知育玩具",
+      "reason": "日本おもちゃ大賞2023の優秀賞を受賞。タッチで遊びながら楽しく言葉や音を学べる安全なタブレット玩具。",
+      "whyBuyNow": "参考価格￥5,280から44%OFFと大幅値引きされており、小さなお子様へのプレゼントにうってつけ。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0GQGFDQ1J?tag=aegis-22"
+        "name": "Amazon通常割引",
+        "url": "https://www.amazon.co.jp/dp/B0C8HK543G"
       },
       "highlights": [
-        "99段階の強力振動",
-        "8種のアタッチメント",
-        "超軽量デザイン"
+        "遊びながらあいうえお学習",
+        "メロディや効果音も充実",
+        "日本おもちゃ大賞2023受賞"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0GQGFDQ1J?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B0C8HK543G",
+      "imageUrl": "https://m.media-amazon.com/images/I/51tamHMPgCL._SL500_.jpg"
     },
     {
-      "asin": "B0FJXBZW45",
-      "title": "アイリスオーヤマ コードレス掃除機 軽量1.3kg SCD-AZ18P2-B",
-      "price": "￥10,300",
-      "category": "生活家電",
-      "reason": "軽量設計で取り回しやすく、サイクロン式で強力な吸引力を持つコードレス掃除機。Amazon.co.jp限定モデルです。",
-      "whyBuyNow": "13,800円からの大幅値引きで、コストパフォーマンスが非常に高くお買い得です。",
+      "asin": "B0B8Z7GHGK",
+      "title": "ドギーマン 噛みごたえ牛すじのササミ巻き",
+      "price": "￥314",
+      "category": "ペットフード・おやつ",
+      "reason": "牛すじとササミの2つの旨みが楽しめる無添加良品。ハードな噛み応えでストレス発散にもなる。",
+      "whyBuyNow": "参考価格から32%OFFで提供されており、愛犬の健康的なおやつをお手頃価格でまとめ買いする好機。",
       "source": {
-        "name": "Amazon",
-        "url": "https://www.amazon.co.jp/dp/B0FJXBZW45?tag=aegis-22"
+        "name": "Amazon通常割引",
+        "url": "https://www.amazon.co.jp/dp/B0B8Z7GHGK"
       },
       "highlights": [
-        "軽量1.3kg",
-        "強力サイクロン",
-        "パワーブラシ搭載"
+        "牛すじとササミの旨み",
+        "噛みごたえで歯を鍛える",
+        "安心の無添加良品シリーズ"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0FJXBZW45?tag=aegis-22"
+      "url": "https://www.amazon.co.jp/dp/B0B8Z7GHGK",
+      "imageUrl": "https://m.media-amazon.com/images/I/41bqmvaKA-L._SL500_.jpg"
+    },
+    {
+      "asin": "B0GS5T1KXC",
+      "title": "Baiinin 多機能フットレスト 足置き",
+      "price": "￥2,999",
+      "category": "オフィス用品",
+      "reason": "整体師監修の設計で、足首や膝の負担を軽減。正しい姿勢をサポートしリモートワークの疲れを和らげる。",
+      "whyBuyNow": "2026年4月29日の発売に向けて予約受付中で、参考価格￥4,780から37%OFFの特別価格で事前注文可能。",
+      "source": {
+        "name": "Amazon新製品予約割引",
+        "url": "https://www.amazon.co.jp/dp/B0GS5T1KXC"
+      },
+      "highlights": [
+        "整体師監修の人間工学設計",
+        "足枕やストレッチにも使える",
+        "高反発スポンジで快適なサポート"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B0GS5T1KXC",
+      "imageUrl": "https://m.media-amazon.com/images/I/418VbsB1XcL._SL500_.jpg"
+    },
+    {
+      "asin": "B07PQD5JMP",
+      "title": "苦しかったときの話をしようか (Kindle版)",
+      "price": "￥1,485",
+      "category": "ビジネス・経済書",
+      "reason": "キャリアや人生に悩む多くのビジネスパーソンから支持される、森岡毅氏による大ベストセラー本。",
+      "whyBuyNow": "Kindle版が紙の本の価格から10%OFFで提供されており、ゴールデンウィーク前の読書用にすぐダウンロードして読める。",
+      "source": {
+        "name": "Amazon Kindle割引",
+        "url": "https://www.amazon.co.jp/dp/B07PQD5JMP"
+      },
+      "highlights": [
+        "森岡毅氏の大ヒット作",
+        "キャリアの悩みに応える内容",
+        "Kindle版でいつでも読める"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B07PQD5JMP",
+      "imageUrl": "https://m.media-amazon.com/images/I/51xcKZdqiCL._SL500_.jpg"
+    },
+    {
+      "asin": "B0FPLJG8GX",
+      "title": "Leacco フットケア レッグリラックス",
+      "price": "￥6,314",
+      "category": "健康家電・マッサージ",
+      "reason": "ふくらはぎを360度包み込むエアバッグと温感ヒーターで、脚の疲れをじんわり解きほぐすコードレスケア機器。",
+      "whyBuyNow": "タイムセールにて参考価格から40%OFF。母の日が近づく中、実用的なギフトとして今のうちに準備したい逸品。",
+      "source": {
+        "name": "Amazonタイムセール",
+        "url": "https://www.amazon.co.jp/dp/B0FPLJG8GX"
+      },
+      "highlights": [
+        "360度包むダブルエアバッグ",
+        "3段階の温熱ケア機能",
+        "便利なコードレス設計"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B0FPLJG8GX",
+      "imageUrl": "https://m.media-amazon.com/images/I/41NhN93toEL._SL500_.jpg"
     }
   ],
   "searchContext": {
-    "todayOverview": "2026年4月25日現在、最新テクノロジーを搭載したガジェット（MacBook Neo、PS5 Pro）や、春の新生活・行楽シーズンに向けたアイテム（観葉植物、ボードゲーム、スキンケア用品）に注目が集まっています。幅広いカテゴリから、生活を豊かにする実用的な商品を厳選しました。",
+    "todayOverview": "2026年4月26日は、新生活や母の日ギフトに向けた需要が高まる時期です。Amazonではタイムセールが複数開催されており、実用的な家電から日用品、健康グッズまで幅広いカテゴリでお得な商品が見つかります。",
     "searchedCategories": [
-      "PC・周辺機器",
-      "スマートウォッチ",
-      "ボードゲーム",
-      "ゲーム機本体",
-      "観葉植物",
-      "オーディオ",
+      "ファッション・バッグ",
+      "キッチン家電",
+      "調理器具",
       "サプリメント",
-      "スキンケア",
-      "マッサージ機器",
-      "生活家電"
+      "美容・スキンケア",
+      "知育玩具",
+      "ペットフード・おやつ",
+      "オフィス用品",
+      "ビジネス・経済書",
+      "健康家電・マッサージ"
     ]
   }
 }


### PR DESCRIPTION
Updated `data/recommendations/today.json` with 10 diverse product recommendations for the current date (2026-04-26). Each recommendation includes explicit evidence sources and "why buy now" reasoning based on active sales and discounts.

---
*PR created automatically by Jules for task [6699047049360770692](https://jules.google.com/task/6699047049360770692) started by @aegisfleet*