### PR TITLE
Potential fix for code scanning alert no. 37: DOM text reinterpreted as HTML

### DIFF
--- a/src/schemas/InvestigationSchema.ts
+++ b/src/schemas/InvestigationSchema.ts
@@ -47,6 +47,11 @@ export const InvestigationFileSchema = z.looseObject({
       score: z.number(),
     }),
     lastInvestigated: z.string().trim().optional(),
+    productName: z.string().trim().optional(),
+    parentAsin: z.string().trim().optional(),
+    productDescription: z.string().trim().optional(),
+    productUsage: z.array(z.string().trim()).optional(),
+    technicalSpecs: z.record(z.string(), z.unknown()).optional(),
   }),
 });
 

--- a/src/scripts/article-generation-cli.ts
+++ b/src/scripts/article-generation-cli.ts
@@ -21,7 +21,7 @@ import { ArticleGenerator } from '../article/ArticleGenerator';
 import { GitHubPublisher } from '../github/GitHubPublisher';
 import { InvestigationFileSchema } from '../schemas/InvestigationSchema';
 import type { GeneratedArticle } from '../types/ArticleTypes';
-import type { InvestigationResult } from '../types/JulesTypes';
+import type { CompetitiveProduct, InvestigationResult, SourceReference } from '../types/JulesTypes';
 import type { Product, ProductDetail } from '../types/Product';
 import { setGitHubOutput } from '../utils/github-actions';
 import { Logger } from '../utils/Logger';
@@ -150,11 +150,64 @@ export async function loadInvestigationResults(targetFiles?: string[]): Promise<
             generatedAt = stats.mtime;
           }
 
+          // exactOptionalPropertyTypes に適合するようにマッピング
+          const rawAnalysis = parsed.analysis as any;
+          const analysis: InvestigationResult['analysis'] = {
+            positivePoints: parsed.analysis.positivePoints,
+            negativePoints: parsed.analysis.negativePoints,
+            useCases: parsed.analysis.useCases,
+            userImpression: parsed.analysis.userImpression,
+            recommendation: {
+              ...parsed.analysis.recommendation,
+              targetUsers: parsed.analysis.recommendation.targetUsers,
+              pros: parsed.analysis.recommendation.pros,
+              cons: parsed.analysis.recommendation.cons,
+              score: parsed.analysis.recommendation.score,
+            },
+            competitiveAnalysis: parsed.analysis.competitiveAnalysis.map((c) => {
+              const comp: CompetitiveProduct = {
+                name: c.name,
+                priceComparison: c.priceComparison,
+                featureComparison: c.featureComparison,
+                differentiators: c.differentiators,
+              };
+              if (c.asin) comp.asin = c.asin;
+              return comp;
+            }),
+            sources: parsed.analysis.sources.map((s) => {
+              const ref: SourceReference = {
+                name: s.name,
+              };
+              if (s.url) ref.url = s.url;
+              if (s.tier && s.tier !== 'primary') ref.tier = s.tier;
+              if (s.evidenceType) ref.evidenceType = s.evidenceType;
+              if (s.publishedAt) ref.publishedAt = s.publishedAt;
+              if (s.author) ref.author = s.author;
+              if (s.conflictOfInterest) ref.conflictOfInterest = s.conflictOfInterest;
+              if (s.notes) ref.notes = s.notes;
+              return ref;
+            }),
+            userStories: (parsed.analysis.userStories || []).map((s) => ({
+              userType: s.userType,
+              scenario: s.scenario,
+              experience: s.experience,
+              sentiment: s.sentiment,
+            })),
+          };
+
+          // その他の optional フィールドを安全に設定（exactOptionalPropertyTypes対策）
+          if (rawAnalysis.productName) analysis.productName = rawAnalysis.productName;
+          if (rawAnalysis.parentAsin) analysis.parentAsin = rawAnalysis.parentAsin;
+          if (rawAnalysis.lastInvestigated) analysis.lastInvestigated = rawAnalysis.lastInvestigated;
+          if (rawAnalysis.productDescription) analysis.productDescription = rawAnalysis.productDescription;
+          if (rawAnalysis.productUsage) analysis.productUsage = rawAnalysis.productUsage;
+          if (rawAnalysis.technicalSpecs) analysis.technicalSpecs = rawAnalysis.technicalSpecs;
+
           // InvestigationResultを構築
           const investigation: InvestigationResult = {
             sessionId: `file-${asin}`,
             product,
-            analysis: parsed.analysis as unknown as InvestigationResult['analysis'],
+            analysis,
             generatedAt: generatedAt,
           };
 

