### PR TITLE
chore: investigate B0DVJ64ZLT (Amazon Fire TV Stick HD)

### DIFF
--- a/data/investigations/B0DVJ64ZLT.json
+++ b/data/investigations/B0DVJ64ZLT.json
@@ -1,0 +1,174 @@
+{
+  "analysis": {
+    "productName": "Amazon Fire TV Stick HD",
+    "parentAsin": "B0DVJ64ZLT",
+    "productDescription": "Fire TV Stick HDは、フルHD画質とWi-Fi 6に対応したストリーミングメディアプレーヤーです。Alexa対応音声認識リモコンが付属し、テレビのHDMIポートに挿すだけでPrime VideoやNetflixなどの動画配信サービスを楽しめます。",
+    "productUsage": [
+      "テレビでの動画ストリーミング視聴",
+      "Alexaを通じたスマートホーム家電の操作"
+    ],
+    "positivePoints": [
+      "USB-Cケーブルを用いてテレビから直接給電可能になり、電源アダプタが不要になった（一部テレビのUSBポート仕様による）",
+      "Wi-Fi 6に対応し、より安定したストリーミング再生が可能",
+      "コンパクトで持ち運びやすく、旅先のテレビでも利用可能"
+    ],
+    "negativePoints": [
+      "4K画質には非対応（最大フルHD 1080pまで）",
+      "テレビのUSBポートの電力不足時には正常に起動しない可能性がある"
+    ],
+    "useCases": [
+      "古いテレビやモニターをスマートTV化する",
+      "旅行先や出張先のホテルのテレビで自身のサブスク動画を視聴する"
+    ],
+    "userStories": [],
+    "userImpression": "USB-C給電に対応したことで配線周りがスッキリし、使い勝手が向上したエントリーモデルのストリーミングデバイスとして評価されています。4Kが不要なユーザーには十分な性能を備えています。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0DVJ64ZLT",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-06-01",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "製品仕様、機能、価格などの公式情報"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "Wi-Fi 6対応で安定した通信が可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-1"],
+        "crossChecked": true,
+        "notes": "商品詳細より確認"
+      },
+      {
+        "claim": "USB-Cケーブル経由でテレビから直接給電可能",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": ["src-1"],
+        "crossChecked": true,
+        "notes": "商品特徴の「セットアップがさらに簡単に」より確認"
+      }
+    ],
+    "lastInvestigated": "2026-06-01",
+    "competitiveAnalysis": [
+      {
+        "name": "Amazon Fire TV Stick 4K Select",
+        "asin": "B0CN415PTV",
+        "priceComparison": "対象商品より約1,100円高いが、4K高画質ストリーミングに対応している。",
+        "featureComparison": [
+          "共通点：Alexa対応音声認識リモコン付属、Wi-Fi対応",
+          "相違点：Fire TV Stick HDは最大1080p（フルHD）、4K Selectは最大4K Ultra HD画質に対応"
+        ],
+        "differentiators": [
+          "Amazon Fire TV Stick HDの利点：価格が手頃で、フルHD対応のテレビで十分なユーザー向け。",
+          "Amazon Fire TV Stick 4K Selectの利点：4Kテレビを所有しており、より高画質で映像を楽しみたいユーザーに最適。"
+        ]
+      },
+      {
+        "name": "Amazon Fire TV Stick 4K Max",
+        "asin": "B0G2TXBSWJ",
+        "priceComparison": "対象商品より約5,100円高いが、Fire TV Stick史上最もパワフルでWi-Fi 6Eに対応。",
+        "featureComparison": [
+          "共通点：ストリーミングメディアプレイヤー",
+          "相違点：Maxはより高速なプロセッサ、Wi-Fi 6E、アンビエントディスプレイ機能などを搭載"
+        ],
+        "differentiators": [
+          "Amazon Fire TV Stick HDの利点：機能をシンプルに絞り、価格を抑えたエントリーモデル。",
+          "Amazon Fire TV Stick 4K Maxの利点：動作のサクサク感や最新のWi-Fi規格を重視するヘビーユーザー向け。"
+        ]
+      },
+      {
+        "name": "Amazon Fire TV Cube",
+        "asin": "B0C7K814LB",
+        "priceComparison": "対象商品より約11,100円高いが、ハンズフリーのAlexa操作や強力なプロセッサを備える。",
+        "featureComparison": [
+          "共通点：Alexaを用いた音声操作が可能",
+          "相違点：Cubeは内蔵マイク・スピーカーによりリモコンなしでの音声操作が可能で、有線LANにも対応"
+        ],
+        "differentiators": [
+          "Amazon Fire TV Stick HDの利点：テレビの裏に隠れるコンパクトサイズで、導入費用が格段に安い。",
+          "Amazon Fire TV Cubeの利点：リビングの中心となるスマートホームハブとして、リモコンを使わず音声のみで様々な機器を操作したいケース。"
+        ]
+      },
+      {
+        "name": "スマートTV Stick HD対応スタンダードモデル",
+        "asin": "B0GT8C1PB9",
+        "priceComparison": "対象商品より約1,900円高い。",
+        "featureComparison": [
+          "共通点：HD対応のストリーミングメディアプレイヤー",
+          "相違点：対象商品はAmazonの公式デバイスであり、Prime Video等とのシームレスな連携が可能"
+        ],
+        "differentiators": [
+          "Amazon Fire TV Stick HDの利点：Amazonエコシステムとの高い親和性と、信頼性の高いサポート体制。",
+          "スマートTV Stick HD対応スタンダードモデルの利点：特定の非Amazon環境や特殊な用途での利用が必要なケース。"
+        ]
+      },
+      {
+        "name": "Topmeda 4Kメディアプレーヤー",
+        "asin": "B0GS1NF7T7",
+        "priceComparison": "対象商品より約800円高い。",
+        "featureComparison": [
+          "共通点：テレビでメディアを再生できる",
+          "相違点：対象商品は主にネットストリーミング用だが、TopmedaはSDカードやUSBメモリ等に保存されたローカルファイルの再生に特化（デジタルサイネージ等）"
+        ],
+        "differentiators": [
+          "Amazon Fire TV Stick HDの利点：Prime VideoやNetflixなどのオンライン動画サービスの視聴に最適化されている。",
+          "Topmeda 4Kメディアプレーヤーの利点：店頭のデジタルサイネージや、オフライン環境での動画・画像リピート再生が必要なケース。"
+        ]
+      },
+      {
+        "name": "メディアプレーヤー 4k マルチメディアプレーヤー",
+        "asin": "B0DQPRMWMC",
+        "priceComparison": "対象商品より約200円安い。",
+        "featureComparison": [
+          "共通点：テレビでメディアを再生できる",
+          "相違点：対象商品はオンライン動画配信用、こちらはローカルストレージ（SDカード・USBメモリ）の再生・店頭展示向け"
+        ],
+        "differentiators": [
+          "Amazon Fire TV Stick HDの利点：VODサービスの視聴が主目的であればこちらの一択。",
+          "メディアプレーヤー 4k マルチメディアプレーヤーの利点：オンライン接続不要でローカル動画を連続再生したい用途に適している。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "フルHD（1080p）までのテレビを使用している人",
+        "安価にテレビで動画配信サービスを楽しみたい人",
+        "旅行や出張に持ち運んで使いたい人"
+      ],
+      "pros": [
+        "4,880円という手頃な価格",
+        "テレビのUSBから直接給電できる手軽さ（電源アダプタ不要）",
+        "Wi-Fi 6対応による安定した通信"
+      ],
+      "cons": [
+        "4K画質には対応していない",
+        "USB給電はテレビ側の出力に依存する"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (USB-C給電対応による設置のしやすさ・利便性の向上)\n[加点: +5] (Wi-Fi 6対応により、エントリーモデルながら通信安定性が高い)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "17.5mm",
+        "width": "38.6mm",
+        "depth": "141.2mm"
+      },
+      "weight": "45g",
+      "capacity": "8GB（内蔵ストレージ推測）",
+      "material": "プラスチック",
+      "origin": "中国",
+      "other": [
+        "出力: 最大1080p（フルHD）",
+        "Wi-Fi: Wi-Fi 6 (802.11a/b/g/n/ac/ax) 対応",
+        "Bluetooth: 対応",
+        "端子: HDMI、USB-C (給電用)",
+        "付属品: Alexa対応音声認識リモコン、USB電源ケーブル"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Amazon Fire TV Stick HD (ASIN: B0DVJ64ZLT) の詳細情報および競合商品調査を行い、指定フォーマットに準拠したJSONファイル (`data/investigations/B0DVJ64ZLT.json`) を作成しました。
- 単位をインチ・ポンドからミリ・グラムへ変換
- `lastInvestigated` を 2026-06-01 に設定
- 公式商品ページからの機能・仕様情報を抽出
- 競合情報（Fire TV Stick 4K等）との比較を追加
- 推奨スコアの計算を追加
- `validate_artifact.py` による検証をパス

---
*PR created automatically by Jules for task [13938748326348986724](https://jules.google.com/task/13938748326348986724) started by @aegisfleet*