### PR TITLE
Fix mobile layout overflow on recommendations page

### DIFF
--- a/layouts/recommendations/list.html
+++ b/layouts/recommendations/list.html
@@ -1,5 +1,31 @@
 {{- define "main" -}}
-<div class="container" style="padding-top: var(--spacing-xl);">
+<style>
+    .recommendations-container {
+        padding-top: var(--spacing-xl);
+    }
+    .card-title,
+    .article-header h1,
+    .pros-card h2 {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+    @media (max-width: 768px) {
+        .competitor-card {
+            padding-left: var(--spacing-md) !important;
+            padding-right: var(--spacing-md) !important;
+        }
+        .rank-badge {
+            left: 0 !important;
+            top: 0 !important;
+            border-top-left-radius: var(--radius-lg) !important;
+            border-bottom-right-radius: var(--radius-sm) !important;
+        }
+        .pros-card h2 {
+            font-size: 1.25rem !important;
+        }
+    }
+</style>
+<div class="container recommendations-container">
     {{- partial "breadcrumb.html" . -}}
 
     {{- $todayData := hugo.Data.recommendations.today -}}
@@ -60,13 +86,13 @@
         <div class="competitor-card"
             style="display: flex; flex-direction: column; gap: var(--spacing-md); border-left: 4px solid var(--color-primary); position: relative; padding: var(--spacing-md) 32px; margin-top: 12px;">
             <!-- Rank Badge -->
-            <div
+            <div class="rank-badge"
                 style="position: absolute; top: -12px; left: -12px; background: var(--color-primary); color: white; width: 32px; height: 32px; display: flex; justify-content: center; align-items: center; font-weight: bold; font-size: 1.1rem; border-radius: var(--radius-sm); box-shadow: var(--shadow-md); z-index: 10;">
                 {{ add $index 1 }}
             </div>
 
             <div
-                style="display: flex; gap: var(--spacing-lg); align-items: flex-start; flex-wrap: wrap; flex: 1;">
+                style="display: flex; gap: var(--spacing-lg); align-items: flex-start; flex-wrap: wrap; flex: 1; min-width: 0;">
 
                 <!-- Product Image -->
                 <div style="flex-shrink: 0; width: 100%; max-width: 200px; text-align: center; margin: 0 auto;">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,6 +13,7 @@ body {
   color: var(--color-text-main);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  overflow-wrap: break-word;
 }
 
 img {
@@ -439,6 +440,8 @@ a:hover {
   font-weight: 700;
   margin-bottom: var(--spacing-sm);
   color: var(--color-text-main);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .card-title a {


### PR DESCRIPTION
This change fixes the horizontal overflow and text clipping on the recommendations page when viewed on mobile devices. 

Key improvements:
1. **Responsive Padding:** Reduced fixed 32px padding to `var(--spacing-md)` on screens below 768px.
2. **Badge Adjustment:** Repositioned the rank badge from `left: -12px` (which caused overflow) to `left: 0` on mobile.
3. **Enhanced Word Wrapping:** Applied `overflow-wrap: anywhere` and `word-break: break-word` to product titles and headings to prevent long names from breaking the layout.
4. **Flexbox Optimization:** Added `min-width: 0` to flex children to allow them to shrink properly on small screens.
5. **Global Safety:** Added `overflow-wrap: break-word` to the `body` to handle unexpected long strings globally.

Fixes #6697

---
*PR created automatically by Jules for task [13444198548904599912](https://jules.google.com/task/13444198548904599912) started by @aegisfleet*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 長いテキストやURLがモバイル画面で正しく折り返されるよう改善しました。

* **Style**
  * モバイルデバイス（画面幅768px以下）でのレイアウトとカードの表示を最適化しました。
  * タイトルとテキストの折り返し動作を改善し、読みやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->