--- a/src/scripts/article-generation-cli.ts
+++ b/src/scripts/article-generation-cli.ts
@@ -77,6 +77,148 @@ function getOptions(): CLIOptions {
 /**
  * ファイル名からASINを抽出し、JSON構造を変換してInvestigationDataを構築
  */
+/**
+ * 単一の調査結果ファイルをロードし、検証および変換を実行する
+ */
+async function loadAndValidateInvestigation(filePath: string): Promise<InvestigationData | null> {
+  try {
+    const rawData = await fs.readFile(filePath, 'utf-8');
+    const jsonParsed: unknown = JSON.parse(rawData);
+    const validation = InvestigationFileSchema.safeParse(jsonParsed);
+
+    if (!validation.success) {
+      logger.warn(`Invalid investigation file format ${filePath}:`, validation.error);
+      return null;
+    }
+
+    const parsed = validation.data;
+
+    const fileName = path.basename(filePath);
+    // Skip if not a JSON file or is summary
+    if (!fileName.endsWith('.json') || fileName === 'latest-summary.json') {
+      return null;
+    }
+
+    // ファイル名からASINを抽出 (e.g., "B07DZZJ2B9.json" -> "B07DZZJ2B9")
+    const asin = path.basename(fileName, '.json');
+
+    // 最小限のProduct情報を構築（ASINのみ必須、他はプレースホルダー）
+    const product: Product = {
+      asin,
+      title: `Product ${asin}`, // タイトルは後で記事生成時に更新可能
+      category: '',
+      price: { amount: 0, currency: 'JPY', formatted: '' },
+      images: { primary: '', thumbnails: [] },
+      specifications: {},
+      rating: { average: 0, count: 0 },
+    };
+
+    // lastInvestigatedがあればそれを優先、なければファイルの更新日時（fs.stat）を取得
+    let generatedAt: Date | null = null;
+    if (parsed.analysis.lastInvestigated) {
+      const parsedDate = new Date(parsed.analysis.lastInvestigated);
+      // Check if the date is valid
+      if (!Number.isNaN(parsedDate.getTime())) {
+        generatedAt = parsedDate;
+      }
+    }
+
+    if (!generatedAt) {
+      // ファイルの更新日時を取得（作成日時の代用）
+      const stats = await fs.stat(filePath);
+      generatedAt = stats.mtime;
+    }
+
+    // exactOptionalPropertyTypes に適合するようにマッピング
+    const analysis: InvestigationResult['analysis'] = {
+      positivePoints: parsed.analysis.positivePoints,
+      negativePoints: parsed.analysis.negativePoints,
+      useCases: parsed.analysis.useCases,
+      userImpression: parsed.analysis.userImpression,
+      recommendation: {
+        ...parsed.analysis.recommendation,
+        targetUsers: parsed.analysis.recommendation.targetUsers,
+        pros: parsed.analysis.recommendation.pros,
+        cons: parsed.analysis.recommendation.cons,
+        score: parsed.analysis.recommendation.score,
+      },
+      competitiveAnalysis: parsed.analysis.competitiveAnalysis.map((c) => {
+        const comp: CompetitiveProduct = {
+          name: c.name,
+          priceComparison: c.priceComparison,
+          featureComparison: c.featureComparison,
+          differentiators: c.differentiators,
+        };
+        if (c.asin) comp.asin = c.asin;
+        return comp;
+      }),
+      sources: parsed.analysis.sources.map((s) => {
+        const ref: SourceReference = {
+          name: s.name,
+        };
+        if (s.url) ref.url = s.url;
+        if (s.tier && s.tier !== 'primary') ref.tier = s.tier;
+        if (s.evidenceType) ref.evidenceType = s.evidenceType;
+        if (s.publishedAt) ref.publishedAt = s.publishedAt;
+        if (s.author) ref.author = s.author;
+        if (s.conflictOfInterest) ref.conflictOfInterest = s.conflictOfInterest;
+        if (s.notes) ref.notes = s.notes;
+        return ref;
+      }),
+      userStories: (parsed.analysis.userStories || []).map((s) => ({
+        userType: s.userType,
+        scenario: s.scenario,
+        experience: s.experience,
+        sentiment: s.sentiment,
+      })),
+    };
+
+    // その他の optional フィールドを安全に設定（exactOptionalPropertyTypes対策）
+    if (parsed.analysis.productName) {
+      analysis.productName = parsed.analysis.productName;
+    }
+    if (parsed.analysis.parentAsin) {
+      analysis.parentAsin = parsed.analysis.parentAsin;
+    }
+    if (parsed.analysis.lastInvestigated) {
+      analysis.lastInvestigated = parsed.analysis.lastInvestigated;
+    }
+    if (parsed.analysis.productDescription) {
+      analysis.productDescription = parsed.analysis.productDescription;
+    }
+    if (parsed.analysis.productUsage) {
+      analysis.productUsage = parsed.analysis.productUsage;
+    }
+    if (parsed.analysis.technicalSpecs) {
+      analysis.technicalSpecs = parsed.analysis.technicalSpecs;
+    }
+
+    // InvestigationResultを構築
+    const investigation: InvestigationResult = {
+      sessionId: `file-${asin}`,
+      product,
+      analysis,
+      generatedAt: generatedAt,
+    };
+
+    return {
+      product,
+      investigation,
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ENOENT') {
+      logger.warn(`File not found: ${filePath}, skipping`);
+      return null;
+    }
+    logger.warn(`Failed to load investigation file ${filePath}:`, error);
+    return null;
+  }
+}
+
+/**
+ * ファイル名からASINを抽出し、JSON構造を変換してInvestigationDataを構築
+ */
 export async function loadInvestigationResults(targetFiles?: string[]): Promise<InvestigationData[]> {
   const investigationsDir = path.join(process.cwd(), 'data', 'investigations');
   let filesToProcess: string[];
@@ -100,132 +242,7 @@ export async function loadInvestigationResults(targetFiles?: string[]): Promise<
 
   for (let i = 0; i < filesToProcess.length; i += chunkSize) {
     const chunk = filesToProcess.slice(i, i + chunkSize);
-    const chunkResults = await Promise.all(
-      chunk.map(async (filePath) => {
-        try {
-          const rawData = await fs.readFile(filePath, 'utf-8');
-          const jsonParsed: unknown = JSON.parse(rawData);
-          const validation = InvestigationFileSchema.safeParse(jsonParsed);
-
-          if (!validation.success) {
-            logger.warn(`Invalid investigation file format ${filePath}:`, validation.error);
-            return null;
-          }
-
-          const parsed = validation.data;
-
-          const fileName = path.basename(filePath);
-          // Skip if not a JSON file or is summary
-          if (!fileName.endsWith('.json') || fileName === 'latest-summary.json') {
-            return null;
-          }
-
-          // ファイル名からASINを抽出 (e.g., "B07DZZJ2B9.json" -> "B07DZZJ2B9")
-          const asin = path.basename(fileName, '.json');
-
-          // 最小限のProduct情報を構築（ASINのみ必須、他はプレースホルダー）
-          const product: Product = {
-            asin,
-            title: `Product ${asin}`, // タイトルは後で記事生成時に更新可能
-            category: '',
-            price: { amount: 0, currency: 'JPY', formatted: '' },
-            images: { primary: '', thumbnails: [] },
-            specifications: {},
-            rating: { average: 0, count: 0 },
-          };
-
-          // lastInvestigatedがあればそれを優先、なければファイルの更新日時（fs.stat）を取得
-          let generatedAt: Date | null = null;
-          if (parsed.analysis.lastInvestigated) {
-            const parsedDate = new Date(parsed.analysis.lastInvestigated);
-            // Check if the date is valid
-            if (!Number.isNaN(parsedDate.getTime())) {
-              generatedAt = parsedDate;
-            }
-          }
-
-          if (!generatedAt) {
-            // ファイルの更新日時を取得（作成日時の代用）
-            const stats = await fs.stat(filePath);
-            generatedAt = stats.mtime;
-          }
-
-          // exactOptionalPropertyTypes に適合するようにマッピング
-          const rawAnalysis = parsed.analysis as any;
-          const analysis: InvestigationResult['analysis'] = {
-            positivePoints: parsed.analysis.positivePoints,
-            negativePoints: parsed.analysis.negativePoints,
-            useCases: parsed.analysis.useCases,
-            userImpression: parsed.analysis.userImpression,
-            recommendation: {
-              ...parsed.analysis.recommendation,
-              targetUsers: parsed.analysis.recommendation.targetUsers,
-              pros: parsed.analysis.recommendation.pros,
-              cons: parsed.analysis.recommendation.cons,
-              score: parsed.analysis.recommendation.score,
-            },
-            competitiveAnalysis: parsed.analysis.competitiveAnalysis.map((c) => {
-              const comp: CompetitiveProduct = {
-                name: c.name,
-                priceComparison: c.priceComparison,
-                featureComparison: c.featureComparison,
-                differentiators: c.differentiators,
-              };
-              if (c.asin) comp.asin = c.asin;
-              return comp;
-            }),
-            sources: parsed.analysis.sources.map((s) => {
-              const ref: SourceReference = {
-                name: s.name,
-              };
-              if (s.url) ref.url = s.url;
-              if (s.tier && s.tier !== 'primary') ref.tier = s.tier;
-              if (s.evidenceType) ref.evidenceType = s.evidenceType;
-              if (s.publishedAt) ref.publishedAt = s.publishedAt;
-              if (s.author) ref.author = s.author;
-              if (s.conflictOfInterest) ref.conflictOfInterest = s.conflictOfInterest;
-              if (s.notes) ref.notes = s.notes;
-              return ref;
-            }),
-            userStories: (parsed.analysis.userStories || []).map((s) => ({
-              userType: s.userType,
-              scenario: s.scenario,
-              experience: s.experience,
-              sentiment: s.sentiment,
-            })),
-          };
-
-          // その他の optional フィールドを安全に設定（exactOptionalPropertyTypes対策）
-          if (rawAnalysis.productName) analysis.productName = rawAnalysis.productName;
-          if (rawAnalysis.parentAsin) analysis.parentAsin = rawAnalysis.parentAsin;
-          if (rawAnalysis.lastInvestigated) analysis.lastInvestigated = rawAnalysis.lastInvestigated;
-          if (rawAnalysis.productDescription) analysis.productDescription = rawAnalysis.productDescription;
-          if (rawAnalysis.productUsage) analysis.productUsage = rawAnalysis.productUsage;
-          if (rawAnalysis.technicalSpecs) analysis.technicalSpecs = rawAnalysis.technicalSpecs;
-
-          // InvestigationResultを構築
-          const investigation: InvestigationResult = {
-            sessionId: `file-${asin}`,
-            product,
-            analysis,
-            generatedAt: generatedAt,
-          };
-
-          return {
-            product,
-            investigation,
-            timestamp: new Date().toISOString(),
-          };
-        } catch (error) {
-          if ((error as { code?: string }).code === 'ENOENT') {
-            logger.warn(`File not found: ${filePath}, skipping`);
-            return null;
-          }
-          logger.warn(`Failed to load investigation file ${filePath}:`, error);
-          return null;
-        }
-      }),
-    );
+    const chunkResults = await Promise.all(chunk.map((filePath) => loadAndValidateInvestigation(filePath)));
 
     results.push(...chunkResults.filter((result): result is InvestigationData => result !== null));
   }

--- a/static/js/bargain-filter.js
+++ b/static/js/bargain-filter.js
@@ -41,44 +41,114 @@ function scoreClass(score) {
   return 'score-fair';
 }
 
+function safeUrl(url) {
+  if (!url) return '#';
+  try {
+    const u = new URL(String(url), window.location.origin);
+    if (u.protocol === 'http:' || u.protocol === 'https:') {
+      return u.href;
+    }
+  } catch {
+    // ignore invalid URL
+  }
+  return '#';
+}
+
 // --- Render ---
 function renderCard(p) {
-  const imgHtml = p.image
-    ? `<img src="${p.image}" alt="${p.title}" loading="lazy" decoding="async">`
-    : `<div class="bargain-card-noimage">画像なし</div>`;
+  const article = document.createElement('article');
+  article.className = 'bargain-card';
 
-  const amazonBadge = p.isAmazonDirect
-    ? `<span class="badge-amazon-direct">Amazon直販</span>`
-    : '';
+  const imageLink = document.createElement('a');
+  imageLink.className = 'bargain-card-image-link';
+  imageLink.href = safeUrl(p.url);
 
-  const pointsBadge = p.loyaltyPoints
-    ? `<span class="bargain-card-points">🎁 ${p.loyaltyPoints}pt</span>`
-    : '';
+  const imageWrap = document.createElement('div');
+  imageWrap.className = 'bargain-card-image';
 
-  const btnHtml = p.affiliateUrl
-    ? `<a href="${p.affiliateUrl}" class="btn-amazon-small" target="_blank" rel="noopener noreferrer">🛒 Amazonで見る</a>`
-    : `<a href="${p.url}" class="bargain-card-review-link">レビューを読む →</a>`;
+  if (p.image) {
+    const img = document.createElement('img');
+    img.src = safeUrl(p.image);
+    img.alt = String(p.title || '');
+    img.loading = 'lazy';
+    img.decoding = 'async';
+    imageWrap.appendChild(img);
+  } else {
+    const noImage = document.createElement('div');
+    noImage.className = 'bargain-card-noimage';
+    noImage.textContent = '画像なし';
+    imageWrap.appendChild(noImage);
+  }
 
-  return `
-    <article class="bargain-card">
-      <a href="${p.url}" class="bargain-card-image-link">
-        <div class="bargain-card-image">${imgHtml}</div>
-      </a>
-      <div class="bargain-card-body">
-        <div class="bargain-card-category">${p.category || ''}</div>
-        <h3 class="bargain-card-title">
-          <a href="${p.url}">${p.title}</a>
-        </h3>
-        <div class="bargain-card-meta">
-          <span class="bargain-card-price">${p.price || ''}</span>
-          <span class="card-score ${scoreClass(p.score)}">🏆 ${p.score}点</span>
-        </div>
-        <div class="bargain-card-badges">
-          ${amazonBadge}${pointsBadge}
-        </div>
-        <div class="bargain-card-actions">${btnHtml}</div>
-      </div>
-    </article>`;
+  imageLink.appendChild(imageWrap);
+  article.appendChild(imageLink);
+
+  const body = document.createElement('div');
+  body.className = 'bargain-card-body';
+
+  const category = document.createElement('div');
+  category.className = 'bargain-card-category';
+  category.textContent = String(p.category || '');
+  body.appendChild(category);
+
+  const title = document.createElement('h3');
+  title.className = 'bargain-card-title';
+  const titleLink = document.createElement('a');
+  titleLink.href = safeUrl(p.url);
+  titleLink.textContent = String(p.title || '');
+  title.appendChild(titleLink);
+  body.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'bargain-card-meta';
+
+  const price = document.createElement('span');
+  price.className = 'bargain-card-price';
+  price.textContent = String(p.price || '');
+  meta.appendChild(price);
+
+  const score = document.createElement('span');
+  score.className = `card-score ${scoreClass(p.score)}`;
+  score.textContent = `🏆 ${p.score}点`;
+  meta.appendChild(score);
+
+  body.appendChild(meta);
+
+  const badges = document.createElement('div');
+  badges.className = 'bargain-card-badges';
+  if (p.isAmazonDirect) {
+    const amazonBadge = document.createElement('span');
+    amazonBadge.className = 'badge-amazon-direct';
+    amazonBadge.textContent = 'Amazon直販';
+    badges.appendChild(amazonBadge);
+  }
+  if (p.loyaltyPoints) {
+    const pointsBadge = document.createElement('span');
+    pointsBadge.className = 'bargain-card-points';
+    pointsBadge.textContent = `🎁 ${p.loyaltyPoints}pt`;
+    badges.appendChild(pointsBadge);
+  }
+  body.appendChild(badges);
+
+  const actions = document.createElement('div');
+  actions.className = 'bargain-card-actions';
+  const btn = document.createElement('a');
+  if (p.affiliateUrl) {
+    btn.href = safeUrl(p.affiliateUrl);
+    btn.className = 'btn-amazon-small';
+    btn.target = '_blank';
+    btn.rel = 'noopener noreferrer';
+    btn.textContent = '🛒 Amazonで見る';
+  } else {
+    btn.href = safeUrl(p.url);
+    btn.className = 'bargain-card-review-link';
+    btn.textContent = 'レビューを読む →';
+  }
+  actions.appendChild(btn);
+  body.appendChild(actions);
+
+  article.appendChild(body);
+  return article;
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -247,7 +317,7 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         noResultsEl.style.display = 'none';
         gridEl.style.display = '';
-        gridEl.innerHTML = filtered.map(renderCard).join('');
+        gridEl.replaceChildren(...filtered.map(renderCard));
       }
       statsEl.textContent = String(filtered.length);
 

--- a/static/js/bargain-filter.js
+++ b/static/js/bargain-filter.js
@@ -44,7 +44,7 @@ function scoreClass(score) {
 function safeUrl(url) {
   if (!url) return '#';
   try {
-    const u = new URL(String(url), window.location.origin);
+    const u = new URL(String(url), globalThis.location.origin);
     if (u.protocol === 'http:' || u.protocol === 'https:') {
       return u.href;
     }
@@ -53,6 +53,20 @@ function safeUrl(url) {
   }
   return '#';
 }
+
+function safeImageUrl(url) {
+  if (!url) return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+  try {
+    const u = new URL(String(url), globalThis.location.origin);
+    if (u.protocol === 'http:' || u.protocol === 'https:' || u.protocol === 'data:') {
+      return u.href;
+    }
+  } catch {
+    // ignore invalid URL
+  }
+  return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+}
+
 
 // --- Render ---
 function renderCard(p) {
@@ -68,7 +82,7 @@ function renderCard(p) {
 
   if (p.image) {
     const img = document.createElement('img');
-    img.src = safeUrl(p.image);
+    img.src = safeImageUrl(p.image);
     img.alt = String(p.title || '');
     img.loading = 'lazy';
     img.decoding = 'async';


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/amazon-product-article/security/code-scanning/37](https://github.com/aegisfleet/amazon-product-article/security/code-scanning/37)

The safest fix without changing behavior is to **stop building HTML with unescaped interpolation** for untrusted fields and instead **construct DOM nodes with `document.createElement` + `textContent` + validated URLs**, then append via `replaceChildren`. This prevents HTML interpretation of attacker-controlled text.

Best concrete approach in `static/js/bargain-filter.js`:
- Replace `renderCard(p)` (currently returns an HTML string) with a function that returns an `HTMLElement` (`<article>` card) built with DOM APIs.
- Add a small helper to safely set `href`/`src` only for allowed protocols (`http:`/`https:`), defaulting to `#` (or omit attribute) otherwise.
- In `applyFilters` render block, replace `gridEl.innerHTML = filtered.map(renderCard).join('')` with `gridEl.replaceChildren(...filtered.map(renderCard))`.
- Keep existing CSS class structure and text content identical so UI/behavior remains unchanged.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * URLのセキュリティ検証機能を強化し、不正なプロトコルからの読み込みを防止しました。
  * DOM生成方式の改善により、クロスサイトスクリプティング（XSS）の脆弱性リスクを軽減しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegisfleet/amazon-product-article/pull/6340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->