### PR TITLE
Investigate Elecom Kids PC Glasses (B08JGSTK59)

### DIFF
--- a/data/investigations/B08JGSTK59.json
+++ b/data/investigations/B08JGSTK59.json
@@ -1,0 +1,118 @@
+{
+  "analysis": {
+    "productName": "エレコム キッズ用ブルーライトカット眼鏡 低学年向 Sサイズ",
+    "parentAsin": "B08JGSTK59",
+    "productDescription": "お子様の目を守る、ブルーライトを約50%カットする低学年向けのキッズ用PC眼鏡です。超軽量で弾力性のある「TR-90」素材を採用し、衝撃に強いレンズを使用しています。",
+    "productUsage": [
+      "タブレット学習やゲーム時の目の保護",
+      "スマートフォン利用時のブルーライト対策"
+    ],
+    "positivePoints": [
+      "ブルーライトを約50%しっかりカットし目の負担を軽減する",
+      "超軽量・弾力素材（TR-90）で長時間かけても耳が痛くなりにくい",
+      "衝撃に強く割れにくいレンズでお子様でも安全",
+      "鼻パッドがフレームと一体成形で変形や破損のリスクが少ない"
+    ],
+    "negativePoints": [
+      "Sサイズ（低学年向け）のため、成長によりサイズアウトする可能性がある"
+    ],
+    "useCases": [
+      "学校のタブレット学習",
+      "自宅でのゲームや動画視聴"
+    ],
+    "userStories": [],
+    "userImpression": "お子様のタブレット学習やゲーム時の目の保護を目的とした製品で、軽量性や割れにくい設計により安全性が高く評価できる作りとなっています。",
+    "sources": [
+      {
+        "id": "src-amazon",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B08JGSTK59",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2020-10-04",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "商品の基本仕様や特徴（ブルーライトカット率、TR-90素材、重量など）を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "ブルーライトを約50%カット",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon"],
+        "crossChecked": false,
+        "notes": "公式の商品説明に記載"
+      },
+      {
+        "claim": "超軽量弾力素材「TR-90」を採用",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": ["src-amazon"],
+        "crossChecked": false,
+        "notes": "公式の商品説明に記載"
+      }
+    ],
+    "lastInvestigated": "2026-06-17",
+    "competitiveAnalysis": [
+      {
+        "name": "BEATON JAPAN キッズ ブルーライトカットメガネ",
+        "asin": "B07SLHBQH2",
+        "priceComparison": "対象商品とほぼ同等の価格帯です。",
+        "featureComparison": [
+          "共通点：子供向けのブルーライトカット眼鏡である点",
+          "相違点：対象商品はエレコム製で鼻パッド一体型やTR-90採用など堅牢な作りが特徴ですが、競合商品はJIS規格検査認証を強調しています。"
+        ],
+        "differentiators": [
+          "エレコム キッズ用ブルーライトカット眼鏡 低学年向 Sサイズの利点：国内大手メーカー製であり、超軽量弾力素材や一体成型の鼻パッドなど、子供の使用に特化した安全設計が魅力です。",
+          "BEATON JAPAN キッズ ブルーライトカットメガネの利点：JIS規格検査認証済という明確な基準を重視する場合に適しています。"
+        ]
+      },
+      {
+        "name": "ekubo キッズ用 ブルーライトカットメガネ",
+        "asin": "B098KGR7Q7",
+        "priceComparison": "対象商品よりやや高い価格帯です。",
+        "featureComparison": [
+          "共通点：子供向けにブルーライトカットを目的としたPC眼鏡である点",
+          "相違点：対象商品は低学年向け（6〜8歳）に特化していますが、競合商品は3歳〜12歳までと幅広い年齢層を対象にしています。"
+        ],
+        "differentiators": [
+          "エレコム キッズ用ブルーライトカット眼鏡 低学年向 Sサイズの利点：対象年齢（6〜8歳）に絞ったサイズ設計と、大手メーカーならではの安心感があります。",
+          "ekubo キッズ用 ブルーライトカットメガネの利点：年齢幅が広いため、長く使いたい場合や兄弟で使い回したい場合に適しています。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "小学校低学年（6〜8歳）のお子様",
+        "タブレット学習やゲームをよくするお子様"
+      ],
+      "pros": [
+        "ブルーライト50%カットで目を保護",
+        "TR-90素材により軽量で壊れにくい",
+        "鼻パッド一体成型で安全性が高い"
+      ],
+      "cons": [
+        "対象年齢が狭いため、成長に合わせて買い替えが必要"
+      ],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +2] (国内大手メーカーによる高い信頼性)\n[加点: +3] (TR-90素材や一体成型の鼻パッドによる高い安全性)\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "不明",
+        "width": "不明",
+        "depth": "不明"
+      },
+      "weight": "約17g",
+      "capacity": "1個",
+      "material": "TR-90（テンプル部）",
+      "origin": "不明",
+      "other": [
+        "対象年齢: 6〜8歳（低学年向け）",
+        "ブルーライトカット率: 約50%",
+        "付属品: 収納ポーチ"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds investigation data for Elecom kids PC glasses B08JGSTK59. Converts weight from pounds to grams, collects competitor information, formats findings strictly as requested, and implements accurate score formatting rules.

---
*PR created automatically by Jules for task [4305133702227020461](https://jules.google.com/task/4305133702227020461) started by @aegisfleet*