### PR TITLE
Add investigation result for Anker Soundcore 3 (B08CXJ3HMF)

### DIFF
--- a/data/investigations/B08CXJ3HMF.json
+++ b/data/investigations/B08CXJ3HMF.json
@@ -1,0 +1,229 @@
+{
+  "analysis": {
+    "productName": "Anker Soundcore 3",
+    "parentAsin": "B08CXJ3HMF",
+    "productDescription": "チタニウムドライバー搭載で高音質を実現した、防水対応(IPX7)のポータブルBluetoothスピーカー。最大24時間の連続再生とアプリによるイコライザー設定に対応。",
+    "productUsage": [
+      "お風呂や水回りでの音楽鑑賞",
+      "屋外・アウトドアでの使用",
+      "室内でのBGM再生やスマートフォンからの音楽再生"
+    ],
+    "positivePoints": [
+      "最大24時間のロングバッテリー搭載で充電の手間が少ない",
+      "IPX7防水仕様でお風呂など水濡れの心配がある場所でも安心して使える",
+      "チタニウムドライバーと16W(8W×2)の出力によるクリアな高音質",
+      "専用アプリでイコライザーを調整でき、好みの音質にカスタマイズ可能"
+    ],
+    "negativePoints": [
+      "完全ワイヤレスステレオペアリングには非対応",
+      "AUXポートがなく、接続はBluetoothのみ"
+    ],
+    "useCases": [
+      "お風呂に持ち込んでリラックスタイムに音楽を楽しむ",
+      "キャンプなどのアウトドアレジャーでBGMを流す",
+      "スマートフォンの内蔵スピーカーの音質をアップグレードする"
+    ],
+    "userStories": [
+      {
+        "userType": "一般ユーザー",
+        "scenario": "入浴時の使用",
+        "experience": "IPX7の防水性能があるので、お風呂に持ち込んで音楽を楽しんでいます。水しぶきを気にせず使えて、入浴時間が快適になりました。バッテリー持ちも良く、頻繁に充電しなくて済むのが便利です。",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "一般ユーザー",
+        "scenario": "音楽鑑賞",
+        "experience": "コンパクトなサイズながら、BassUpテクノロジーとデュアルパッシブラジエーターのおかげで、低音がしっかり響きます。専用アプリでイコライザーをカスタマイズできるので、曲に合わせて好みの音質に調整できるのが魅力的です。",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "多くのユーザーが、コンパクトなボディでありながら迫力のある低音とクリアな音質に満足しています。特に、お風呂などの水回りで安心して使えるIPX7の防水性能と、最大24時間という長時間のバッテリー駆動が高く評価されています。また、専用アプリによるイコライザー調整機能も、音質にこだわるユーザーから支持を集めています。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Anker (アンカー) 公式オンラインストア - Soundcore 3",
+        "url": "https://www.ankerjapan.com/products/a3117",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2021-12-01",
+        "author": "Anker Japan",
+        "conflictOfInterest": "possible",
+        "notes": "製品仕様、機能説明、発売月などを確認"
+      },
+      {
+        "id": "src-2",
+        "name": "Amazon製品ページ",
+        "url": "https://www.amazon.co.jp/dp/B08CXJ3HMF",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-05-21",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "価格、製品特徴、基本スペックを確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "最大24時間の連続再生が可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "crossChecked": true,
+        "notes": "公式サイトおよびAmazonの製品ページで確認"
+      },
+      {
+        "claim": "IPX7の防水規格に対応",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "crossChecked": true,
+        "notes": "公式サイトおよびAmazonの製品ページで確認"
+      },
+      {
+        "claim": "専用アプリでイコライザーの調整が可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "crossChecked": true,
+        "notes": "公式サイトおよびAmazonの製品ページで確認"
+      }
+    ],
+    "lastInvestigated": "2026-05-21",
+    "competitiveAnalysis": [
+      {
+        "name": "JBL GO4",
+        "asin": "B0CZDSX163",
+        "priceComparison": "Soundcore 3よりも若干安価。価格差なりの出力差があるが、JBLならではのサウンドとよりコンパクトなサイズ感が特徴。",
+        "featureComparison": [
+          "共通点：Bluetooth接続対応、アプリによるイコライザー設定対応、ポータブルサイズ、USB-C充電",
+          "相違点：Soundcore 3は16W出力で最大24時間再生・IPX7防水。JBL GO4はIP67防塵防水対応だが、サイズがより小さく出力と再生時間が短い傾向。"
+        ],
+        "differentiators": [
+          "Anker Soundcore 3の利点：より大きな16W出力と最大24時間の長時間再生が可能。自宅内での据え置きや長時間の使用に向いている。",
+          "JBL GO4の利点：より軽量コンパクトで持ち運びに特化。防塵性能も備えており、砂浜などの過酷な環境での使用に適している。"
+        ]
+      },
+      {
+        "name": "Xiaomi サウンドポケット",
+        "asin": "B0CZRLRGM5",
+        "priceComparison": "Soundcore 3の半額程度と非常に安価。コストを重視するユーザー向けの選択肢。",
+        "featureComparison": [
+          "共通点：ポータブルサイズ、Bluetooth接続、防水対応",
+          "相違点：Soundcore 3は16W出力・最大24時間再生・アプリ対応。Xiaomiは5W出力・最大10時間再生で、IP67防塵防水対応。"
+        ],
+        "differentiators": [
+          "Anker Soundcore 3の利点：出力の大きさによる迫力あるサウンドと、アプリによる音質のカスタマイズ性。バッテリー持ちの長さ。",
+          "Xiaomi サウンドポケットの利点：約200gと非常に軽量で、価格が安く手軽に購入できる点。"
+        ]
+      },
+      {
+        "name": "Anker Soundcore 2",
+        "asin": "B01NAVANRX",
+        "priceComparison": "Soundcore 3より少し安い旧モデル。価格差を考慮するとSoundcore 3の機能向上が魅力的。",
+        "featureComparison": [
+          "共通点：IPX7防水、最大24時間再生、ポータブルサイズ",
+          "相違点：Soundcore 3は16W出力・チタニウムドライバー採用・アプリ対応。Soundcore 2は12W出力でアプリ非対応だがステレオペアリングに対応。"
+        ],
+        "differentiators": [
+          "Anker Soundcore 3の利点：チタニウムドライバーによる高音質化、16Wへの出力向上、専用アプリによるイコライザー調整が可能。",
+          "Anker Soundcore 2の利点：2台をペアリングして完全ワイヤレスステレオ再生ができる点。"
+        ]
+      },
+      {
+        "name": "Anker Soundcore Select 4 Go",
+        "asin": "B0D9YMNXZL",
+        "priceComparison": "Soundcore 3よりも安価なエントリー向けポータブルスピーカー。",
+        "featureComparison": [
+          "共通点：Bluetooth対応、ポータブルサイズ",
+          "相違点：Soundcore 3は16W出力・IPX7・最大24時間再生。Select 4 Goは5W出力・IP67・最大20時間再生でワイヤレスステレオ対応。"
+        ],
+        "differentiators": [
+          "Anker Soundcore 3の利点：出力が大きく、アプリでのカスタマイズが可能。低音から高音まで高音質を楽しめる。",
+          "Anker Soundcore Select 4 Goの利点：IP67防塵防水でアウトドアでの使用に強く、ステレオペアリングが可能。"
+        ]
+      },
+      {
+        "name": "STSEETOP Bluetooth スピーカー",
+        "asin": "B0BHT4S8DM",
+        "priceComparison": "Soundcore 3の半額程度で安価な無名ブランドの製品。",
+        "featureComparison": [
+          "共通点：IPX7防水、Bluetooth接続",
+          "相違点：Soundcore 3は有名ブランドでアプリ対応・24時間再生。STSEETOPは360度サウンド・12時間再生で軽量。"
+        ],
+        "differentiators": [
+          "Anker Soundcore 3の利点：Ankerというブランドの信頼性、アプリによる細かい音質調整、2倍の連続再生時間。",
+          "STSEETOP Bluetooth スピーカーの利点：360度全方位に音を拡散できる構造と、約163gという圧倒的な軽さ。"
+        ]
+      },
+      {
+        "name": "JBL GO4 (ブルー)",
+        "asin": "B0CZDCWM48",
+        "priceComparison": "Soundcore 3よりも若干安価。JBL GO4の色違い。",
+        "featureComparison": [
+          "共通点：Bluetooth接続対応、アプリによるイコライザー設定対応",
+          "相違点：Soundcore 3は16W出力で最大24時間再生。JBL GO4はIP67防塵防水対応だが、サイズがより小さく出力と再生時間が短い傾向。"
+        ],
+        "differentiators": [
+          "Anker Soundcore 3の利点：より大きな16W出力と最大24時間の長時間再生が可能。",
+          "JBL GO4 (ブルー)の利点：より軽量コンパクトで持ち運びに特化。防塵性能も備えている。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "お風呂やアウトドアで音楽を楽しみたい人",
+        "長時間のバッテリー駆動を求める人",
+        "コンパクトながら高音質なスピーカーを探している人",
+        "アプリで自分好みの音質に調整したい人"
+      ],
+      "pros": [
+        "最大24時間のロングバッテリー搭載",
+        "水回りでも安心なIPX7防水規格",
+        "アプリ連携によるイコライザーカスタマイズ機能",
+        "チタニウムドライバー採用によるクリアな音質"
+      ],
+      "cons": [
+        "ステレオペアリング機能には非対応",
+        "AUX有線接続ができない"
+      ],
+      "score": 88,
+      "scoreRationale": "[基本点: 70]\n[加点: +8] (最大24時間の長寿命バッテリーによる高い利便性)\n[加点: +5] (IPX7の防水性能による使用シーンの広さ)\n[加点: +5] (専用アプリによるイコライザー調整機能の使い勝手)\n[加点: +3] (チタニウムドライバーと16W出力による音質の向上)\n[減点: -3] (完全ワイヤレスステレオペアリングやAUX接続に非対応)\n[合計: 88]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "57mm",
+        "width": "60mm",
+        "depth": "174mm"
+      },
+      "weight": "500g",
+      "capacity": "なし",
+      "material": "不明",
+      "origin": "不明",
+      "other": [
+        "オーディオ出力: 16W (8W × 2)",
+        "防塵・防水規格: IPX7",
+        "通信規格: Bluetooth 5",
+        "連続再生可能時間: 最大24時間",
+        "機能: BassUpテクノロジー、デュアルパッシブラジエーター搭載、アプリ対応、イコライザー設定可能、PartyCast機能",
+        "接続: USB-C"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added the JSON file `data/investigations/B08CXJ3HMF.json` containing the investigation results and competitive analysis for the Anker Soundcore 3 portable Bluetooth speaker.

---
*PR created automatically by Jules for task [15880465223552445613](https://jules.google.com/task/15880465223552445613) started by @aegisfleet*