### PR TITLE
Update today's recommendations with 10 diverse categories (2026-04-27)

### DIFF
--- a/data/recommendations/today.json
+++ b/data/recommendations/today.json
@@ -1,211 +1,211 @@
 {
-  "date": "2026-04-26",
+  "date": "2026-04-27",
   "headline": "本日の厳選ピックアップ：確かな理由がある注目商品10選",
   "recommendations": [
     {
-      "asin": "B085HLVJYP",
-      "title": "GLEVIO ビジネスリュック 拡張機能付き",
-      "price": "￥6,180",
-      "category": "ファッション・バッグ",
-      "reason": "マチ幅を拡張できるため、普段の通勤から短期出張まで対応可能。PC専用ポケットや充実した小物収納が魅力。",
-      "whyBuyNow": "タイムセール中で参考価格￥9,800から37%OFFとなっており、新生活や出張の多いビジネスマンに今おすすめ。",
+      "asin": "B0812Y64G9",
+      "title": "シリコンパワー 1TB M.2 SSD",
+      "price": "￥22,480",
+      "category": "SSD",
+      "reason": "最新のPCIe Gen3x4インターフェースを採用した高速SSDです。データ保全のために強化されたRAIDエンジンを搭載しており、安定したパフォーマンスを発揮します。安心の5年保証も付いており、長くお使いいただけます。",
+      "whyBuyNow": "現在9%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
+      "source": {
+        "name": "Amazon 9%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B0812Y64G9?tag=aegis-22&linkCode=ogi&th=1&psc=1"
+      },
+      "highlights": [
+        "最大リード3400MB/sの高速転送",
+        "データ保全用のRAIDエンジン搭載",
+        "安心の5年間メーカー保証付き"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B0812Y64G9?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41EF+W6CYWL._SL500_.jpg"
+    },
+    {
+      "asin": "B092D5BYY2",
+      "title": "by Amazon 強炭酸水 ラベルレス 500ml 24本",
+      "price": "￥1,425",
+      "category": "炭酸水",
+      "reason": "大自然で磨かれた天然水に極限まで炭酸をプラスした強炭酸水です。スッキリとした飲みやすい味わいで、そのまま飲むだけでなくお酒の割り材にも適しています。エコで手間のかからないラベルレス仕様も魅力です。",
+      "whyBuyNow": "現在9%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
+      "source": {
+        "name": "Amazon 9%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B092D5BYY2?tag=aegis-22&linkCode=ogi&th=1&psc=1"
+      },
+      "highlights": [
+        "スッキリとした飲みやすい天然水使用",
+        "極限まで炭酸を加えた強炭酸",
+        "分別に便利なラベルレスボトル"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B092D5BYY2?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41iFEMg7HEL._SL500_.jpg"
+    },
+    {
+      "asin": "B0F6C94HJP",
+      "title": "山善 一人暮らし向け マイコン炊飯器 5.5合",
+      "price": "￥5,980",
+      "category": "炊飯器",
+      "reason": "最大5.5合まで炊ける、一人暮らしや家族暮らしに最適な炊飯器です。白米だけでなく、低温調理モードや無洗米モードなど多彩な機能を搭載しています。コンパクトながらも毎日の食卓を美味しくサポートします。",
+      "whyBuyNow": "現在タイムセール対象となっており、大変お買い得なタイミングです。",
       "source": {
         "name": "Amazonタイムセール",
-        "url": "https://www.amazon.co.jp/dp/B085HLVJYP"
+        "url": "https://www.amazon.co.jp/gp/goldbox/"
       },
       "highlights": [
-        "マチ幅最大22.5cmに拡張可能",
-        "15.6インチPC収納対応",
-        "撥水加工で雨の日も安心"
+        "3種類の炊き分け機能搭載",
+        "便利な低温調理・無洗米モード",
+        "1合からおいしく炊けるコンパクト設計"
       ],
-      "url": "https://www.amazon.co.jp/dp/B085HLVJYP",
-      "imageUrl": "https://m.media-amazon.com/images/I/41xZBLIz39L._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B0F6C94HJP?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/31ZWxemPyeL._SL500_.jpg"
     },
     {
-      "asin": "B092ZS3LLB",
-      "title": "Wallfire ノンフライヤー 4.5L",
-      "price": "￥6,950",
-      "category": "キッチン家電",
-      "reason": "4.5Lの大容量で家族の料理にも対応。油を使わずヘルシーに揚げ物を作ることができ、お手入れも簡単。",
-      "whyBuyNow": "タイムセール開催中で45%OFFと大幅割引されており、健康的な食生活を始めたい方に最適なタイミング。",
+      "asin": "B08R1BFJG5",
+      "title": "ニベアUV ディープ プロテクト & ケア ジェル 80g",
+      "price": "￥828",
+      "category": "日焼け止め",
+      "reason": "強力な紫外線から肌を守るSPF50+/PA++++の高機能UVジェルです。日やけによるシミ・そばかすを防ぎながら、美容ケアも同時に行えます。肌にすっとなじみ、べたつかない軽やかな使い心地が特徴です。",
+      "whyBuyNow": "現在16%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
+      "source": {
+        "name": "Amazon 16%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B08R1BFJG5?tag=aegis-22&linkCode=ogi&th=1&psc=1"
+      },
+      "highlights": [
+        "SPF50+/PA++++の高いUVカット力",
+        "日やけによるシミ・そばかすを防ぐ",
+        "ベタつかない軽やかなジェルタイプ"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B08R1BFJG5?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41Ghmy18puL._SL500_.jpg"
+    },
+    {
+      "asin": "B002GGRDSI",
+      "title": "貝印 KAI 軽量 軽いフライパン 26cm",
+      "price": "￥1,309",
+      "category": "フライパン",
+      "reason": "軽くて扱いやすい、本格派のフライパンです。底面を厚く、側面を薄くするスピン製法により、高い熱効率と軽量化を両立しています。ガス火にもIHにも対応しており、毎日の料理が快適になります。",
+      "whyBuyNow": "現在41%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
+      "source": {
+        "name": "Amazon 41%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B002GGRDSI?tag=aegis-22&linkCode=ogi&th=1&psc=1"
+      },
+      "highlights": [
+        "扱いやすい軽量設計",
+        "高熱効率を実現するスピン製法",
+        "IH・ガス火などオール熱源対応"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B002GGRDSI?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41U7atRK9FL._SL500_.jpg"
+    },
+    {
+      "asin": "B09VSXYD6N",
+      "title": "アディダス アドバンコート ベース スニーカー",
+      "price": "￥4,999",
+      "category": "スニーカー",
+      "reason": "シンプルでスタイリッシュなデザインが魅力のアディダススニーカーです。どんなコーディネートにも合わせやすく、デイリーユースにぴったりです。軽量で歩きやすく、長時間の外出でも疲れにくい一足です。",
+      "whyBuyNow": "現在30%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
+      "source": {
+        "name": "Amazon 30%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B09VSXYD6N?tag=aegis-22&linkCode=ogi&th=1&psc=1"
+      },
+      "highlights": [
+        "どんな服にも合うシンプルデザイン",
+        "軽量で歩きやすい快適な履き心地",
+        "日常使いに最適な耐久性"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B09VSXYD6N?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/21wyrJwSa1L._SL500_.jpg"
+    },
+    {
+      "asin": "B0GCB58RFD",
+      "title": "FEEKI Qi2認証 25W マグネット式 ワイヤレス充電器",
+      "price": "￥2,796",
+      "category": "ワイヤレス充電器",
+      "reason": "最新のQi2規格に対応し、最大25Wの急速充電が可能なワイヤレス充電器です。強力なマグネットでピタッと吸着し、充電中のズレを防ぎます。コンパクトで持ち運びやすく、スマートフォンの充電を効率化します。",
+      "whyBuyNow": "現在タイムセール対象となっており、大変お買い得なタイミングです。",
       "source": {
         "name": "Amazonタイムセール",
-        "url": "https://www.amazon.co.jp/dp/B092ZS3LLB"
+        "url": "https://www.amazon.co.jp/gp/goldbox/"
       },
       "highlights": [
-        "4.5Lの大容量で3〜5人分対応",
-        "油なしでヘルシー調理",
-        "8種類のプリセットメニュー搭載"
+        "最新のQi2規格による25W急速充電",
+        "ピタッと吸着する強力マグネット式",
+        "持ち運びに便利な超薄型軽量設計"
       ],
-      "url": "https://www.amazon.co.jp/dp/B092ZS3LLB",
-      "imageUrl": "https://m.media-amazon.com/images/I/41H-2L59m9L._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B0GCB58RFD?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41yQY8f1S6L._SL500_.jpg"
     },
     {
-      "asin": "B0BBM6R6DR",
-      "title": "ティファール 電気圧力鍋 3L",
-      "price": "￥14,200",
-      "category": "調理器具",
-      "reason": "独自の球状煮込み鍋でムラなく熱が伝わり、多彩なモードで本格的な料理が時短で完成する優れた機能性。",
-      "whyBuyNow": "現在タイムセールで過去価格から10%OFFで提供されており、オンライン限定カラーのブラックが手に入るチャンス。",
+      "asin": "B0BJKJMVBG",
+      "title": "Coleman リゾートチェア グレージュ",
+      "price": "￥2,362",
+      "category": "キャンプ チェア",
+      "reason": "キャンプやBBQ、スポーツ観戦など様々なアウトドアシーンで活躍するチェアです。便利なカップホルダーを備え、快適な座り心地を提供します。コンパクトに収納でき、専用ケース付きで持ち運びも簡単です。",
+      "whyBuyNow": "現在21%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
       "source": {
-        "name": "Amazonタイムセール",
-        "url": "https://www.amazon.co.jp/dp/B0BBM6R6DR"
+        "name": "Amazon 21%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B0BJKJMVBG?tag=aegis-22&linkCode=ogi&th=1&psc=1"
       },
       "highlights": [
-        "ムラなく熱が伝わる球状鍋",
-        "調理時間を最大1/3まで短縮",
-        "オンライン限定のブラック色"
+        "便利な両側カップホルダー付き",
+        "コンパクトに折りたためる収納性",
+        "持ち運びに便利な収納ケース付属"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0BBM6R6DR",
-      "imageUrl": "https://m.media-amazon.com/images/I/41O8ZRZfK-L._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B0BJKJMVBG?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41cdAjD2nLL._SL500_.jpg"
     },
     {
-      "asin": "B0CV4329W3",
-      "title": "睡眠グッスリEX GABA100mg",
-      "price": "￥1,630",
-      "category": "サプリメント",
-      "reason": "GABAを100mg配合し、睡眠の質向上と一時的な疲労感の緩和をサポートする機能性表示食品。",
-      "whyBuyNow": "期間限定のセール価格で18%OFFとなっており、睡眠に悩みを持つ方が手軽に試しやすいタイミング。",
+      "asin": "B017SB7QLO",
+      "title": "カタン スタンダード版 ボードゲーム",
+      "price": "￥2,582",
+      "category": "ボードゲーム",
+      "reason": "世界中で3,000万個以上販売されている大人気ボードゲームのスタンダード版です。交渉や戦略が鍵となる奥深いゲーム性で、子供から大人まで夢中になれます。家族や友人とのコミュニケーションツールとして最適です。",
+      "whyBuyNow": "現在44%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
       "source": {
-        "name": "Amazonタイムセール",
-        "url": "https://www.amazon.co.jp/dp/B0CV4329W3"
+        "name": "Amazon 44%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B017SB7QLO?tag=aegis-22&linkCode=ogi&th=1&psc=1"
       },
       "highlights": [
-        "睡眠の質を高めるGABA配合",
-        "11種類のビタミンをプラス",
-        "徹底した国内GMP工場製造"
+        "世界で3,000万個売れた大ヒット作",
+        "交渉と戦略が熱い奥深いゲーム性",
+        "世代を超えて楽しめる定番ボードゲーム"
       ],
-      "url": "https://www.amazon.co.jp/dp/B0CV4329W3",
-      "imageUrl": "https://m.media-amazon.com/images/I/51+gUYTYdsL._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B017SB7QLO?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/51Nwc2zQKRL._SL500_.jpg"
     },
     {
-      "asin": "B073W263CM",
-      "title": "オルナ オーガニック スキンケアセット",
-      "price": "￥5,800",
-      "category": "美容・スキンケア",
-      "reason": "化粧水・美容液・乳液が揃った保湿ケアの基本セット。無添加処方で敏感肌の方にも使いやすい。",
-      "whyBuyNow": "参考価格￥7,180から19%OFFの割引が適用されており、ギフトや自分へのご褒美として最適。",
+      "asin": "B007F45LKS",
+      "title": "ビューティープロ 成猫用 キャットフード 1.5kg",
+      "price": "￥1,237",
+      "category": "キャットフード",
+      "reason": "獣医師監修のもと作られた、成猫用の国産キャットフードです。愛猫の健康を維持し、美しい毛並みをサポートする栄養バランスが特徴です。鮮度を保つ小分け包装で、いつでも風味豊かな食事を提供できます。",
+      "whyBuyNow": "現在43%の割引が適用されており、通常よりもお得に購入できるチャンスです。",
       "source": {
-        "name": "Amazon通常割引",
-        "url": "https://www.amazon.co.jp/dp/B073W263CM"
+        "name": "Amazon 43%OFFセール",
+        "url": "https://www.amazon.co.jp/dp/B007F45LKS?tag=aegis-22&linkCode=ogi&th=1&psc=1"
       },
       "highlights": [
-        "化粧水・乳液・美容液のセット",
-        "肌に優しい無添加処方",
-        "ビタミンC誘導体配合美容液"
+        "獣医師監修の最適な栄養バランス",
+        "安心・安全の国内生産フード",
+        "鮮度を保つ便利な小分け包装"
       ],
-      "url": "https://www.amazon.co.jp/dp/B073W263CM",
-      "imageUrl": "https://m.media-amazon.com/images/I/41Egu5WUSDL._SL500_.jpg"
-    },
-    {
-      "asin": "B0C8HK543G",
-      "title": "アンパンマン はじめてのキッズタブレット",
-      "price": "￥2,955",
-      "category": "知育玩具",
-      "reason": "日本おもちゃ大賞2023の優秀賞を受賞。タッチで遊びながら楽しく言葉や音を学べる安全なタブレット玩具。",
-      "whyBuyNow": "参考価格￥5,280から44%OFFと大幅値引きされており、小さなお子様へのプレゼントにうってつけ。",
-      "source": {
-        "name": "Amazon通常割引",
-        "url": "https://www.amazon.co.jp/dp/B0C8HK543G"
-      },
-      "highlights": [
-        "遊びながらあいうえお学習",
-        "メロディや効果音も充実",
-        "日本おもちゃ大賞2023受賞"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0C8HK543G",
-      "imageUrl": "https://m.media-amazon.com/images/I/51tamHMPgCL._SL500_.jpg"
-    },
-    {
-      "asin": "B0B8Z7GHGK",
-      "title": "ドギーマン 噛みごたえ牛すじのササミ巻き",
-      "price": "￥314",
-      "category": "ペットフード・おやつ",
-      "reason": "牛すじとササミの2つの旨みが楽しめる無添加良品。ハードな噛み応えでストレス発散にもなる。",
-      "whyBuyNow": "参考価格から32%OFFで提供されており、愛犬の健康的なおやつをお手頃価格でまとめ買いする好機。",
-      "source": {
-        "name": "Amazon通常割引",
-        "url": "https://www.amazon.co.jp/dp/B0B8Z7GHGK"
-      },
-      "highlights": [
-        "牛すじとササミの旨み",
-        "噛みごたえで歯を鍛える",
-        "安心の無添加良品シリーズ"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0B8Z7GHGK",
-      "imageUrl": "https://m.media-amazon.com/images/I/41bqmvaKA-L._SL500_.jpg"
-    },
-    {
-      "asin": "B0GS5T1KXC",
-      "title": "Baiinin 多機能フットレスト 足置き",
-      "price": "￥2,999",
-      "category": "オフィス用品",
-      "reason": "整体師監修の設計で、足首や膝の負担を軽減。正しい姿勢をサポートしリモートワークの疲れを和らげる。",
-      "whyBuyNow": "2026年4月29日の発売に向けて予約受付中で、参考価格￥4,780から37%OFFの特別価格で事前注文可能。",
-      "source": {
-        "name": "Amazon新製品予約割引",
-        "url": "https://www.amazon.co.jp/dp/B0GS5T1KXC"
-      },
-      "highlights": [
-        "整体師監修の人間工学設計",
-        "足枕やストレッチにも使える",
-        "高反発スポンジで快適なサポート"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0GS5T1KXC",
-      "imageUrl": "https://m.media-amazon.com/images/I/418VbsB1XcL._SL500_.jpg"
-    },
-    {
-      "asin": "B07PQD5JMP",
-      "title": "苦しかったときの話をしようか (Kindle版)",
-      "price": "￥1,485",
-      "category": "ビジネス・経済書",
-      "reason": "キャリアや人生に悩む多くのビジネスパーソンから支持される、森岡毅氏による大ベストセラー本。",
-      "whyBuyNow": "Kindle版が紙の本の価格から10%OFFで提供されており、ゴールデンウィーク前の読書用にすぐダウンロードして読める。",
-      "source": {
-        "name": "Amazon Kindle割引",
-        "url": "https://www.amazon.co.jp/dp/B07PQD5JMP"
-      },
-      "highlights": [
-        "森岡毅氏の大ヒット作",
-        "キャリアの悩みに応える内容",
-        "Kindle版でいつでも読める"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B07PQD5JMP",
-      "imageUrl": "https://m.media-amazon.com/images/I/51xcKZdqiCL._SL500_.jpg"
-    },
-    {
-      "asin": "B0FPLJG8GX",
-      "title": "Leacco フットケア レッグリラックス",
-      "price": "￥6,314",
-      "category": "健康家電・マッサージ",
-      "reason": "ふくらはぎを360度包み込むエアバッグと温感ヒーターで、脚の疲れをじんわり解きほぐすコードレスケア機器。",
-      "whyBuyNow": "タイムセールにて参考価格から40%OFF。母の日が近づく中、実用的なギフトとして今のうちに準備したい逸品。",
-      "source": {
-        "name": "Amazonタイムセール",
-        "url": "https://www.amazon.co.jp/dp/B0FPLJG8GX"
-      },
-      "highlights": [
-        "360度包むダブルエアバッグ",
-        "3段階の温熱ケア機能",
-        "便利なコードレス設計"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0FPLJG8GX",
-      "imageUrl": "https://m.media-amazon.com/images/I/41NhN93toEL._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B007F45LKS?tag=aegis-22&linkCode=ogi&th=1&psc=1",
+      "imageUrl": "https://m.media-amazon.com/images/I/41W4Spk+OtL._SL500_.jpg"
     }
   ],
   "searchContext": {
-    "todayOverview": "2026年4月26日は、新生活や母の日ギフトに向けた需要が高まる時期です。Amazonではタイムセールが複数開催されており、実用的な家電から日用品、健康グッズまで幅広いカテゴリでお得な商品が見つかります。",
+    "todayOverview": "新生活やこれからのシーズンに向け、実用的な日用品やガジェットを中心に、現在確かな割引・セールが適用されている商品を厳選しました。",
     "searchedCategories": [
-      "ファッション・バッグ",
-      "キッチン家電",
-      "調理器具",
-      "サプリメント",
-      "美容・スキンケア",
-      "知育玩具",
-      "ペットフード・おやつ",
-      "オフィス用品",
-      "ビジネス・経済書",
-      "健康家電・マッサージ"
+      "SSD",
+      "炭酸水",
+      "炊飯器",
+      "日焼け止め",
+      "フライパン",
+      "スニーカー",
+      "ワイヤレス充電器",
+      "キャンプ チェア",
+      "ボードゲーム",
+      "キャットフード"
     ]
   }
 }


### PR DESCRIPTION
This update completely overwrites `data/recommendations/today.json` with 10 fresh, highly-curated product recommendations for the date 2026-04-27. 

Key improvements:
- Scanned across 10 distinct, non-overlapping categories (e.g., SSD, camping chair, board game, etc.).
- Filtered products to ensure there are legitimate deals or time-sales (avoiding fake 70%+ discounts).
- Cleaned and shortened the SEO-stuffed product titles for better readability.
- Hand-crafted concise `reason` and `highlights` based on raw product features, strictly adhering to character limits and instructional formatting.
- Fully validated the JSON schema and URLs via the `validate_artifact.py` script.

---
*PR created automatically by Jules for task [15547418777496588753](https://jules.google.com/task/15547418777496588753) started by @aegisfleet*