### PR TITLE
Update today's recommendations with 10 diverse, evidence-backed items

### DIFF
--- a/data/recommendations/today.json
+++ b/data/recommendations/today.json
@@ -1,231 +1,231 @@
 {
-  "date": "2026-06-16",
+  "date": "2026-06-17",
   "headline": "本日の厳選ピックアップ：確かな理由がある注目商品10選",
   "recommendations": [
     {
-      "asin": "B0DS7WX8QS",
-      "title": "Bioré ビオレUV アクアリッチ ウォータリーエッセンス 100g 日...",
-      "price": 1182,
-      "category": "日焼け止め",
-      "reason": "夏の紫外線から肌を守るウォーターベースの日焼け止めエッセンスです。",
-      "whyBuyNow": "マイベストの「顔用日焼け止めおすすめランキング」で高評価を獲得しており、夏本番に向けての紫外線対策として今すぐ準備すべきアイテムです。",
-      "rankReason": "高評価の紫外線対策",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "マイベスト 顔用日焼け止めランキング",
-        "url": "https://my-best.com/24276"
-      },
-      "highlights": [
-        "みずみずしい使用感",
-        "強力なUVカット",
-        "石けんで落とせる"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0DS7WX8QS/",
-      "imageUrl": "https://m.media-amazon.com/images/I/41p3XSQADSL._SL500_.jpg"
-    },
-    {
-      "asin": "B01MSDX4T9",
-      "title": "サーモス 真空断熱タンブラー 400ml ステンレス JDI-400 S",
-      "price": 973,
-      "category": "タンブラー",
-      "reason": "冷たい飲み物の温度を長時間キープできるステンレス製の真空断熱タンブラーです。",
-      "whyBuyNow": "マイベストのランキングで常に上位に入り、夏の冷たい飲み物を長時間キープできるため、これからの季節の必需品です。",
-      "rankReason": "夏に必須の実用品",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "マイベスト タンブラーランキング",
-        "url": "https://my-best.com/4922"
-      },
-      "highlights": [
-        "真空断熱構造",
-        "結露しにくい",
-        "長時間の保冷効果"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B01MSDX4T9/",
-      "imageUrl": "https://m.media-amazon.com/images/I/216HWFMCrTS._SL500_.jpg"
-    },
-    {
-      "asin": "B09G9YRX1P",
-      "title": "サントリー 天然水 ラベルレス 2L ×9本 南アルプス 【Amazon....",
-      "price": 1476,
-      "category": "飲料・水",
-      "reason": "すっきりとした飲み口で毎日飲みやすい国産の天然水ミネラルウォーターです。",
-      "whyBuyNow": "マイベストのミネラルウォーター比較で飲みやすさが評価されており、夏場の水分補給や防災用備蓄としてまとめ買いが推奨されます。",
-      "rankReason": "水分補給の必需品",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "マイベスト ミネラルウォーター",
-        "url": "https://my-best.com/5305"
-      },
-      "highlights": [
-        "すっきりとした味わい",
-        "大容量2L",
-        "備蓄にも最適"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B09G9YRX1P/",
-      "imageUrl": "https://m.media-amazon.com/images/I/51-bQLHhR0L._SL500_.jpg"
-    },
-    {
-      "asin": "4087452069",
-      "title": "マスカレード・ホテル (集英社文庫)",
-      "price": 1100,
-      "category": "ミステリー小説",
-      "reason": "東野圭吾による大人気マスカレードシリーズの第一作目となる傑作ミステリーです。",
-      "whyBuyNow": "マイベストの小説ランキングで紹介されている定番ミステリー。休日の読書時間を充実させるのに最適な一冊です。",
-      "rankReason": "読書時間の充実",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "マイベスト 小説ランキング",
-        "url": "https://my-best.com/34298"
-      },
-      "highlights": [
-        "東野圭吾の傑作",
-        "映画化された名作",
-        "緻密な伏線"
-      ],
-      "url": "https://www.amazon.co.jp/dp/4087452069/",
-      "imageUrl": "https://m.media-amazon.com/images/I/41Hk2Z2gEHL._SL500_.jpg"
-    },
-    {
-      "asin": "B0DV35N5CC",
-      "title": "BURTLE バートル アイスクラフト ベスト＆ペルチェセット(ユニセック...",
-      "price": 15900,
-      "category": "空調服",
-      "reason": "ファンを搭載し、真夏の過酷な環境でも涼しく快適に過ごせる冷却ベストです。",
-      "whyBuyNow": "マイベストの「冷却ベストランキング」に特集されており、屋外作業やアウトドアでの熱中症対策として本格的な夏前に揃えておきたい商品です。",
-      "rankReason": "熱中症対策の要",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "マイベスト 冷却ベストランキング",
-        "url": "https://my-best.com/18779"
-      },
-      "highlights": [
-        "ファン付きで涼しい",
-        "屋外作業に最適",
-        "熱中症対策"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0DV35N5CC/",
-      "imageUrl": "https://m.media-amazon.com/images/I/41qpBTGukSL._SL500_.jpg"
-    },
-    {
-      "asin": "B0DJLX7WB6",
-      "title": "愛の不時着 韓国ドラマ Blu-ray 全話 日本語字幕 トールケース付 ...",
-      "price": 5980,
-      "category": "韓国ドラマ",
-      "reason": "世界中で大ブームを巻き起こした感動作『愛の不時着』の完全版Blu-rayです。",
-      "whyBuyNow": "マイベストの「韓国ドラマ人気ランキング」で依然として高い人気を誇り、休日にじっくりと映像美を楽しむのにおすすめです。",
-      "rankReason": "人気のエンタメ",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "マイベスト 韓国ドラマランキング",
-        "url": "https://my-best.com/1490"
-      },
-      "highlights": [
-        "大ヒット感動作",
-        "映像美を堪能",
-        "イッキ見におすすめ"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0DJLX7WB6/",
-      "imageUrl": "https://m.media-amazon.com/images/I/41vczqPwXLL._SL500_.jpg"
-    },
-    {
-      "asin": "B0DGJBNYVY",
-      "title": "Apple AirPods 4 アクティブノイズ キャンセリング搭載、ワイ...",
-      "price": 29800,
-      "category": "オーディオ",
-      "reason": "インナーイヤー型ながら強力なノイズキャンセリングを備えた最新のAirPodsです。",
-      "whyBuyNow": "カジェログのレビューで「インナーイヤー型として圧倒的なノイキャン性能」と絶賛されている最新の注目デバイスです。",
-      "rankReason": "絶賛の最新モデル",
-      "scoreDisclaimer": null,
-      "source": {
-        "name": "カジェログ 徹底比較レビュー",
-        "url": "https://kajetblog.com/airpods-4-airpods-pro-2/"
-      },
-      "highlights": [
-        "最新ノイキャン機能",
-        "快適な装着感",
-        "Apple連携の良さ"
-      ],
-      "url": "https://www.amazon.co.jp/dp/B0DGJBNYVY/",
-      "imageUrl": "https://m.media-amazon.com/images/I/31rVluq7nAL._SL500_.jpg"
-    },
-    {
-      "asin": "B099MTRBD4",
-      "title": "オキシクリーン 1500g 酸素系漂白剤 つけ置き シミ抜き 界面活性剤不...",
-      "price": 1173,
-      "category": "洗濯洗剤",
-      "reason": "ガンコな汚れや部屋干しのニオイを元から落とす強力な酸素系漂白剤です。",
-      "whyBuyNow": "マイベスト等で最強の漂白・消臭力として定番化しており、梅雨時の部屋干し臭対策として今買うべき日用品です。",
+      "asin": "B0GGYVLY1Y",
+      "title": "[山善] 洗える サーキュレーター 静音 14畳",
+      "price": 3584,
+      "category": "家電",
+      "reason": "14畳対応で上下角度調節や左右首振りが可能なコンパクトで洗いやすいサーキュレーターです。",
+      "whyBuyNow": "価格.comの扇風機・サーキュレーター売れ筋ランキングに常駐しており、梅雨時の部屋干しや夏の冷房効率アップに向けて買い時です。",
       "rankReason": "梅雨の部屋干し対策",
       "scoreDisclaimer": null,
       "source": {
-        "name": "マイベスト 酸素系漂白剤",
+        "name": "価格.com 扇風機・サーキュレーター",
+        "url": "https://kakaku.com/kaden/fan/itemlist.aspx"
+      },
+      "highlights": [
+        "簡単分解でお手入れ楽々",
+        "14畳まで対応のパワフル送風",
+        "静音モード搭載"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B0GGYVLY1Y/",
+      "imageUrl": "https://m.media-amazon.com/images/I/41MV6PWHrZL._SL500_.jpg"
+    },
+    {
+      "asin": "B0CVDJ4JX6",
+      "title": "Amazon Fire HD 8 タブレット 64GB",
+      "price": 17980,
+      "category": "タブレット",
+      "reason": "持ち運びに便利な8インチで、動画視聴や読書に最適なAmazonのタブレットです。",
+      "whyBuyNow": "価格.comのタブレットPCランキングで注目されており、夏のエンタメ消費に備えてチェックしておくべき定番商品です。",
+      "rankReason": "エンタメ消費の定番",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "価格.com タブレットPC",
+        "url": "https://kakaku.com/pc/pda/itemlist.aspx"
+      },
+      "highlights": [
+        "8インチのHDディスプレイ",
+        "最大13時間の長寿命バッテリー",
+        "Alexa対応でスマート操作"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B0CVDJ4JX6/",
+      "imageUrl": "https://m.media-amazon.com/images/I/31SbAxXx8iL._SL500_.jpg"
+    },
+    {
+      "asin": "B07GBD2WKB",
+      "title": "FRECIOUS 富士 9.3L×2 天然水",
+      "price": 2780,
+      "category": "飲料・水",
+      "reason": "富士山の標高1,000m地点で採水した、ほのかな甘みとまろやかな味わいの天然水です。",
+      "whyBuyNow": "マイベストのミネラルウォーターランキング等で評価されており、本格的な夏を前に水分補給用として備蓄推奨です。",
+      "rankReason": "夏場の水分補給に",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "マイベスト ミネラルウォーターランキング",
+        "url": "https://my-best.com/5305"
+      },
+      "highlights": [
+        "富士山の天然水",
+        "PFAS不検出で安心",
+        "使い捨てボトルで衛生的"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B07GBD2WKB/",
+      "imageUrl": "https://m.media-amazon.com/images/I/41c3aYy63ZL._SL500_.jpg"
+    },
+    {
+      "asin": "B0FFN1RB6J",
+      "title": "アタック 抗菌EX 洗濯洗剤 液体 つめかえ用",
+      "price": 1404,
+      "category": "日用品",
+      "reason": "100日間蓄積した黄ばみも強力に洗浄し、24時間抗菌防臭効果のある液体洗剤です。",
+      "whyBuyNow": "梅雨の部屋干し臭対策の必需品として需要が急増しており、マイベストでも高い評価を得ている定番洗剤です。",
+      "rankReason": "梅雨の部屋干し対策",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "マイベスト 酸素系漂白剤・洗濯洗剤",
         "url": "https://my-best.com/1126"
       },
       "highlights": [
-        "強力な漂白・消臭",
-        "部屋干し臭を防ぐ",
-        "大容量で経済的"
+        "蓄積した黄ばみも強力洗浄",
+        "24時間抗菌で臭いを防ぐ",
+        "大容量2500gでお得"
       ],
-      "url": "https://www.amazon.co.jp/dp/B099MTRBD4/",
-      "imageUrl": "https://m.media-amazon.com/images/I/51iCO-+4UfL._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B0FFN1RB6J/",
+      "imageUrl": "https://m.media-amazon.com/images/I/51EBBX-71wL._SL500_.jpg"
+    },
+    {
+      "asin": "B07D6GXJQQ",
+      "title": "Nutro シュプレモ 小型犬用 成犬用 3kg",
+      "price": 5202,
+      "category": "ペット用品",
+      "reason": "厳選された自然素材を使用し、小型犬の健康な体作りに適した栄養バランスのドッグフードです。",
+      "whyBuyNow": "マイベストのドッグフードランキングでも評価が高く、ペットの健康管理に欠かせない高品質なフードです。",
+      "rankReason": "愛犬の健康管理に",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "マイベスト ドッグフードおすすめランキング",
+        "url": "https://my-best.com/131"
+      },
+      "highlights": [
+        "厳選自然素材を使用",
+        "小型犬に合わせた小粒",
+        "最適な栄養バランス"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B07D6GXJQQ/",
+      "imageUrl": "https://m.media-amazon.com/images/I/41yBtGAfscL._SL500_.jpg"
     },
     {
       "asin": "B0CQX67KTW",
-      "title": "Anker Power Bank (10000mAh, 22.5W) (モ...",
-      "price": 3490,
-      "category": "モバイルバッテリー",
-      "reason": "スマートフォンを複数回フル充電できるコンパクトかつ大容量なモバイルバッテリーです。",
-      "whyBuyNow": "マイベストのバッテリー特集で定番商品として紹介されており、夏の旅行やイベントの際のスマホ充電用として必須です。",
-      "rankReason": "旅行の必需品",
+      "title": "Anker Power Bank (10000mAh, 22.5W)",
+      "price": 3100,
+      "category": "PC周辺機器",
+      "reason": "スマートフォンを約2回充電できる大容量ながら、薄型コンパクトで持ち運びに便利なモバイルバッテリーです。",
+      "whyBuyNow": "夏のお出かけや旅行などの長時間の外出時にスマートフォンのバッテリー切れを防ぐ必需品として評価されています。",
+      "rankReason": "お出かけの必需品",
       "scoreDisclaimer": null,
       "source": {
-        "name": "マイベスト モバイルバッテリー",
+        "name": "マイベスト モバイルバッテリーランキング",
         "url": "https://my-best.com/6044"
       },
       "highlights": [
         "10000mAhの大容量",
-        "軽量・コンパクト",
-        "Ankerの信頼性"
+        "世界最薄クラスの設計",
+        "最大22.5W急速充電"
       ],
       "url": "https://www.amazon.co.jp/dp/B0CQX67KTW/",
       "imageUrl": "https://m.media-amazon.com/images/I/31HITWDgArL._SL500_.jpg"
     },
     {
-      "asin": "B06XF9NSFK",
-      "title": "チャオ (CIAO) ちゅ~る まぐろバラエティ 14g×20本 猫用おやつ",
-      "price": 781,
-      "category": "ペット用品",
-      "reason": "猫が夢中になる美味しさで、手軽に水分補給もできる液状の定番おやつです。",
-      "whyBuyNow": "マイベストのおやつランキングでも定番。暑さで食欲が落ちがちなペットへの水分補給やご褒美として最適です。",
-      "rankReason": "ペットの定番おやつ",
+      "asin": "B0GCJBQ6T2",
+      "title": "コードレス掃除機 軽量 ハンディークリーナー",
+      "price": 5980,
+      "category": "生活家電",
+      "reason": "28000paの超強力吸引と0.6kgの超軽量ボディを両立したコードレス掃除機です。",
+      "whyBuyNow": "湿気が多くホコリが溜まりやすい季節に、手軽に家中を掃除できる軽量クリーナーとしてAmazonランキングでも人気です。",
+      "rankReason": "手軽な掃除に最適",
       "scoreDisclaimer": null,
       "source": {
-        "name": "マイベスト キャットフード",
-        "url": "https://my-best.com/5135"
+        "name": "Amazon スティッククリーナー売れ筋",
+        "url": "https://www.amazon.co.jp/gp/bestsellers/kitchen/3238692051"
       },
       "highlights": [
-        "猫が喜ぶ美味しさ",
-        "水分補給に便利",
-        "定番のちゅーる"
+        "28KPaの強力な吸引力",
+        "わずか0.6kgの超軽量",
+        "多機能アタッチメント付属"
       ],
-      "url": "https://www.amazon.co.jp/dp/B06XF9NSFK/",
-      "imageUrl": "https://m.media-amazon.com/images/I/51BXCQWZtnL._SL500_.jpg"
+      "url": "https://www.amazon.co.jp/dp/B0GCJBQ6T2/",
+      "imageUrl": "https://m.media-amazon.com/images/I/41xbLYnxfHL._SL500_.jpg"
+    },
+    {
+      "asin": "B00QQKCV6E",
+      "title": "エッセンシャル思考 最少の時間で成果を最大にする",
+      "price": 1584,
+      "category": "書籍",
+      "reason": "「より少なく、しかしより良く」を追求する思考法を解説したベストセラーです。",
+      "whyBuyNow": "下半期に向けて仕事や生活の生産性を見直すタイミングであり、各種ビジネス書ランキングでも長年トップセラーを維持する名著です。",
+      "rankReason": "生産性向上の名著",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "Amazon ビジネス・経済ランキング",
+        "url": "https://www.amazon.co.jp/gp/bestsellers/books/466282"
+      },
+      "highlights": [
+        "生産性を飛躍的に高める",
+        "ベストセラービジネス書",
+        "働き方の見直しに最適"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B00QQKCV6E/",
+      "imageUrl": "https://m.media-amazon.com/images/I/51wXGl5-leL._SL500_.jpg"
+    },
+    {
+      "asin": "B079S1WB7S",
+      "title": "オルナ オーガニック ヘアオイル",
+      "price": 1760,
+      "category": "コスメ・美容",
+      "reason": "植物オイルが髪に素早く浸透し、潤いとツヤを与えるオーガニック成分配合のヘアオイルです。",
+      "whyBuyNow": "マイベストなどの美容ランキングで上位にあり、梅雨の湿気で広がる髪のケアに今すぐ取り入れたい商品です。",
+      "rankReason": "梅雨のヘアケアに",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "マイベスト ヘアオイルおすすめ",
+        "url": "https://my-best.com/264"
+      },
+      "highlights": [
+        "オーガニック成分配合",
+        "ベタつかずサラサラな仕上がり",
+        "熱から髪を守る処方"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B079S1WB7S/",
+      "imageUrl": "https://m.media-amazon.com/images/I/41an7pUJaZL._SL500_.jpg"
+    },
+    {
+      "asin": "B0DCVMD3ZK",
+      "title": "EdoErgo オフィスチェア",
+      "price": 6280,
+      "category": "家具・インテリア",
+      "reason": "人間工学に基づいたランバーサポートと通気性の高いメッシュ素材を採用したオフィスチェアです。",
+      "whyBuyNow": "マイベストのオフィスチェア特集でも注目され、在宅ワーク環境の改善と蒸し暑い季節の対策に最適です。",
+      "rankReason": "快適な作業環境構築",
+      "scoreDisclaimer": null,
+      "source": {
+        "name": "マイベスト オフィスチェアおすすめ",
+        "url": "https://my-best.com/2026"
+      },
+      "highlights": [
+        "人間工学設計で腰をサポート",
+        "跳ね上げ式アームレスト",
+        "通気性抜群のメッシュ生地"
+      ],
+      "url": "https://www.amazon.co.jp/dp/B0DCVMD3ZK/",
+      "imageUrl": "https://m.media-amazon.com/images/I/41R1sqLAqRL._SL500_.jpg"
     }
   ],
   "searchContext": {
-    "todayOverview": "本日は、各種レビューサイト（マイベスト、カジェログ等）にて高く評価されている、夏本番に向けた実用品・日用品や、休日に楽しみたいエンタメ、そして最新ガジェットなどを幅広く10ジャンルから選定しました。",
+    "todayOverview": "本日は、本格的な夏に向けた準備や梅雨対策に焦点を当てました。熱中症対策としての飲料水やサーキュレーター、部屋干し用洗剤、さらに通気性の良いオフィスチェアなど、今の時期の必需品を幅広く選定。各種レビューサイトやランキング上位の確かな実績を持つ商品です。",
     "searchedCategories": [
-      "日焼け止め",
-      "タンブラー",
+      "家電",
+      "タブレット",
       "飲料・水",
-      "ミステリー小説",
-      "空調服",
-      "韓国ドラマ",
-      "オーディオ",
-      "洗濯洗剤",
-      "モバイルバッテリー",
-      "ペット用品"
+      "日用品",
+      "ペット用品",
+      "PC周辺機器",
+      "生活家電",
+      "書籍",
+      "コスメ・美容",
+      "家具・インテリア"
     ]
   }
 }


### PR DESCRIPTION
本日（2026-06-17）の「今買うべき」おすすめ10選の調査を完了し、`data/recommendations/today.json`を更新しました。

- 多様な10のカテゴリ（生活家電、タブレット、飲料水、洗濯洗剤、ペット用品、PC周辺機器、家具など）から商品を厳選しました。
- 各商品について「なぜ今日おすすめするのか（whyBuyNow）」と「その客観的な根拠（source: 情報元URL）」を具体的に明記しました。
- `validate_artifact.py`で構造およびURLの死活チェックを実施し、リンク切れがないことを確認しました。
- 他の一時ファイルやスクリプトは削除し、リポジトリに変更が含まれないようにしています。

---
*PR created automatically by Jules for task [16897370972694396890](https://jules.google.com/task/16897370972694396890) started by @aegisfleet*