### PR TITLE
Create investigation data for B0DMFLV4B1

### DIFF
--- a/data/investigations/B0DMFLV4B1.json
+++ b/data/investigations/B0DMFLV4B1.json
@@ -1,0 +1,132 @@
+{
+  "analysis": {
+    "productName": "ON Gold Standard 100% ホエイプロテイン ダブルリッチチョコレート 主原料WPI 669g ボトルタイプ",
+    "parentAsin": "B0DMFLV4B1",
+    "productDescription": "世界的なプロテインブランド、Optimum Nutritionのホエイプロテイン（ダブルリッチチョコレート風味・669g）。主原料にWPIを採用し、高品質なタンパク質を効率的に補給できるボトルタイプの製品です。",
+    "productUsage": ["トレーニング後のタンパク質補給", "日常的な栄養補給", "ダイエット中の食事置き換え"],
+    "positivePoints": ["主原料として高純度のWPI（ホエイプロテインアイソレート）を使用している", "定番のダブルリッチチョコレート風味で飲みやすい", "ボトルタイプのため保管と計量が容易である"],
+    "negativePoints": ["内容量669gに対して価格が比較的高め（約10.4円/g）", "国内製造ではなくアメリカ合衆国が原産国のため輸送によるコストが反映されている", "ボトルタイプは袋タイプと比較して廃棄時の手間がかかる場合がある"],
+    "useCases": ["筋力トレーニング直後のタンパク質補給", "朝食時のタンパク質不足の補強", "間食代わり"],
+    "userStories": [],
+    "userImpression": "高純度なWPIを主原料としているため、品質を重視するトレーニーからの信頼は厚いが、容量に対する価格面では国産プロテインと比較して割高に感じられる傾向がある。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon Product Detail Page",
+        "url": "https://www.amazon.co.jp/dp/B0DMFLV4B1",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-11-19",
+        "author": "Optimum Nutrition",
+        "conflictOfInterest": "none",
+        "notes": "製品基本情報、寸法、重量（メートル法へ換算済み）、価格（6980円）"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "主原料としてWPI（ホエイプロテインアイソレート）を使用",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-1"],
+        "crossChecked": false,
+        "notes": "製品仕様からの確認"
+      }
+    ],
+    "lastInvestigated": "2026-06-07",
+    "competitiveAnalysis": [
+      {
+        "name": "VALX ホエイ プロテイン WPI パーフェクト チョコレート 風味 1kg",
+        "asin": "B08BWVQJQM",
+        "priceComparison": "VALXの方が容量が多く価格も安いため、単価面で優れている",
+        "featureComparison": [
+          "共通点：WPIを使用したチョコレート風味のプロテインである",
+          "相違点：対象商品は669gのボトルタイプ、VALXは1kgの袋タイプであり、タンパク質含有量の設計が異なる"
+        ],
+        "differentiators": [
+          "ON Gold Standard 100% ホエイプロテインの利点：グローバルブランドの信頼性とボトルタイプの保管のしやすさ",
+          "VALX ホエイ プロテイン WPIの利点：容量1kgに対するコストパフォーマンスの高さ"
+        ]
+      },
+      {
+        "name": "REYS WPI ホエイ プロテイン アイソレート 1kg チョコレート風味",
+        "asin": "B0CKKFBRKR",
+        "priceComparison": "REYSの方が容量が多く価格も安いため、単価面で優れている",
+        "featureComparison": [
+          "共通点：WPIを使用したチョコレート風味のプロテインである",
+          "相違点：対象商品は米国産でボトルタイプ、REYSは国内製造でビタミン7種を配合している"
+        ],
+        "differentiators": [
+          "ON Gold Standard 100% ホエイプロテインの利点：世界的に有名なOptimum Nutritionブランドとしての実績",
+          "REYS WPI ホエイ プロテインの利点：国内製造とビタミン配合による付加価値、およびコストパフォーマンス"
+        ]
+      },
+      {
+        "name": "グロング プロテイン WPI ホエイプロテイン アイソレート 1kg チョコレート風味",
+        "asin": "B0DHFMW6T6",
+        "priceComparison": "GronGの方が容量が多く価格も安いため、単価面で優れている",
+        "featureComparison": [
+          "共通点：WPIを使用したチョコレート風味のプロテインである",
+          "相違点：対象商品は669gでボトルタイプ、GronGは1kgで袋タイプである"
+        ],
+        "differentiators": [
+          "ON Gold Standard 100% ホエイプロテインの利点：ボトルの取り回しの良さと伝統のダブルリッチチョコレート風味",
+          "グロング プロテイン WPIの利点：大容量1kgとハイコストパフォーマンス"
+        ]
+      },
+      {
+        "name": "ULTORA ウルトラ ホエイ プロテイン 810g WPI & WPC チョコレート風味",
+        "asin": "B0G2LK3KTJ",
+        "priceComparison": "ULTORAの方が容量が多く価格も安いため、単価面で優れている",
+        "featureComparison": [
+          "共通点：WPIを使用したチョコレート風味のプロテインである（ULTORAはWPI＆WPC）",
+          "相違点：対象商品はWPI主原料、ULTORAは人工甘味料不使用で乳酸菌・ビタミンなどを配合している"
+        ],
+        "differentiators": [
+          "ON Gold Standard 100% ホエイプロテインの利点：海外ブランドの定番商品としての安心感",
+          "ULTORA ウルトラ ホエイ プロテインの利点：人工甘味料不使用やシンバイオティクス配合など成分へのこだわり"
+        ]
+      },
+      {
+        "name": "クレバー ホエイプロテイン [WPI100%] マッスル チョコレート味 810g",
+        "asin": "B091KT3MY9",
+        "priceComparison": "クレバーの方が容量が多く価格も安いため、単価面で優れている",
+        "featureComparison": [
+          "共通点：WPIを100%使用したチョコレート風味のプロテインである",
+          "相違点：対象商品は米国産で669gのボトルタイプ、クレバーは810gの袋タイプである"
+        ],
+        "differentiators": [
+          "ON Gold Standard 100% ホエイプロテインの利点：定番の味とグローバルブランドの信頼感",
+          "クレバー ホエイプロテインの利点：810gという程よい容量でのコストパフォーマンスの良さ"
+        ]
+      },
+      {
+        "name": "Verifyst ベリフィスト 3kg WPI ホエイ プロテイン 100 チョコレート風味",
+        "asin": "B0FCMQ965F",
+        "priceComparison": "Verifystの方が大容量で単価面で非常に優れている",
+        "featureComparison": [
+          "共通点：WPIを使用したチョコレート風味のプロテインである",
+          "相違点：対象商品は669gのボトルタイプ、Verifystは3kgの大容量袋タイプで国内製造である"
+        ],
+        "differentiators": [
+          "ON Gold Standard 100% ホエイプロテインの利点：小分けにする必要のないボトルタイプで取り扱いが手軽",
+          "Verifyst ベリフィスト 3kg WPIの利点：大容量による圧倒的なコストパフォーマンス"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": ["品質の確かなグローバルブランドのプロテインを求める人", "ボトルタイプで保管や計量の手間を減らしたい人"],
+      "pros": ["主原料に高純度のWPIを使用", "定番で評価の高いダブルリッチチョコレート風味", "保管しやすいボトルタイプ"],
+      "cons": ["1gあたりの単価が他の競合製品よりも高い", "内容量が669gとやや少なめ"],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (WPIを主原料とした高品質な成分構成)\n[加点: +5] (保管と計量が容易なボトルタイプの利便性)\n[減点: -5] (内容量に対する単価が高くコストパフォーマンス面で懸念あり)\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "dimensions": { "height": "217mm", "width": "140mm", "depth": "140mm" },
+      "weight": "42g",
+      "capacity": "669g",
+      "material": "プラスチック（ボトル）",
+      "origin": "アメリカ合衆国",
+      "other": ["フレーバー: ダブルリッチチョコレート", "主原料: WPI (ホエイプロテインアイソレート)"]
+    }
+  }
+}


### PR DESCRIPTION
ON Gold Standard 100% ホエイプロテイン ダブルリッチチョコレート 主原料WPI 669g(1.47lb) 「ボトルタイプ」に関する調査データを `data/investigations/B0DMFLV4B1.json` として作成しました。

- 指定されたフォーマットを遵守
- 寸法や重さをメートル法に換算
- 価格・競合商品（6商品）の比較を実施
- ユーザーストーリーは推測を避けるため除外
- 妥当なスコアリングと理由の記載
- バリデーションスクリプトによる検証済み

---
*PR created automatically by Jules for task [999605203032504002](https://jules.google.com/task/999605203032504002) started by @aegisfleet*