### PR TITLE
Add investigation data for B0FT2DGWRN

### DIFF
--- a/data/investigations/B0FT2DGWRN.json
+++ b/data/investigations/B0FT2DGWRN.json
@@ -1,133 +1,200 @@
 {
   "analysis": {
-    "productName": "エレコム USBハブ USB-C 直挿し 3ポート U3HC-R030EBK",
-    "parentAsin": "B0FT8XXFRG",
-    "productDescription": "USB-Cポートに直挿しできるケーブルレスの3ポートUSBハブ。180度回転するスイングコネクターにより、PCやタブレットの側面に沿わせてスッキリ設置できます。",
+    "productName": "エレコム USB-C接続 3ポート USBハブ U3HC-R030EBK",
+    "parentAsin": "B0FT2DGWRN",
+    "productDescription": "180度回転するスイングコネクターを採用し、ケーブル不要で直挿しできるUSB Type-C接続の3ポートハブです。USB 5Gbpsの高速データ転送に対応しています。",
     "productUsage": [
-      "ノートPCやタブレット（iPad等）のUSB-CポートをUSB-Aポートx3に拡張",
-      "マウス、キーボード、USBメモリなどの周辺機器の接続",
-      "外出先やカフェでの省スペース作業（ケーブルレス運用）"
+      "ノートパソコンでのUSBポート増設",
+      "外出先や狭いデスクでの周辺機器接続"
     ],
     "positivePoints": [
-      "ケーブルがないため持ち運びに便利で、デスク上がスッキリする",
-      "180度スイングコネクタで、隣接するポートへの干渉を回避しやすい",
-      "3ポート全てがUSB 5Gbps (USB 3.0) に対応し、高速データ転送が可能",
-      "国内メーカー（エレコム）製であることの安心感"
+      "180度回転するスイングコネクターにより、隣のポートとの干渉を防げる",
+      "ケーブルレスの直挿しタイプで、持ち運びや収納が容易",
+      "3ポートすべてがUSB 5Gbps(理論値)の高速転送に対応"
     ],
     "negativePoints": [
-      "厚みのあるPCケースやタブレットケースを使用していると、コネクタが奥まで挿さらない場合がある",
-      "直挿しタイプのため、接続機器の重みでポートに負荷がかかる可能性がある",
-      "USB PD（Power Delivery）パススルー充電には非対応（充電しながらの使用は不可）"
+      "USB PDなどのパススルー充電機能は備えていない",
+      "厚みのあるケースを装着したデバイスや、ポート周りに段差があるデバイスでは物理的に干渉する可能性がある"
     ],
     "useCases": [
-      "カフェや移動中の新幹線など、狭いスペースでのPC作業",
-      "iPadでのキーボード・マウス接続によるPCライクな活用",
-      "ポート数が少ない薄型ノートPC（MacBook Airなど）の拡張"
+      "カフェやコワーキングスペースなど、限られたスペースでの作業",
+      "出張や旅行時の荷物を減らしたい際の携帯用ハブとして"
     ],
     "userStories": [
       {
-        "userType": "30代フリーランス (推測)",
-        "scenario": "カフェでのリモートワーク",
-        "experience": "ケーブルがぶら下がらないので、狭いテーブルでも邪魔にならず快適。MacBookの側面にピタッと沿わせられるので見た目もスマート。",
-        "sentiment": "positive"
-      },
-      {
-        "userType": "大学生 (推測)",
-        "scenario": "大学でのプレゼン資料作成",
-        "experience": "USBメモリでデータを受け渡す際、充電ケーブルと干渉しがちだったが、コネクタを回転させることで両方同時に使えて便利。",
+        "userType": "ノートPCユーザー",
+        "scenario": "カフェなどの狭いテーブルで作業する時",
+        "experience": "ケーブルがないため机の上がごちゃつかず、スイングコネクタのおかげで隣の充電ポートと干渉せずに使えるのが非常に便利です。コンパクトでポーチにもすっぽり収まります。",
+        "supportingSourceIds": [
+          "src-1"
+        ],
         "sentiment": "positive"
       }
     ],
-    "userImpression": "レビュー数はまだ少ないが、持ち運びやすさと実用性を兼ね備えた製品として評価できる。特に「回転式直挿し」による設置の柔軟性と、全ポート高速転送対応という基本性能の高さが魅力。",
+    "userImpression": "ケーブルレスで直挿しでき、コネクタが回転するため取り回しが非常に良いと評価されています。特にモバイル用途や限られたスペースでの作業において、そのコンパクトさと機能性が好評です。",
     "sources": [
       {
-        "name": "Amazon.co.jp 商品ページ",
+        "id": "src-1",
+        "name": "Amazon.co.jp商品ページ",
         "url": "https://www.amazon.co.jp/dp/B0FT2DGWRN",
-        "credibility": "High"
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2025-10-30",
+        "author": "エレコム",
+        "conflictOfInterest": "possible",
+        "notes": "商品の特徴、仕様、画像データ"
+      },
+      {
+        "id": "src-2",
+        "name": "価格.com 商品情報",
+        "url": "https://kakaku.com/item/K0001715182/",
+        "tier": "high",
+        "evidenceType": "secondary",
+        "publishedAt": "2026-04-26",
+        "author": "価格.com",
+        "conflictOfInterest": "none",
+        "notes": "スペック詳細（サイズ、重量等）"
       }
     ],
-    "lastInvestigated": "2026-02-01",
+    "claims": [
+      {
+        "claim": "180度回転するスイングコネクタを採用",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": true,
+        "notes": "商品画像およびメーカー説明で確認"
+      },
+      {
+        "claim": "全3ポートがUSB 5Gbps(理論値)に対応",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "crossChecked": true,
+        "notes": "スペック表で確認"
+      }
+    ],
+    "lastInvestigated": "2026-04-26",
     "competitiveAnalysis": [
       {
-        "name": "ALLVD USBハブ 回転式 (B0C93PGR84)",
-        "asin": "B0C93PGR84",
-        "priceComparison": "約650円と非常に安価だが、機能面で劣る",
-        "featureComparison": [
-          "USB 3.0 x1 + USB 2.0 x2 (本製品は全ポートUSB 3.0)",
-          "回転機構あり"
-        ],
-        "differentiators": [
-          "価格の安さ",
-          "転送速度の遅さ (USB 2.0混在)"
-        ]
-      },
-      {
-        "name": "サンワサプライ USB-3TCH24SN (B09ZV26GX6)",
-        "asin": "B09ZV26GX6",
-        "priceComparison": "約2,000円とやや高価",
-        "featureComparison": [
-          "USB-A x1 + USB-C x1 (本製品はUSB-A x3)",
-          "スリムな直挿しだが回転機構なし"
-        ],
-        "differentiators": [
-          "Type-Cポート搭載",
-          "アルミボディの質感"
-        ]
-      },
-      {
-        "name": "エレコム U2H-TZ325BGY/EC (B08TH4KFVP)",
+        "name": "エレコム USBハブ U2H-TZ325BGY/EC",
         "asin": "B08TH4KFVP",
-        "priceComparison": "約1,000円と安価",
+        "priceComparison": "対象商品より安価だが、USB2.0かつUSB-A接続の旧モデル。",
         "featureComparison": [
-          "USB 2.0 x3 (本製品はUSB 3.0 x3)",
-          "同じく回転式直挿し"
+          "共通点：ケーブルレスの直挿しタイプで、回転スイングコネクタを採用している点",
+          "相違点：対象商品はUSB-C接続でUSB 5Gbps対応だが、競合はUSB-A接続でUSB2.0対応"
         ],
         "differentiators": [
-          "転送速度 (USB 2.0は遅いためマウス等向き)",
-          "価格"
+          "エレコム U3HC-R030EBKの利点：Type-C接続の最新PCで利用可能で、高速データ転送に対応している",
+          "エレコム U2H-TZ325BGY/ECの利点：USB-Aポートの増設目的で、転送速度を求めない場合に安価に購入できる"
+        ]
+      },
+      {
+        "name": "グリーンハウス GH-HB2A3A-WH",
+        "asin": "B09MCPZRDN",
+        "priceComparison": "対象商品と同等の価格帯だが、仕様が大きく異なる。",
+        "featureComparison": [
+          "共通点：直挿し可能で回転コネクタを搭載している点",
+          "相違点：対象商品はUSB-C接続(5Gbps)だが、競合はUSB-A接続でUSB2.0までの対応"
+        ],
+        "differentiators": [
+          "エレコム U3HC-R030EBKの利点：USB 5Gbpsの高速転送とType-C接続に対応している点",
+          "グリーンハウス GH-HB2A3A-WHの利点：USB-Aポートしかない旧型のPCで利用する場合に適している"
+        ]
+      },
+      {
+        "name": "サンワサプライ USB-3HSC1BK",
+        "asin": "B01AVJBBD4",
+        "priceComparison": "対象商品よりも高価。",
+        "featureComparison": [
+          "共通点：直挿しタイプでコネクタが回転する点",
+          "相違点：対象商品はUSB-C接続で3ポートだが、競合はUSB-A接続で4ポート搭載している"
+        ],
+        "differentiators": [
+          "エレコム U3HC-R030EBKの利点：Type-C接続でよりコンパクトかつ軽量であり、価格も安い",
+          "サンワサプライ USB-3HSC1BKの利点：ポート数が4つあり、USB-A接続のPCで多くの機器を接続できる"
+        ]
+      },
+      {
+        "name": "YFFSFDC USBハブ 3ポート F2",
+        "asin": "B08X2F9G6G",
+        "priceComparison": "対象商品よりも非常に安価。",
+        "featureComparison": [
+          "共通点：ケーブルレスの直挿しタイプで3ポート搭載している点",
+          "相違点：対象商品はコネクタが回転するUSB-C接続だが、競合は回転機構のないUSB-A接続で、USB3.0が1ポートのみ"
+        ],
+        "differentiators": [
+          "エレコム U3HC-R030EBKの利点：回転機構によりポート干渉を回避でき、Type-C接続で全て高速転送可能",
+          "YFFSFDC F2の利点：コストを最小限に抑えたい場合に適している"
+        ]
+      },
+      {
+        "name": "エレコム U3HC-H042BK/E",
+        "asin": "B0DVFVVV5S",
+        "priceComparison": "対象商品よりやや安価。",
+        "featureComparison": [
+          "共通点：USB-C接続でUSB 5Gbpsに対応している点",
+          "相違点：対象商品は直挿しタイプだが、競合は15cmのケーブルタイプで4ポート搭載"
+        ],
+        "differentiators": [
+          "エレコム U3HC-R030EBKの利点：ケーブルがないため収納時に嵩張らず、直挿しでスッキリと使える",
+          "エレコム U3HC-H042BK/Eの利点：ケーブルがあるためPC側のポートの物理的な干渉を気にせず使え、ポート数も多い"
+        ]
+      },
+      {
+        "name": "UGREEN USB-C ハブ 4ポート",
+        "asin": "B0CR6JBJDH",
+        "priceComparison": "対象商品よりもやや高価。",
+        "featureComparison": [
+          "共通点：USB-C接続のハブである点",
+          "相違点：対象商品はUSB-Aポートを増設する直挿しハブだが、競合はUSB-Cポートを4つに増設(10Gbps対応)するケーブルタイプ"
+        ],
+        "differentiators": [
+          "エレコム U3HC-R030EBKの利点：Type-A機器を接続でき、ケーブルレスで取り回しが良い",
+          "UGREEN 4ポートハブの利点：Type-C機器を複数接続したい場合や、より高速な10Gbps転送が必要な場合に適している"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "頻繁にノートPCを持ち歩くビジネスマンや学生",
-        "iPadやMacBookのポートをすっきり拡張したいユーザー",
-        "USBメモリなどでの高速データ転送が必要なユーザー"
+        "Type-Cポートのみ搭載の最新ノートPCで、USB-A機器を使いたいユーザー",
+        "ケーブル付きのハブを煩わしく感じ、スッキリさせたいユーザー",
+        "頻繁にPCを持ち歩くモバイルワーカー"
       ],
       "pros": [
-        "ケーブルレスで携帯性が高い",
-        "180度回転でポート干渉を防げる",
-        "全ポートUSB 5Gbps対応で高速"
+        "スイングコネクタによる優れた取り回しと干渉回避",
+        "ケーブルレスでコンパクト、持ち運びに最適",
+        "全ポートUSB 5Gbpsの高速転送対応"
       ],
       "cons": [
-        "ケース装着時に挿さらない可能性がある",
-        "パススルー充電機能はない"
+        "PCケースや形状によっては直挿しできないリスクがある",
+        "給電(PDパススルー)ポートは非搭載"
       ],
       "score": 85,
-      "scoreRationale": "[基本点: 70]\n[加点: +5] (180度回転スイングコネクタによる高い利便性と設置自由度)\n[加点: +5] (全3ポートがUSB 5Gbps対応で、このサイズとしては高性能)\n[加点: +5] (1500円台という手頃な価格で、安価な中華製より信頼性が高い)\n[合計: 85]"
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (直挿し＆180度スイングコネクタによる高い実用性と携帯性)\n[加点: +5] (全ポートUSB 5Gbps対応の十分な基本性能)\n[加点: +3] (エレコムというブランドの信頼性)\n[加点: +2] (適切な価格設定による良好なコスパ)\n[減点: -3] (PD充電などのパススルー機能非搭載)\n[減点: -2] (PCケースの形状によっては直挿しできないリスク)\n[合計: 85]"
     },
     "technicalSpecs": {
-      "os": null,
-      "cpu": null,
-      "ram": null,
-      "storage": null,
-      "display": null,
-      "battery": null,
-      "camera": null,
       "dimensions": {
         "height": "29mm",
         "width": "65mm",
-        "depth": "21mm",
-        "weight": "21g"
+        "depth": "21mm"
       },
-      "connectivity": [
-        "USB-C (PC側)",
-        "USB-A x3 (USB 5Gbps/USB3.0)"
-      ],
+      "weight": "21g",
+      "capacity": "",
+      "material": "不明",
+      "origin": "不明",
       "other": [
-        "180度スイングコネクタ",
-        "バスパワー専用",
-        "ケーブルレス直挿し"
+        "インターフェース: USB3.2 Gen1 Type-C (パソコン側), USB3.2 Gen1 Type-A×3 (機器側)",
+        "データ転送速度: 最大5Gbps (理論値)",
+        "電源供給: バスパワー",
+        "180度回転スイングコネクタ搭載",
+        "ケーブルレス直挿しタイプ",
+        "カラー: ブラック"
       ]
     }
   }


### PR DESCRIPTION
This PR adds investigation data for the product B0FT2DGWRN (エレコム USBハブ USB-C接続 3ポート).

It covers product specifications, competitive analysis, scoring, and source information, complying with all requested rules. Specs have been converted to the metric system as instructed, and competitive items were collected using Creators API.
All items passed validation smoothly.

---
*PR created automatically by Jules for task [12525338282346914561](https://jules.google.com/task/12525338282346914561) started by @aegisfleet*