### PR TITLE
Add investigation data for B0B5ZF9WCT

### DIFF
--- a/data/investigations/B0B5ZF9WCT.json
+++ b/data/investigations/B0B5ZF9WCT.json
@@ -1,0 +1,134 @@
+{
+  "analysis": {
+    "productName": "Yorano 低温調理器 1100Wハイパワー",
+    "parentAsin": "B0GZFCFV5R",
+    "productDescription": "1100Wのハイパワーと360度水循環機能を備え、精確な温度・時間管理が可能なクリップ式低温調理器。IPX7の防水性能と五重の保護機能を搭載し、安全にこだわりの料理を楽しめます。",
+    "productUsage": [
+      "ローストビーフやサラダチキンなどの低温調理",
+      "食材の旨味と栄養を逃さない真空調理",
+      "レストランのような本格的な肉・魚料理の再現"
+    ],
+    "positivePoints": [
+      "1100Wのハイパワーによる高い予熱効率",
+      "0.1℃単位の細かな温度設定が可能",
+      "IPX7の防水性能で水はねにも安心",
+      "高さ調節可能なクリップ式で様々な鍋に対応可能"
+    ],
+    "negativePoints": [
+      "サイズがやや大きめで収納場所を取る可能性がある"
+    ],
+    "useCases": [
+      "毎日の健康的なサラダチキン作り",
+      "ホームパーティーでの本格的な肉料理の準備",
+      "就寝前や出勤前のタイマー予約調理"
+    ],
+    "userStories": [],
+    "userImpression": "1100Wの高出力と細かな温度調節機能により、初心者でも本格的な低温調理が楽しめると評価される製品。価格も手頃でコストパフォーマンスに優れています。",
+    "sources": [
+      {
+        "id": "src-amazon",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0B5ZF9WCT",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-05-09",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "製品の仕様、価格、機能説明を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "1100Wのハイパワーで効率的に加熱",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon"],
+        "crossChecked": false,
+        "notes": "メーカー公式スペックとして記載"
+      },
+      {
+        "claim": "IPX7の防水性能と五重の保護機能を搭載",
+        "category": "safety",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon"],
+        "crossChecked": false,
+        "notes": "メーカー公式スペックとして記載"
+      }
+    ],
+    "lastInvestigated": "2026-05-09",
+    "competitiveAnalysis": [
+      {
+        "name": "アイリスオーヤマ LTC-01",
+        "asin": "B07Z5482Y6",
+        "priceComparison": "対象商品よりもやや安価だが、出力は1000Wと対象商品の方が上回っている。",
+        "featureComparison": [
+          "共通点：クリップ式で鍋に固定するタイプの低温調理器",
+          "相違点：対象商品は1100W出力、本競合製品は1000W出力であり、温度設定単位は対象商品が0.1℃、競合が0.5℃単位"
+        ],
+        "differentiators": [
+          "Yorano 低温調理器 1100Wハイパワーの利点：より高い出力と、0.1℃単位のより精確な温度設定が可能",
+          "アイリスオーヤマ LTC-01の利点：国内有名メーカーの安心感と実績"
+        ]
+      },
+      {
+        "name": "テスコム TLC70A-K",
+        "asin": "B0BYZDZFC6",
+        "priceComparison": "対象商品の2倍以上の価格設定であり、芯温温度計などの高度な機能を搭載している。",
+        "featureComparison": [
+          "共通点：低温調理による肉料理などを得意とする点",
+          "相違点：対象商品が水温を管理するのに対し、本競合製品は独自の芯温温度計で食材の中心温度を直接測定する"
+        ],
+        "differentiators": [
+          "Yorano 低温調理器 1100Wハイパワーの利点：導入しやすい価格と汎用的な鍋で使用できる手軽さ",
+          "テスコム TLC70A-Kの利点：芯温測定による失敗の少ない調理とコンパクトな設置面積"
+        ]
+      },
+      {
+        "name": "ZWILLING Enfinigy 53103-100",
+        "asin": "B0B2ZYZCFW",
+        "priceComparison": "対象商品よりも高価格帯に位置し、高級感とブランド力がある。",
+        "featureComparison": [
+          "共通点：IPX7の防水性能を備えたスティ型（クリップ固定など）の低温調理器",
+          "相違点：対象商品が0.1℃単位の温度設定に対し、本競合製品は0.5℃単位の温度設定"
+        ],
+        "differentiators": [
+          "Yorano 低温調理器 1100Wハイパワーの利点：低価格でありながら0.1℃単位の細やかな温度設定ができるコストパフォーマンスの高さ",
+          "ZWILLING Enfinigy 53103-100の利点：洗練されたデザインと高級キッチンツールブランドとしての信頼性"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めて低温調理器を購入する人",
+        "手頃な価格で高性能な製品を求める人",
+        "細かい温度設定でこだわりの調理をしたい人"
+      ],
+      "pros": [
+        "1100Wの高出力による素早い加熱",
+        "0.1℃単位での精緻な温度コントロール",
+        "IPX7防水で安心してお手入れ可能"
+      ],
+      "cons": [
+        "本体サイズが大きく、使用する鍋の深さが必要"
+      ],
+      "score": 83,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (1100Wのハイパワーと0.1℃単位の温度調節による高い性能)\n[加点: +8] (高性能ながら6000円台という優れたコストパフォーマンス)\n[合計: 83]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "120mm",
+        "width": "150mm",
+        "depth": "420mm"
+      },
+      "power": "1100W",
+      "timer": "1分 - 99時間",
+      "temperatureControl": "25 - 95℃ (0.1℃単位)",
+      "waterResistance": "IPX7",
+      "other": [
+        "360度水循環加熱",
+        "五重安心保護（燃焼防止センサー、温度センサー、水位感知センサー、110℃高温防止センサー等）",
+        "可調整プレスタイプクリップ"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Yorano 1100W 低温調理器 (B0B5ZF9WCT) の調査結果をJSONファイルとして追加しました。
公式情報と競合情報（アイリスオーヤマ、テスコム、ZWILLING）から製品の仕様や価格を比較し、コストパフォーマンスと性能の観点からスコアリングを行いました。
仕様データのインチはミリメートルに換算して記載し、検証スクリプトによるリンク・単位・必須項目チェックを通過しています。

---
*PR created automatically by Jules for task [9366934208154576572](https://jules.google.com/task/9366934208154576572) started by @aegisfleet*