### PR TITLE
Add investigation data for Anker Nano II 65W (B08X11GD52)

### DIFF
--- a/data/investigations/B08X11GD52.json
+++ b/data/investigations/B08X11GD52.json
@@ -1,0 +1,195 @@
+{
+  "analysis": {
+    "productName": "Anker Nano II 65W",
+    "parentAsin": "B0GP663HK3",
+    "productDescription": "独自技術「Anker GaN II」を採用した、最大65W出力の超小型USB-C急速充電器。折りたたみ式プラグを搭載し、スマートフォンからノートPCまで幅広い機器の充電に対応する。",
+    "productUsage": ["スマートフォンやタブレットの急速充電", "USB PD対応ノートPCの電源供給", "外出先やカフェでのリモートワーク用電源"],
+    "positivePoints": [
+      "最大65Wの高出力ながら、約44×42×36mm・約112gと非常にコンパクト",
+      "持ち運びに便利な折りたたみ式プラグを採用",
+      "独自の「Anker GaN II」技術により発熱を抑えつつ小型化を実現",
+      "国際的な安全規格(IEC 62368-1)に準拠した高い安全性"
+    ],
+    "negativePoints": [
+      "ポートがUSB-Cの1つのみであるため、複数機器の同時充電は不可",
+      "充電中に本体がやや温かくなることがある（仕様の範囲内）"
+    ],
+    "useCases": [
+      "ノートPCの大きくて重い純正ACアダプタの代わりとして持ち歩く",
+      "出張や旅行時の荷物を減らすための万能充電器として活用する"
+    ],
+    "userStories": [
+      {
+        "userType": "ビジネスパーソン",
+        "scenario": "外出先やカフェでのリモートワーク時にノートPCとiPadを充電する",
+        "experience": "iPadやThinkPadの充電に使用している。純正のACアダプタを持ち歩くのが嫌になるほど小さく、充電速度も非常に速い。充電中は本体が熱くなるがトラブルはなく、携帯性に優れている。",
+        "supportingSourceIds": ["kakaku-1"],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "スマートフォンユーザー",
+        "scenario": "日常のスマートフォン(iPhone)の充電に使用する",
+        "experience": "iPhone 13の充電に使用。非常にコンパクトでカバンに入れても邪魔にならず、ほのかに暖かくなる程度で気にならない。",
+        "supportingSourceIds": ["kakaku-1"],
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "高出力でありながら驚くほどコンパクトで、持ち運びに最適という声が多数。充電速度にも満足度が高く、価格以上の価値を感じているユーザーが多い。1ポートという制約はあるものの、その分サイズが小さいため、ノートPCのACアダプタの代替として高く評価されている。",
+    "sources": [
+      {
+        "id": "anker-official",
+        "name": "Anker Japan公式サイト / Anker Nano II 65W",
+        "url": "https://www.ankerjapan.com/products/a2663",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-05-26",
+        "author": "アンカー・ジャパン株式会社",
+        "conflictOfInterest": "possible",
+        "notes": "製品の詳細な仕様（サイズ、重量、出力規格など）および独自技術GaN IIの説明を確認。"
+      },
+      {
+        "id": "kakaku-1",
+        "name": "価格.com / ANKER Nano II 65W A2663N11 レビュー・評価",
+        "url": "https://kakaku.com/item/K0001368772/",
+        "tier": "medium",
+        "evidenceType": "secondary",
+        "publishedAt": "2026-05-01",
+        "author": "価格.comユーザー",
+        "conflictOfInterest": "none",
+        "notes": "コンパクトさ、充電速度の速さ、発熱に対する実際の使用感や評価を確認。"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "最大65W出力でありながら、約44×42×36mmの超コンパクトサイズを実現",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["anker-official", "kakaku-1"],
+        "crossChecked": true,
+        "notes": "公式サイトのスペックと、ユーザーの「とにかく小さい」という実体験から裏付けられている。"
+      },
+      {
+        "claim": "独自のGaN II技術による効率的な充電と発熱管理",
+        "category": "safety",
+        "confidence": "high",
+        "supportingSourceIds": ["anker-official", "kakaku-1"],
+        "crossChecked": true,
+        "notes": "公式サイトの技術説明と、ユーザーの「発熱は仕様の範囲内で問題ない」という声が一致。"
+      }
+    ],
+    "lastInvestigated": "2026-05-26",
+    "competitiveAnalysis": [
+      {
+        "name": "エレコム EC-AC8565BK (65W 1ポート)",
+        "asin": "B0CTJDLWV4",
+        "priceComparison": "本製品よりも安価であり、コストパフォーマンスに優れている。",
+        "featureComparison": [
+          "共通点：USB-C 1ポートで最大65W出力、GaN採用でコンパクト、折りたたみ式プラグ搭載",
+          "相違点：エレコム製品はPPSに対応している旨が明記されており、価格も抑えられている"
+        ],
+        "differentiators": [
+          "Anker Nano II 65Wの利点：Ankerブランドの信頼性と独自技術(GaN II)による極めてコンパクトなサイズ感",
+          "エレコム EC-AC8565BKの利点：同等のスペックで価格が安く、コストを抑えたい場合に適している"
+        ]
+      },
+      {
+        "name": "UGREEN Nexode 65W 3ポート (ブラック)",
+        "asin": "B091BGMKYS",
+        "priceComparison": "本製品よりも高価だが、複数ポートを搭載しているため用途による。",
+        "featureComparison": [
+          "共通点：最大65WのUSB PD出力対応、GaN採用で折りたたみ式プラグ搭載",
+          "相違点：本製品が1ポートであるのに対し、UGREEN製品はUSB-C×2、USB-A×1の合計3ポートを搭載している"
+        ],
+        "differentiators": [
+          "Anker Nano II 65Wの利点：1ポートに特化しているため、より小型で持ち運びに有利",
+          "UGREEN Nexode 65Wの利点：複数機器を同時に充電したい場合に便利"
+        ]
+      },
+      {
+        "name": "エレコム EC-AC12465BK (65W 1ポート)",
+        "asin": "B0GMGHTNBB",
+        "priceComparison": "本製品よりも安価に購入できる。",
+        "featureComparison": [
+          "共通点：最大65W出力、USB-C 1ポート、スイング式(折りたたみ)プラグ採用",
+          "相違点：Ankerの独自技術と比較して、サイズ感や重量に若干の違いがある"
+        ],
+        "differentiators": [
+          "Anker Nano II 65Wの利点：より洗練された超小型デザインとブランドの実績",
+          "エレコム EC-AC12465BKの利点：より安価でありながら必要十分な65W出力を備えている"
+        ]
+      },
+      {
+        "name": "ノーブランド系 65W 3ポート充電器 (B0G3P87H5H)",
+        "asin": "B0G3P87H5H",
+        "priceComparison": "本製品の半額程度と非常に安価だが、ブランドの信頼性に欠ける。",
+        "featureComparison": [
+          "共通点：最大65W出力対応の小型充電器",
+          "相違点：本製品がAnker製の1ポートであるのに対し、こちらは安価で3ポートを搭載しているが、安全性や耐久性の信頼度が不明"
+        ],
+        "differentiators": [
+          "Anker Nano II 65Wの利点：国際的な安全規格に準拠し、長期的な安全性とメーカー保証による信頼性が高い",
+          "ノーブランド系 65W充電器の利点：とにかく安く、ポート数が多い"
+        ]
+      },
+      {
+        "name": "HYDOOD PD 65W 急速充電器 (B0FVMKXCPK)",
+        "asin": "B0FVMKXCPK",
+        "priceComparison": "本製品よりも安価であり、さらにケーブルが付属している。",
+        "featureComparison": [
+          "共通点：最大65W出力対応の小型充電器",
+          "相違点：こちらはケーブル(100W対応 2m)が付属しているが、メーカーの知名度やサポート体制でAnkerに劣る"
+        ],
+        "differentiators": [
+          "Anker Nano II 65Wの利点：圧倒的な知名度と安心のサポート体制、確かな品質",
+          "HYDOOD PD 65Wの利点：ケーブルがセットになっており、初期費用を抑えられる"
+        ]
+      },
+      {
+        "name": "エレコム EC-AC10367BK (65W 3ポート)",
+        "asin": "B0F43M6SBB",
+        "priceComparison": "本製品とほぼ同等の価格帯（やや高い）。",
+        "featureComparison": [
+          "共通点：最大65W出力の小型充電器、折りたたみ式プラグ",
+          "相違点：本製品が1ポートに特化しているのに対し、こちらはUSB-C×2とUSB-A×1の3ポート構成"
+        ],
+        "differentiators": [
+          "Anker Nano II 65Wの利点：1ポート特化による究極のコンパクトさと軽さ",
+          "エレコム EC-AC10367BKの利点：複数ポート搭載により、スマホとPCなどの同時充電が可能"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "ノートPC用の重いACアダプタを持ち歩きたくない人",
+        "出張や旅行が多く、荷物を極力小さく・軽くしたい人",
+        "1つのポートでスマホからPCまで素早く充電したい人"
+      ],
+      "pros": [
+        "65W出力としては最高クラスのコンパクトさと軽さ",
+        "持ち運びに適した折りたたみ式プラグ",
+        "大手ブランドの高い安全性と信頼性"
+      ],
+      "cons": [
+        "ポートが1つしかないため、複数機器の同時充電はできない",
+        "複数ポートを搭載した同価格帯の製品も存在するため、用途が限られる"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (65W出力の十分な性能)\n[加点: +5] (持ち運びに適した極めてコンパクトなサイズ)\n[加点: +3] (高いユーザー満足度)\n[加点: +2] (国際安全規格準拠による高い信頼性)\n[加点: +5] (独自技術GaN IIによる革新的な設計)\n[減点: -2] (1ポートのみの制約)\n[減点: -3] (他社競合と比較してやや高い価格)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "44mm",
+        "width": "42mm",
+        "depth": "36mm"
+      },
+      "weight": "112g",
+      "other": [
+        "入力: 100-240V~ 2.1A 50-60Hz",
+        "出力: 5.0V=3.0A / 9.0V=3.0A / 15.0V=3.0A / 20.0V=3.25A (最大65W)",
+        "ポート数: USB-C 1ポート",
+        "プラグ仕様: 折りたたみ式プラグ",
+        "安全規格: PSE技術基準適合、IEC 62368-1準拠"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Anker Nano II 65W (B08X11GD52) について、最新情報（Anker Japan公式サイト、価格.comなど）を調査し、競合商品6点との比較、加減点の算出（独立性を担保）、インチ表記のメートル法変換などを行い、指定フォーマットに従い JSON データを構築しました。

---
*PR created automatically by Jules for task [14392845440433970680](https://jules.google.com/task/14392845440433970680) started by @aegisfleet*