### PR TITLE
Add investigation data for B0CQ88BP39

### DIFF
--- a/data/investigations/B0CQ88BP39.json
+++ b/data/investigations/B0CQ88BP39.json
@@ -1,0 +1,182 @@
+{
+  "analysis": {
+    "productName": "comfox ボストンバッグ 5WAY 30L",
+    "parentAsin": "B0CS928PF2",
+    "productDescription": "手持ち、肩掛け、ショルダー、リュック、キャリーオンの5WAY仕様に対応した多機能ボストンバッグ。30Lの大容量ながら約650gと軽量で、防水ポケットやシューズ収納も備えています。",
+    "productUsage": [
+      "旅行（1〜2泊）",
+      "スポーツバッグ（ジム、ゴルフなど）",
+      "修学旅行や防災バッグ",
+      "出張などのビジネス用途"
+    ],
+    "positivePoints": [
+      "約650gと非常に軽量",
+      "リュックやキャリーオンを含む5WAY仕様で持ち運びやすい",
+      "耐荷重34kgの頑丈な設計と防錆金具の採用",
+      "防水ポケットとシューズ専用ポケットを搭載"
+    ],
+    "negativePoints": [
+      "30Lは長期旅行にはやや物足りない可能性がある",
+      "デザインはシンプルでカジュアル寄り"
+    ],
+    "useCases": [
+      "ジムやスポーツクラブへの移動時",
+      "1泊2日の出張や小旅行",
+      "スーツケースと併用した旅行時のサブバッグ"
+    ],
+    "userStories": [],
+    "userImpression": "多機能で軽量なため、荷物が多い日の日常使いから短期旅行まで幅広く活躍する使い勝手の良いバッグ。",
+    "sources": [
+      {
+        "id": "src-amazon-api",
+        "name": "Amazon Product API",
+        "url": "https://www.amazon.co.jp/dp/B0CQ88BP39",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-05-01",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "商品スペック、機能、価格情報を取得"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "重量約650gで超軽量",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon-api"
+        ],
+        "crossChecked": false,
+        "notes": "公式のスペックにて確認"
+      },
+      {
+        "claim": "耐荷重34kgの頑丈設計",
+        "category": "durability",
+        "confidence": "medium",
+        "supportingSourceIds": [
+          "src-amazon-api"
+        ],
+        "crossChecked": false,
+        "notes": "メーカーの主張に基づく"
+      }
+    ],
+    "lastInvestigated": "2026-05-01",
+    "competitiveAnalysis": [
+      {
+        "name": "Inomix ボストンバッグ 5WAY 30L",
+        "asin": "B0GVDBPJ6F",
+        "priceComparison": "対象商品とほぼ同価格帯で、スペックも非常に似ている。",
+        "featureComparison": [
+          "共通点：5WAY仕様、容量30L、重量約650g、防水ポケット・シューズ収納付き。",
+          "相違点：comfoxは耐荷重34kgや防錆金具を明記しているが、Inomixも同様の特徴を記載しており、仕様の差は非常に少ない。"
+        ],
+        "differentiators": [
+          "comfox ボストンバッグ 5WAY 30Lの利点：ブランド（岡山県メーカー企画）としての安心感や、防錆金具などの細部のこだわり。",
+          "Inomix ボストンバッグ 5WAY 30Lの利点：機能やスペック面で大きな違いはないため、デザインや在庫状況で選べる。"
+        ]
+      },
+      {
+        "name": "Ｋａｙｉｙａｓｕ スポーツダッフルバッグ",
+        "asin": "B0GLYNNRWZ",
+        "priceComparison": "対象商品よりも高価。",
+        "featureComparison": [
+          "共通点：シューズ収納と乾湿分離（防水ポケット）を備え、リュック等複数の持ち方に対応。",
+          "相違点：Ｋａｙｉｙａｓｕは高密度ナイロン素材やYKK製ファスナーを採用し、耐久性を強調している。"
+        ],
+        "differentiators": [
+          "comfox ボストンバッグ 5WAY 30Lの利点：より手頃な価格で購入でき、5WAYと持ち方のバリエーションが豊富。",
+          "Ｋａｙｉｙａｓｕ スポーツダッフルバッグの利点：YKKファスナーや高密度ナイロンなど、より高い耐久性を求める場合に適している。"
+        ]
+      },
+      {
+        "name": "Ｋａｙｉｙａｓｕ ボストンバッグ 50L",
+        "asin": "B0GLY2LTV8",
+        "priceComparison": "対象商品よりも高価だが、容量が大きい。",
+        "featureComparison": [
+          "共通点：5WAY仕様、シューズ収納、乾湿分離（防水）、キャリーオン対応。",
+          "相違点：容量が50Lと大きく、重量も約0.98kgと対象商品（650g）より重い。"
+        ],
+        "differentiators": [
+          "comfox ボストンバッグ 5WAY 30Lの利点：30L/650gと軽量・コンパクトで、日常使いや1泊程度の旅行に身軽に使える。",
+          "Ｋａｙｉｙａｓｕ ボストンバッグ 50Lの利点：50Lの大容量で、3泊程度の旅行や荷物が多いスポーツ合宿などに適している。"
+        ]
+      },
+      {
+        "name": "JUNA KOOK ボストンバッグ 40L",
+        "asin": "B0GVJDS6BZ",
+        "priceComparison": "対象商品よりやや高価。",
+        "featureComparison": [
+          "共通点：5WAY仕様、シューズ収納、乾湿分離機能付き。",
+          "相違点：容量が40Lで、ポケットが9つと多機能。素材は高密度ナイロン。"
+        ],
+        "differentiators": [
+          "comfox ボストンバッグ 5WAY 30Lの利点：より安価で軽量（650g）なため、持ち運びの負担が少ない。",
+          "JUNA KOOK ボストンバッグ 40Lの利点：40Lの余裕ある容量と豊富なポケットで整理整頓しやすく、2〜3泊の旅行に最適。"
+        ]
+      },
+      {
+        "name": "Zcoli ボストンバッグ 70L",
+        "asin": "B0GSXZW32G",
+        "priceComparison": "対象商品よりも高価で、サイズも大幅に大きい。",
+        "featureComparison": [
+          "共通点：防水ポケットや乾湿分離、複数の持ち方に対応。",
+          "相違点：容量が70Lと非常に大きく、重量も約880gある。"
+        ],
+        "differentiators": [
+          "comfox ボストンバッグ 5WAY 30Lの利点：普段使いやジム用として扱いやすいサイズと軽さ。",
+          "Zcoli ボストンバッグ 70Lの利点：長期旅行や大量の荷物を運ぶ際に圧倒的な収納力を誇る。"
+        ]
+      },
+      {
+        "name": "Lubardy ボストンバッグ 30L",
+        "asin": "B0FKZ3L85P",
+        "priceComparison": "対象商品より安価。",
+        "featureComparison": [
+          "共通点：容量30L、シューズ収納、乾湿分離機能。",
+          "相違点：Lubardyは3WAY（手持ち、肩掛け、斜め掛け）でリュック機能はなく、ポケットが11個と収納が細かい。"
+        ],
+        "differentiators": [
+          "comfox ボストンバッグ 5WAY 30Lの利点：リュックとしても背負えるため、両手を空けたい場合や長時間の移動で疲れにくい。",
+          "Lubardy ボストンバッグ 30Lの利点：より安価で、小物の整理がしやすい多数のポケットを備えている。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "ジムやスポーツ用に機能的なバッグを探している人",
+        "旅行や出張で状況に合わせて持ち方（リュックやキャリーオンなど）を変えたい人",
+        "1〜2泊程度の荷物を軽量に持ち運びたい人"
+      ],
+      "pros": [
+        "リュックにもなる5WAY仕様で移動が快適",
+        "650gの超軽量かつ耐荷重34kgのタフさ",
+        "シューズや濡れた物を分けられる専用ポケット"
+      ],
+      "cons": [
+        "容量30Lのため、長期旅行や大荷物には不向き"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (5WAY仕様による利便性とキャリーオン対応の汎用性の高さ)\n[加点: +5] (650gの超軽量と防水・シューズポケットを備えた機能性)\n[加点: +5] (2,682円という価格に対する機能性の多さでコスパが良い)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "240mm",
+        "width": "330mm",
+        "depth": "460mm"
+      },
+      "weight": "650g",
+      "capacity": "30L",
+      "material": "オックスフォード生地",
+      "origin": "不明",
+      "other": [
+        "カラー: ブラック",
+        "5WAY仕様（手持ち、肩掛け、ショルダー、リュック、キャリーオン）",
+        "耐荷重: 34kg",
+        "防水ポケット付き",
+        "シューズ専用ポケット付き",
+        "防錆金具・ファスナー採用"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the investigation data for ASIN `B0CQ88BP39` (comfox 5WAY ボストンバッグ). It includes competitive analysis with 6 similar products, metrics conversion (inches/lbs to cm/g), and correct scoring format as per the guidelines.

---
*PR created automatically by Jules for task [14479236884049427163](https://jules.google.com/task/14479236884049427163) started by @aegisfleet*