### PR TITLE
Fix Hugo build errors

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 # Canonical production URL (www)
 baseURL = "https://www.amazon-hikaku.com/"
 relativeURLs = false
-languageCode = "ja"
+locale = "ja"
 title = "ポちのAmazon商品徹底比較.com"
 
 defaultContentLanguage = "ja"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -154,4 +154,3 @@
 "itemListElement" $breadcrumbItems -}}
 <script type="application/ld+json">{{- $breadcrumbSchema | jsonify | safeJS -}}</script>
 
-{{- end -}}

--- a/src/article/__tests__/StructuredDataTemplate.test.ts
+++ b/src/article/__tests__/StructuredDataTemplate.test.ts
@@ -15,7 +15,9 @@ describe('head.html simplified SEO template', () => {
   it('contains simple meta description fallback', () => {
     const template = fs.readFileSync(headTemplatePath, 'utf8');
 
-    expect(template).toContain('{{- $metaDescription := .Description | default .Summary | default .Site.Params.description -}}');
+    expect(template).toContain(
+      '{{- $metaDescription := .Description | default .Summary | default .Site.Params.description -}}',
+    );
   });
 
   it('retains WebSite and BreadcrumbList schemas but no Product schema', () => {


### PR DESCRIPTION
This PR fixes the Hugo build errors encountered:
1. Replaced the deprecated `languageCode` setting with `locale` in `config.toml` to address the deprecation warning.
2. Removed the extra `{{- end -}}` on line 157 in `layouts/partials/head.html` to resolve the template parsing failure.

---
*PR created automatically by Jules for task [16640486203676385680](https://jules.google.com/task/16640486203676385680) started by @aegisfleet*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 言語設定を更新しました。

* **Tests**
  * 構造化データテンプレートのテストケースを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegisfleet/amazon-product-article/pull/6159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->