### PR TITLE
Add investigation data for DJI Mic Mini 2 (B0G39G3SZM)

### DIFF
--- a/data/investigations/B0G39G3SZM.json
+++ b/data/investigations/B0G39G3SZM.json
@@ -1,0 +1,164 @@
+{
+  "analysis": {
+    "productName": "DJI Mic Mini 2 ワイヤレスマイク（1 TX + 1 モバイル RX + 充電ケース）",
+    "parentAsin": "B0GYWPN4QJ",
+    "productDescription": "わずか11gの超軽量トランスミッターを採用したワイヤレスラベリアマイク。ノイズキャンセリングや自動リミッティングを搭載し、スマートフォンやPC、さらにDJI製品にも直接接続可能です。",
+    "productUsage": ["Vlog撮影", "ライブ配信", "インタビュー", "ポッドキャスト", "動画制作"],
+    "positivePoints": [
+      "トランスミッターがわずか11gと超軽量で、マグネット式により簡単に装着できる",
+      "DJI Osmoシリーズ製品（Osmo Action 5 ProやPocket 3など）とレシーバー不要で直接接続が可能",
+      "2段階のノイズキャンセリングと自動リミッティング機能で高品質な音声収録ができる",
+      "フル充電で最大24時間の長時間駆動（充電ケース使用時）"
+    ],
+    "negativePoints": [
+      "専用のモバイルRXは特定の端子に依存するため、デバイスによっては変換アダプタが必要になる場合がある"
+    ],
+    "useCases": [
+      "屋外でのVlog撮影やアクティビティ中に、目立たず確実に音声を収録したいシーン",
+      "Osmo Pocket 3やOsmo Action 5 Proを使って映像制作する際の高音質マイクとして",
+      "騒音が気になる環境でのインタビューやポッドキャスト収録"
+    ],
+    "userStories": [],
+    "userImpression": "11gという驚異的な軽さとDJI製品とのシームレスな連携が高く評価されており、Vlogや屋外での撮影において非常に利便性が高いワイヤレスマイクとして注目されています。",
+    "sources": [
+      {
+        "id": "src-amazon-B0G39G3SZM",
+        "name": "Amazon商品ページ B0G39G3SZM",
+        "url": "https://www.amazon.co.jp/dp/B0G39G3SZM",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-04-28",
+        "author": "DJI",
+        "conflictOfInterest": "possible",
+        "notes": "製品仕様、11gの超軽量、2段階ノイズキャンセリング、OsmoAudio直接接続などの特徴を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "トランスミッター重量がわずか11gで超軽量",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon-B0G39G3SZM"],
+        "crossChecked": false,
+        "notes": "商品仕様に記載"
+      },
+      {
+        "claim": "OsmoAudioによるDJIエコシステム製品へのレシーバー不要の直接接続が可能",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon-B0G39G3SZM"],
+        "crossChecked": false,
+        "notes": "商品特徴に明記"
+      }
+    ],
+    "lastInvestigated": "2026-05-16",
+    "competitiveAnalysis": [
+      {
+        "name": "CoolSwan ピンマイク ワイヤレス",
+        "asin": "B0G6ZGSYM1",
+        "priceComparison": "DJI Mic Mini 2よりも低価格。安価に2人同時録音を始めたい初心者向けの構成となっている。",
+        "featureComparison": [
+          "共通点：ノイズキャンセリング機能を搭載し、スマートフォンなどのデバイスと接続できるワイヤレスマイクである点",
+          "相違点：DJI製品は11gと極めて軽くDJIカメラ製品と直接連携できるが、CoolSwanはリバーブ機能などのエフェクト機能を持ち2個セットで安価である点"
+        ],
+        "differentiators": [
+          "DJI Mic Mini 2の利点：11gの圧倒的な軽量さ、DJI製品とのシームレスな連携、自動リミッティングによる音割れ防止など高い信頼性",
+          "CoolSwan ピンマイク ワイヤレスの利点：価格が安く、最初からトランスミッターが2つ付属しているためコスパに優れる"
+        ]
+      },
+      {
+        "name": "Oulou ワイヤレスマイク ダイナミックマイク",
+        "asin": "B0FQ67Z5D6",
+        "priceComparison": "DJI Mic Mini 2よりも低価格。カラオケやスピーチに特化したハンドヘルド型の製品。",
+        "featureComparison": [
+          "共通点：ワイヤレスで音声を伝送できるマイクシステムである点",
+          "相違点：DJIはラベリア（ピンマイク）型で動画撮影向きだが、Oulouはハンドヘルド（手持ち）型でスピーチやカラオケ向けである点"
+        ],
+        "differentiators": [
+          "DJI Mic Mini 2の利点：ハンズフリーで衣服に装着でき、カメラやスマホでの動画撮影に特化している",
+          "Oulou ワイヤレスマイクの利点：会議やスピーチ、イベントでの手持ちマイクとして適している"
+        ]
+      },
+      {
+        "name": "XIAOKOA ワイヤレスマイク ヘッドセット",
+        "asin": "B06Y5CBK6C",
+        "priceComparison": "DJI Mic Mini 2よりも低価格。拡声器やアンプに接続するイベント向けの製品。",
+        "featureComparison": [
+          "共通点：ワイヤレスで音声を伝送する点",
+          "相違点：DJIはスマホ・PC・カメラ向けだが、XIAOKOAは耳掛け型のヘッドセットマイクでPAデバイス（拡声器）専用である点"
+        ],
+        "differentiators": [
+          "DJI Mic Mini 2の利点：高品位な録音用途に適しており、スマホやPCに直接接続して配信やVlogに使える",
+          "XIAOKOA ワイヤレスマイクの利点：ハンズフリーで授業や講演など拡声器を通して喋る用途に特化している"
+        ]
+      },
+      {
+        "name": "TONOR ワイヤレスマイク",
+        "asin": "B0BX9J19MT",
+        "priceComparison": "DJI Mic Mini 2よりも低価格。2本セットのハンドヘルドマイクシステム。",
+        "featureComparison": [
+          "共通点：ワイヤレス通信技術を用いている点",
+          "相違点：DJIは超小型のラベリアマイクだが、TONORはイベントやカラオケ向けの標準的なダイナミックマイク2本セットである点"
+        ],
+        "differentiators": [
+          "DJI Mic Mini 2の利点：映像制作向けに極小サイズで作られ、カメラ等に高音質で記録できる",
+          "TONOR ワイヤレスマイクの利点：パーティーやカラオケなど、複数人でマイクを回す・持つ場面に適している"
+        ]
+      },
+      {
+        "name": "DJI Mic Miniトランスミッター（インフィニティブラック）",
+        "asin": "B0DDLD9X2P",
+        "priceComparison": "DJI Mic Mini 2のセットよりも低価格。こちらはトランスミッター（送信機）単体での販売となっている。",
+        "featureComparison": [
+          "共通点：どちらもDJI Mic Miniのトランスミッターであり、重量やノイズキャンセリングなどの基本性能は同じである点",
+          "相違点：B0G39G3SZMはRX（受信機）と充電ケースが含まれるセットだが、B0DDLD9X2PはTX（送信機）のみの単体製品である点"
+        ],
+        "differentiators": [
+          "DJI Mic Mini 2の利点：スマホやPCに接続するためのレシーバーと充電ケースが付属し、すぐに幅広いデバイスで使える",
+          "DJI Mic Miniトランスミッターの利点：すでにDJI OsmoAudio対応のカメラを持っているユーザーが、マイク単体を追加で安価に購入できる"
+        ]
+      },
+      {
+        "name": "JBL QUANTUM STREAM WIRELESS",
+        "asin": "B0CVX2LW2C",
+        "priceComparison": "DJI Mic Mini 2よりもやや低価格。ゲーミング・ストリーマー向けブランドの製品。",
+        "featureComparison": [
+          "共通点：2.4GHzワイヤレス接続に対応したクリップオンタイプのマイクである点",
+          "相違点：DJIは11gと極小でカメラ連携に強みを持つが、JBLは防水仕様（IPX4）やアプリによる細かなカスタマイズ機能を持つ点"
+        ],
+        "differentiators": [
+          "DJI Mic Mini 2の利点：圧倒的な軽さとDJIカメラとの強力な連携機能",
+          "JBL QUANTUM STREAM WIRELESSの利点：IPX4防水を備え、PCソフトウェア等でのオーディオカスタマイズが充実している"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "Vlogや動画配信で高品質な音声を録音したいクリエイター",
+        "衣服の形状を崩したくない、目立たないマイクを求めているユーザー",
+        "DJI Osmo Pocket 3やOsmo Action 5 ProなどのDJIカメラを使用しているユーザー"
+      ],
+      "pros": [
+        "11gの超軽量設計で装着時の負担がない",
+        "DJI製品と直接接続できシステムが非常にスマート",
+        "ノイズキャンセリングや自動リミッティングなど録音ミスを防ぐ機能が充実"
+      ],
+      "cons": [
+        "無名ブランドの製品と比較すると初期投資コストが高い"
+      ],
+      "score": 93,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] 2段階ノイズキャンセリングや自動リミッティングなど高度な録音支援機能\n[加点: +3] ブランドの信頼性と高性能ながら1万円を切る価格設定によるコスパの良さ\n[加点: +5] 11gという圧倒的な軽さと取り回しのしやすいマグネットデザイン\n[加点: +5] DJIエコシステム（Osmo製品等）へのレシーバー無しでの直接接続という独自の強み\n[合計: 93]"
+    },
+    "technicalSpecs": {
+      "dimensions": { "height": "44.7mm", "width": "33.1mm", "depth": "78.8mm" },
+      "weight": "88.5g",
+      "capacity": "1 TX + 1 モバイル RX + 充電ケース",
+      "material": "不明",
+      "origin": "不明",
+      "other": [
+        "互換性: iPhone 17/16/15, Android, タブレット, PC, DJI Osmo製品群",
+        "機能: 2段階ノイズキャンセリング, 自動リミッティング, 3つの音声トーンプリセット"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added comprehensive investigation data for DJI Mic Mini 2 (B0G39G3SZM). The JSON includes comparative analysis with 6 similar products, metric units conversion, scoring based on performance/cost criteria, and successfully passes the validation script.

---
*PR created automatically by Jules for task [4677165331117636798](https://jules.google.com/task/4677165331117636798) started by @aegisfleet*