### PR TITLE
Add investigation data for JBL QUANTUM STREAM WIRELESS

### DIFF
--- a/data/investigations/B0CVX2LW2C.json
+++ b/data/investigations/B0CVX2LW2C.json
@@ -1,0 +1,182 @@
+{
+  "analysis": {
+    "productName": "JBL QUANTUM STREAM WIRELESS",
+    "parentAsin": "B0CVX2LW2C",
+    "productDescription": "JBLの高品質なクリップオンタイプのワイヤレスコンデンサーマイク。USB Type-Cドングルにより簡単に接続・使用可能。",
+    "productUsage": [
+      "ゲーム実況・動画配信",
+      "テレワーク・Web会議",
+      "Vlog・屋外撮影"
+    ],
+    "positivePoints": [
+      "ノイズキャンセリング機能搭載でクリアな音声録音が可能",
+      "USB Type-Cドングルによる簡単なプラグアンドプレイ接続",
+      "JBLブランドの信頼性の高い音質設計",
+      "専用アプリを用いた詳細な設定やカスタマイズが可能"
+    ],
+    "negativePoints": [
+      "付属のウインドスクリーンが専用ケースに収納できない"
+    ],
+    "useCases": [
+      "自宅でのゲーム配信やオンラインミーティング",
+      "屋外での動画撮影やVlog制作",
+      "複数人でのインタビュー収録"
+    ],
+    "userStories": [
+      {
+        "userType": "コンテンツクリエーター",
+        "scenario": "屋外でのVlog撮影や室内での配信",
+        "experience": "胸元にワンタッチでクリップ装着でき、手軽に高音質な録音環境を構築可能。専用アプリで音質やノイズキャンセリングを細かく調整でき、初心者から中級者まで満足できる使い勝手の良さがある。",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "JBLブランドの信頼性に見合ったクリアな音質と、1万円台の手頃な価格が評価されている。初心者にも扱いやすくコストパフォーマンスに優れる。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "【実機レビュー】ワイヤレスマイク JBL Quantum STREAM WIRELESS / Mac Fan Portal",
+        "url": "https://macfan.book.mynavi.jp/article/m143232/",
+        "tier": "medium",
+        "evidenceType": "secondary",
+        "publishedAt": "2024-04-01",
+        "author": "小寺信良",
+        "conflictOfInterest": "disclosed",
+        "notes": "製品貸与のもと行われた実機レビュー。音質の良さ、伝送距離の実測(約120m)、アプリでのカスタマイズ性などが高評価だが、ウインドスクリーンがケースに入らない点も指摘されている。"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "スペック上の伝送可能距離は100mだが、実測で約120mまで伝送可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "レビュアーによる実測データ"
+      },
+      {
+        "claim": "付属のウインドスクリーンがケースに収納できない",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "レビューで明確に指摘されているデメリット"
+      }
+    ],
+    "lastInvestigated": "2026-05-16",
+    "competitiveAnalysis": [
+      {
+        "name": "Ulanzi WM-10 ワイヤレスクリップオンマイクロホン",
+        "asin": "B0GJ5RJ26C",
+        "priceComparison": "JBLより安価だが、JBLブランドの音質や専用アプリの利便性を考慮すると、価格差に見合う価値がある",
+        "featureComparison": [
+          "共通点：クリップオンタイプのワイヤレスマイクであること",
+          "相違点：JBLは専用アプリによる詳細設定やノイズキャンセリングの調整が可能"
+        ],
+        "differentiators": [
+          "JBL QUANTUM STREAM WIRELESSの利点：ブランドの信頼性と高音質、アプリによるカスタマイズ性",
+          "Ulanzi WM-10の利点：より手頃な価格で導入しやすい"
+        ]
+      },
+      {
+        "name": "Vbestlife ワイヤレスラベリアマイク",
+        "asin": "B0BRCFZ3TS",
+        "priceComparison": "JBLより安価だが、長期的な信頼性や音質を求めるならJBLが有利",
+        "featureComparison": [
+          "共通点：クリップオンタイプのワイヤレスマイク",
+          "相違点：JBLはType-CドングルでPC/Mac等に直接接続しやすく、アプリ対応も充実している"
+        ],
+        "differentiators": [
+          "JBL QUANTUM STREAM WIRELESSの利点：実績ある音響メーカーのノウハウと専用アプリの存在",
+          "Vbestlife ワイヤレスラベリアマイクの利点：初期投資を抑えられる低価格"
+        ]
+      },
+      {
+        "name": "BOYA BY-V4D ワイヤレスラベリアマイクロホン",
+        "asin": "B0DHX2SGHM",
+        "priceComparison": "JBLより高価。BOYAは複数人(4人)での同時収録など特定の用途向けに特化している",
+        "featureComparison": [
+          "共通点：ワイヤレスのラベリアマイクシステム",
+          "相違点：BOYAは多人数での同時使用を想定したパッケージ内容"
+        ],
+        "differentiators": [
+          "JBL QUANTUM STREAM WIRELESSの利点：単体でのコスパが良く、個人での配信や録音に最適",
+          "BOYA BY-V4Dの利点：多人数での同時収録が必要なケースに適している"
+        ]
+      },
+      {
+        "name": "Sennheiser XS LAV USB-C クリップオンマイク",
+        "asin": "B08YS2G4FB",
+        "priceComparison": "同価格帯の競合製品。どちらも老舗オーディオブランドであり比較検討の対象となる",
+        "featureComparison": [
+          "共通点：USB-C接続の高品質マイク、オーディオメーカー製",
+          "相違点：JBLはワイヤレスシステムであり、ゼンハイザーは有線接続の安定性を重視している"
+        ],
+        "differentiators": [
+          "JBL QUANTUM STREAM WIRELESSの利点：ワイヤレスによる取り回しの良さと自由な設置",
+          "Sennheiser XS LAV USB-Cの利点：有線接続による遅延のなさと安定性"
+        ]
+      },
+      {
+        "name": "QEEKADA ラベリアマイク付きワイヤレスボイスアンプ",
+        "asin": "B0FGD6NGQJ",
+        "priceComparison": "JBLより安価だが、用途がメガホン・拡声器向きであり配信向けマイクとしてはJBLが優れる",
+        "featureComparison": [
+          "共通点：ワイヤレスマイクを使用",
+          "相違点：QEEKADAはスピーカ(アンプ)が付属し拡声用途向け、JBLはPC等への録音・配信向け"
+        ],
+        "differentiators": [
+          "JBL QUANTUM STREAM WIRELESSの利点：PC・スマホでの録音や配信に特化した高音質設計",
+          "QEEKADAの利点：教室やツアーガイドなど、その場で声を大きく拡声する用途に適している"
+        ]
+      },
+      {
+        "name": "Denash ワイヤレスクリップオン楽器マイク",
+        "asin": "B0GVPNH5Z3",
+        "priceComparison": "ほぼ同価格帯だが、用途が異なる",
+        "featureComparison": [
+          "共通点：クリップオン式のワイヤレスマイク",
+          "相違点：Denashは楽器（バイオリン、チェロ、ギターなど）の集音に特化している"
+        ],
+        "differentiators": [
+          "JBL QUANTUM STREAM WIRELESSの利点：人間の声（ボーカル、スピーチ）の集音に最適化されている",
+          "Denashの利点：特定の弦楽器などの集音に適した設計"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めてワイヤレスマイクを導入する配信者",
+        "テレワークで音質を向上させたいビジネスパーソン",
+        "Vlog撮影でクリアな音声を録音したいクリエイター"
+      ],
+      "pros": [
+        "JBLブランドの安心感と高音質",
+        "専用アプリによるカスタマイズ性の高さ",
+        "接続が簡単で取り回しが良い"
+      ],
+      "cons": [
+        "ウインドスクリーンの収納に難がある"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] JBLブランドの高い音質と信頼性(品質・デザイン)\n[加点: +5] USB-Cドングルによる簡単な接続(性能・機能)\n[加点: +5] 専用アプリによるカスタマイズ性(性能・機能)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "weight": "約6g",
+      "frequencyResponse": "20Hz ～ 20kHz",
+      "bitDepth": "16ビット",
+      "sampleRate": "48kHz（ENCオフ）、16kHz（ENCオン）",
+      "batteryLife": "最大24時間（マイク本体約6時間＋充電ケース約18時間）",
+      "chargingTime": "約2時間",
+      "connection": "USB Type-C 2.4GHzドングルワイヤレス",
+      "waterResistance": "IPX4",
+      "range": "約100m"
+    }
+  }
+}


### PR DESCRIPTION
Completed fully autonomous investigation of ASIN B0CVX2LW2C (JBL QUANTUM STREAM WIRELESS) per guidelines. Fixed minor unit conversion (pound to g) and addressed rationale formatting in code review. JSON successfully validated via scripts.

---
*PR created automatically by Jules for task [11602999211923460646](https://jules.google.com/task/11602999211923460646) started by @aegisfleet*