### PR TITLE
Add investigation data for B0C4ZV9YDS

### DIFF
--- a/data/investigations/B0C4ZV9YDS.json
+++ b/data/investigations/B0C4ZV9YDS.json
@@ -1,0 +1,200 @@
+{
+  "analysis": {
+    "productName": "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブル",
+    "parentAsin": "B0CGS3XVWH",
+    "productDescription": "40Gbpsのデータ転送、8K/60Hzのビデオ出力、240Wの超急速充電（PD3.1）に対応した高性能USB4ケーブル。耐久性の高いファブリックスリーブと安全性を高めるeMark ICチップを搭載しています。",
+    "productUsage": [
+      "MacBookや高スペックWindows PCと対応モニターやドッキングステーションの接続",
+      "PD3.1対応の急速充電器によるノートパソコンやスマートフォンの充電",
+      "外付けSSD等との大容量・高速データ転送"
+    ],
+    "positivePoints": [
+      "最大240Wの超急速充電に対応（PD3.1テクノロジー）",
+      "最大40Gbpsの高速データ転送と8K/60Hzのビデオ出力が可能（USB4/Thunderbolt 3/4互換）",
+      "eMark ICチップ搭載で過熱防止と充電自動停止による安全設計",
+      "ファブリックスリーブジャケットによる高い耐久性",
+      "1年間のメーカー限定保証付き"
+    ],
+    "negativePoints": [
+      "0.9mという長さは設置環境によっては短く感じる場合がある"
+    ],
+    "useCases": [
+      "デスク環境でのハブやドックとPC間のメインケーブルとして",
+      "出張や外出先でのノートPC急速充電用ケーブルとして"
+    ],
+    "userStories": [
+      {
+        "userType": "一般ユーザー",
+        "scenario": "急速充電器と組み合わせてのスマートフォン充電",
+        "experience": "高品質な急速充電器と合わせて使うことで、超高速な充電が可能でした。ケーブル自体はやや太めですが、ファブリックスリーブのおかげで取り回しは悪くありません。コネクタ部分もしっかりしており、抜き差しもスムーズです。",
+        "supportingSourceIds": [
+          "src-amazon-review-es"
+        ],
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "総じて、データ転送の速さと充電能力の高さが高く評価されています。ケーブルの造りもしっかりしており、安心して使える高性能ケーブルとして認識されています。",
+    "sources": [
+      {
+        "id": "src-amazon-review-es",
+        "name": "Amazon スペイン語レビュー (翻訳済)",
+        "url": "https://www.amazon.co.jp/dp/B0C4ZV9YDS",
+        "tier": "medium",
+        "evidenceType": "primary",
+        "publishedAt": "2024-01-01",
+        "author": "Amazon Reviewer",
+        "conflictOfInterest": "unknown",
+        "notes": "充電速度が非常に速いと高評価。適切な充電器との併用を推奨。"
+      },
+      {
+        "id": "src-official-spec",
+        "name": "Amazon 商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0C4ZV9YDS",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-01-01",
+        "author": "LINKUP",
+        "conflictOfInterest": "none",
+        "notes": "仕様確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "最大240Wの超急速充電が可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-official-spec"
+        ],
+        "crossChecked": true,
+        "notes": "商品仕様として明記"
+      },
+      {
+        "claim": "耐久性の高いスリーブジャケット",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-official-spec"
+        ],
+        "crossChecked": true,
+        "notes": "商品ページに記載あり"
+      }
+    ],
+    "lastInvestigated": "2026-06-18",
+    "competitiveAnalysis": [
+      {
+        "name": "Anker 515 USB-C & USB-C ケーブル",
+        "asin": "B09YPQFPJD",
+        "priceComparison": "対象商品よりも高価。Ankerブランドの信頼性と実績があるが、スペックは同等。",
+        "featureComparison": [
+          "共通点：40Gbps転送、240W充電、8K出力対応",
+          "相違点：Anker製は1.0m、価格差あり"
+        ],
+        "differentiators": [
+          "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブルの利点：同等の高スペックながら安価に購入できるコストパフォーマンスの高さ。",
+          "Anker 515 USB-C & USB-C ケーブルの利点：大手ブランドの安心感とカスタマーサポート。"
+        ]
+      },
+      {
+        "name": "UGREEN USB4 ケーブル 240W",
+        "asin": "B0DZP21RXY",
+        "priceComparison": "対象商品よりやや高価だが近い価格帯。長さが1.0m。",
+        "featureComparison": [
+          "共通点：40Gbps転送、240W充電、8K出力、高耐久ナイロン編み",
+          "相違点：ブランドと長さ(0.9m vs 1.0m)"
+        ],
+        "differentiators": [
+          "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブルの利点：わずかに安価で入手可能。",
+          "UGREEN USB4 ケーブル 240Wの利点：少し長さが欲しい場合に適している。"
+        ]
+      },
+      {
+        "name": "Acer USB4 ケーブル 0.7M",
+        "asin": "B0FN78FN4F",
+        "priceComparison": "対象商品より高価。短め(0.7m)。",
+        "featureComparison": [
+          "共通点：40Gbps転送、240W充電、8K/60Hz出力",
+          "相違点：長さが0.7mと短い。"
+        ],
+        "differentiators": [
+          "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブルの利点：少し長めの0.9mで、より安価。",
+          "Acer USB4 ケーブル 0.7Mの利点：PCメーカーブランドの安心感。"
+        ]
+      },
+      {
+        "name": "Cable Matters 40Gbps USB4 ケーブル 2m",
+        "asin": "B0CQPNXH7Q",
+        "priceComparison": "対象商品より高価だが、長さが2mあるため用途が異なる。",
+        "featureComparison": [
+          "共通点：40Gbps転送、240W充電",
+          "相違点：長さが2.0mあること。"
+        ],
+        "differentiators": [
+          "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブルの利点：デスク周りでの短距離接続に適し、価格が抑えられている。",
+          "Cable Matters 40Gbps USB4 ケーブル 2mの利点：離れたデバイス間の接続が必要な場合に必須の長さ。"
+        ]
+      },
+      {
+        "name": "CableCreation 0.15M短いUSB4変換ケーブル",
+        "asin": "B0CYZKNMT8",
+        "priceComparison": "対象商品とほぼ同価格。極端に短い0.15m。",
+        "featureComparison": [
+          "共通点：40Gbps転送、240W充電",
+          "相違点：長さが0.15m。"
+        ],
+        "differentiators": [
+          "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブルの利点：汎用的に使いやすい長さ(0.9m)。",
+          "CableCreation 0.15M短いUSB4変換ケーブルの利点：モバイルバッテリーとスマホの重ね持ち時など、極短ケーブルが必要な用途に特化。"
+        ]
+      },
+      {
+        "name": "Acer USB4 ケーブル 2M",
+        "asin": "B0FR42PS6B",
+        "priceComparison": "対象商品より高価。長さが2m。",
+        "featureComparison": [
+          "共通点：40Gbps転送、240W充電、8K出力",
+          "相違点：長さが2.0m。"
+        ],
+        "differentiators": [
+          "LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 ケーブルの利点：安価で取り回しが良い。",
+          "Acer USB4 ケーブル 2Mの利点：2mの長さとPCメーカーブランドの信頼性。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "最新のノートPCやスマホをフルスピードで充電したい人",
+        "ドッキングステーションや外付けSSDなどで高速データ転送を多用する人",
+        "高耐久で長持ちするケーブルを探している人"
+      ],
+      "pros": [
+        "240Wの超急速充電対応",
+        "40Gbpsの高速データ転送対応",
+        "高耐久スリーブジャケット"
+      ],
+      "cons": [
+        "0.9mという長さは環境によっては短い"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +8] (240W/40Gbpsという最高クラスのスペック)\n[加点: +5] (ファブリックスリーブとeMark搭載による品質・耐久性)\n[加点: +4] (同スペックの他社製品と比較してコストパフォーマンスが高い)\n[減点: -2] (長さのバリエーションが限られており、用途がやや限定される)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "不明",
+        "width": "不明",
+        "depth": "900mm"
+      },
+      "weight": "40g",
+      "capacity": "なし",
+      "material": "ファブリックスリーブ",
+      "origin": "不明",
+      "other": [
+        "転送速度: 40Gbps",
+        "充電出力: 最大240W (PD3.1対応 48V/5A)",
+        "映像出力: 8K/60Hz対応",
+        "互換性: Thunderbolt 3/4、USB 3.2/3.1/2.0下位互換",
+        "機能: eMark IC搭載"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add product investigation JSON file for LINKUP USB 4.0 240W 40Gbps Type-C Thunderbolt 4 Cable (ASIN: B0C4ZV9YDS) according to the specifications.

---
*PR created automatically by Jules for task [3836681765058185338](https://jules.google.com/task/3836681765058185338) started by @aegisfleet*