### PR TITLE
Add investigation data for ASIN B0F1S6XSL6 (Tapo H110C)

### DIFF
--- a/data/investigations/B0F1S6XSL6.json
+++ b/data/investigations/B0F1S6XSL6.json
@@ -1,0 +1,189 @@
+{
+  "analysis": {
+    "productName": "Tapo スマートホーム 赤外線スマートハブ H110C",
+    "parentAsin": "B0F1S6XSL6",
+    "productDescription": "Tapoデバイスや赤外線家電を統合管理できるスマートハブ。チャイム機能を内蔵し、Sub-1GHz通信で各種Tapoセンサーとも連携可能です。",
+    "productUsage": [
+      "エアコン、テレビなど赤外線リモコン家電のスマート化",
+      "外出先からの家電の遠隔操作",
+      "Tapoブランドの各種センサーと組み合わせたホームオートメーション構築"
+    ],
+    "positivePoints": [
+      "約3,000円台という手頃な価格で赤外線スマートリモコン機能とハブ機能が手に入る",
+      "Sub-1GHz対応により、Wi-Fiに比べ広範囲・低消費電力でTapoセンサー等と接続可能",
+      "チャイム機能が内蔵されており、ドアホンやセンサーと連動して音を鳴らすことができる"
+    ],
+    "negativePoints": [
+      "赤外線の学習・対応データベースについて、一部のシーリングファンやエアコンでペアリングできないケースが報告されている",
+      "簡易パッケージ仕様のため、プレゼント等には不向きな可能性がある"
+    ],
+    "useCases": [
+      "帰宅前にスマートフォンからエアコンをオンにし、快適な室温にしておく",
+      "音声アシスタント（Alexa等）を使って、ハンズフリーでテレビのチャンネルを変える",
+      "別売りのTapoドア・窓センサーと連携し、扉が開いた際に内蔵チャイムを鳴らす"
+    ],
+    "userStories": [
+      {
+        "userType": "スマートホーム導入ユーザー",
+        "scenario": "シーリングファンとエアコンのスマート化",
+        "experience": "リビングのテレビは登録できたものの、寝室のテレビやシーリングファン、エアコンのペアリングがうまくいかず、リモコンの代替として十分に機能しませんでした。",
+        "supportingSourceIds": [
+          "src-amazon-review-sg"
+        ],
+        "sentiment": "negative"
+      }
+    ],
+    "userImpression": "価格の安さとTapoエコシステム（Sub-1GHzセンサー連携等）への拡張性は魅力ですが、赤外線リモコンとしての基本性能（対応家電の幅や登録のしやすさ）において一部不満の声も見受けられます。",
+    "sources": [
+      {
+        "id": "src-amazon-product",
+        "name": "Amazon.co.jp 製品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0F1S6XSL6",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2025-06-06",
+        "author": "TP-Link",
+        "conflictOfInterest": "disclosed",
+        "notes": "製品仕様、価格（￥3,132）、特徴（チャイム機能、Sub-1GHz対応）を確認"
+      },
+      {
+        "id": "src-amazon-review-sg",
+        "name": "Amazon.co.jp カスタマーレビュー",
+        "url": "https://www.amazon.co.jp/dp/B0F1S6XSL6",
+        "tier": "medium",
+        "evidenceType": "primary",
+        "publishedAt": "2026-02-27",
+        "author": "購入者",
+        "conflictOfInterest": "none",
+        "notes": "一部の家電（エアコン、シーリングファン等）でペアリングできないというレビューを確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "18種類の家電、8000以上のブランドに対応",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon-product"
+        ],
+        "crossChecked": false,
+        "notes": "メーカー公式の仕様として記載あり"
+      },
+      {
+        "claim": "一部の家電とペアリングできない場合がある",
+        "category": "quality",
+        "confidence": "medium",
+        "supportingSourceIds": [
+          "src-amazon-review-sg"
+        ],
+        "crossChecked": false,
+        "notes": "ユーザーレビューにて報告あり"
+      }
+    ],
+    "lastInvestigated": "2026-06-12",
+    "competitiveAnalysis": [
+      {
+        "name": "SwitchBot ハブミニ (Matter対応)",
+        "asin": "B0DSPXKDP8",
+        "priceComparison": "Tapo H110Cの方が大幅に安価です。SwitchBotはMatter規格に対応しており、より広範なスマートホーム規格との互換性に価値を見出せる場合は適しています。",
+        "featureComparison": [
+          "共通点：赤外線スマートリモコン機能、Alexa等の音声操作対応",
+          "相違点：SwitchBotはMatterに対応し温湿度センサーも搭載していますが、Tapo H110CはSub-1GHz通信とチャイム機能に特化しています。"
+        ],
+        "differentiators": [
+          "Tapo H110Cの利点：価格が安く、TapoのSub-1GHzセンサーと連携してチャイムを鳴らすシステムが安価に構築できる点",
+          "SwitchBot ハブミニの利点：Matter対応による汎用性の高さと、赤外線リモコンとしての実績・対応機器の多さ"
+        ]
+      },
+      {
+        "name": "SwitchBot ハブ2",
+        "asin": "B0BM8VS13P",
+        "priceComparison": "Tapo H110Cの方が非常に安価です。ハブ2は高価ですが、温湿度・照度センサー内蔵や本体ボタンでの操作など多機能です。",
+        "featureComparison": [
+          "共通点：赤外線スマートリモコン機能、スマートホームハブ機能",
+          "相違点：ハブ2は画面付きで温湿度や照度を計測できMatterにも対応しますが、Tapo H110Cはチャイム機能搭載でシンプルです。"
+        ],
+        "differentiators": [
+          "Tapo H110Cの利点：初期導入コストを大幅に抑えられる点",
+          "SwitchBot ハブ2の利点：温湿度トリガーなど高度なオートメーションが可能で、画面で状態を確認できる点"
+        ]
+      },
+      {
+        "name": "LinkJapan eRemote5+",
+        "asin": "B08BN8WSGZ",
+        "priceComparison": "Tapo H110Cの方が安価です。eRemote5+は国内メーカー製で高精度の温湿度センサーを備えています。",
+        "featureComparison": [
+          "共通点：赤外線スマートリモコン、Alexa連携、外出先からの操作",
+          "相違点：eRemote5+は温湿度センサー内蔵で国内サポートが手厚い一方、Tapo H110Cはチャイム機能とSub-1GHz通信を持ちます。"
+        ],
+        "differentiators": [
+          "Tapo H110Cの利点：価格と、Tapo製センサー類との連携しやすさ",
+          "LinkJapan eRemote5+の利点：国内サーバー・国内メーカーによる安心感と温湿度センサーの活用"
+        ]
+      },
+      {
+        "name": "アイリスオーヤマ スマートリモコン SMT-RC2-B",
+        "asin": "B0C7VC2Y21",
+        "priceComparison": "価格帯は同等です。機能面での比較が重要になります。",
+        "featureComparison": [
+          "共通点：赤外線家電の操作、スマートスピーカー連携、価格帯",
+          "相違点：アイリスオーヤマ製は非常に小型軽量（約57g）でシンプルなリモコン機能に特化していますが、Tapo H110CはTapo独自のSub-1GHzハブ機能とチャイム機能があります。"
+        ],
+        "differentiators": [
+          "Tapo H110Cの利点：Tapoエコシステム（カメラやセンサー）との連携性やチャイム機能の存在",
+          "アイリスオーヤマ スマートリモコンの利点：コンパクトな筐体と、アイリスオーヤマという国内ブランドの馴染みやすさ"
+        ]
+      },
+      {
+        "name": "エジソンスマート USBマルチスマートリモコン DIR-US01BK",
+        "asin": "B0BR4QV26G",
+        "priceComparison": "エジソンスマートの方がさらに安価です。機能や設置方法の違いを考慮する必要があります。",
+        "featureComparison": [
+          "共通点：赤外線リモコン機能、スマホアプリや音声による操作",
+          "相違点：エジソンスマートはUSBメモリ型で直挿し給電する非常にコンパクトな設計ですが、Tapo H110Cはハブ機能やチャイム機能を備えた据え置き型です。"
+        ],
+        "differentiators": [
+          "Tapo H110Cの利点：Tapoセンサー群を繋ぐハブとしての拡張性とチャイム機能",
+          "エジソンスマートの利点：USBポートに直接挿すだけでケーブル不要で設置できる極めて高い省スペース性"
+        ]
+      },
+      {
+        "name": "Tapo Smart IR & IoTハブ (Tapo H110)",
+        "asin": "B0F889ZMC5",
+        "priceComparison": "Tapo H110C（Amazon限定版）の方が安価です。機能面は同等と思われますが、価格差があります。",
+        "featureComparison": [
+          "共通点：18種類のデバイス対応、サイレン/チャイム機能内蔵、Sub-1GHz通信ハブ機能",
+          "相違点：H110CはAmazon限定の簡易パッケージモデルであり、通常パッケージのH110と製品仕様自体はほぼ同じです。"
+        ],
+        "differentiators": [
+          "Tapo H110Cの利点：簡易パッケージである分、通常版より価格が抑えられている点",
+          "Tapo H110の利点：通常パッケージが欲しい場合"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "コストを抑えてスマートリモコンを導入したい方",
+        "既にTapoブランドのスマートプラグやカメラを使用している方",
+        "ドアセンサー等と連動して鳴るチャイム機能が欲しい方"
+      ],
+      "pros": [
+        "3,000円台という高いコストパフォーマンス",
+        "Sub-1GHz対応で広範囲のTapoデバイスと安定接続が可能",
+        "チャイム/サイレン機能内蔵で防犯や通知に活用できる"
+      ],
+      "cons": [
+        "一部の古い家電やマイナーな家電で赤外線登録ができないリスクがある",
+        "温湿度センサーは内蔵していないため、温度連動のオートメーションには別売センサーが必要"
+      ],
+      "score": 83,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (Sub-1GHzハブ機能と内蔵チャイムによる独自の拡張性)\n[加点: +10] (3,000円台という他社ハブ製品と比較した高いコストパフォーマンス)\n[減点: -2] (一部家電でのペアリング不具合報告によるユーザー満足度の懸念)\n[合計: 83]"
+    },
+    "technicalSpecs": {
+      "color": "ブラック",
+      "communication": "IEEE802.11 b/g/n (2.4GHz帯), Sub-1GHz",
+      "features": "赤外線リモコン, チャイム機能",
+      "warranty": "3年 (メーカー保証)"
+    }
+  }
+}


### PR DESCRIPTION
Adds the product investigation JSON file for the Amazon product B0F1S6XSL6 (Tapo H110C Smart Hub).

- Generated competitive analysis comparing the hub against 6 other similar items (e.g., SwitchBot, LinkJapan).
- Included verified sources and negative user story based on real Amazon review.
- Set base score to 70 and correctly formatted score rationale.
- Ran validation script and ensured zero errors or broken links.

---
*PR created automatically by Jules for task [16053033288957883365](https://jules.google.com/task/16053033288957883365) started by @aegisfleet*