### PR TITLE
Add investigation result for B0CZNG4VCL

### DIFF
--- a/data/investigations/B0CZNG4VCL.json
+++ b/data/investigations/B0CZNG4VCL.json
@@ -1,0 +1,171 @@
+{
+  "analysis": {
+    "productName": "SUMPK USB4 Type-C ケーブル 1m",
+    "parentAsin": "B0CCMC9548",
+    "productDescription": "最大240Wの急速充電と40Gbpsの高速データ転送、8K映像出力に対応したUSB4 Type-Cケーブル。",
+    "productUsage": [
+      "ノートパソコンやスマートフォンの急速充電",
+      "大容量データの高速転送",
+      "8K対応モニターへの映像出力"
+    ],
+    "positivePoints": [
+      "最大240Wの高出力充電に対応",
+      "40Gbpsの超高速データ転送",
+      "単8K/デュアル4Kの高解像度映像出力",
+      "E-markerチップ内蔵による安全な充電",
+      "コストパフォーマンスが非常に高い"
+    ],
+    "negativePoints": [
+      "耐久性やケーブルの素材に関する詳細な記載がない"
+    ],
+    "useCases": [
+      "大容量の動画ファイルを短時間でPCに転送する",
+      "MacBookを外部の4K/8Kディスプレイに接続して作業領域を広げる",
+      "出張先やカフェでノートパソコンを素早く充電する"
+    ],
+    "userStories": [],
+    "userImpression": "非常に安価でありながら240W/40Gbps/8K出力といった最新スペックを満たすコストパフォーマンスの高いケーブル。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0CZNG4VCL",
+        "tier": "medium",
+        "evidenceType": "primary",
+        "publishedAt": "2026-06-18",
+        "author": "SUMPK",
+        "conflictOfInterest": "possible",
+        "notes": "製品スペック、価格、機能説明を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "240Wの急速充電に対応している",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-1"],
+        "crossChecked": false,
+        "notes": "公式スペックに記載あり"
+      },
+      {
+        "claim": "40Gbpsのデータ転送に対応している",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-1"],
+        "crossChecked": false,
+        "notes": "公式スペックに記載あり"
+      },
+      {
+        "claim": "8K@60Hzおよびデュアル4K@60Hzの映像出力に対応している",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": ["src-1"],
+        "crossChecked": false,
+        "notes": "公式スペックに記載あり"
+      }
+    ],
+    "lastInvestigated": "2026-06-18",
+    "competitiveAnalysis": [
+      {
+        "name": "Amazonベーシック USB-C - USB-C 4 ケーブル",
+        "asin": "B0C93G2M83",
+        "priceComparison": "対象商品の方が安い。",
+        "featureComparison": [
+          "共通点：240W充電、40Gbps転送、8K出力対応",
+          "相違点：AmazonベーシックはUSB-IF認証を取得している"
+        ],
+        "differentiators": [
+          "SUMPK USB4 Type-C ケーブル 1mの利点：価格がより安い",
+          "Amazonベーシック USB-C - USB-C 4 ケーブルの利点：USB-IF認証取得済みで信頼性が高い"
+        ]
+      },
+      {
+        "name": "Anker 515 USB-C & USB-C ケーブル",
+        "asin": "B09YPQFPJD",
+        "priceComparison": "対象商品の方が大幅に安い。Ankerはブランド力が価格に反映されている。",
+        "featureComparison": [
+          "共通点：240W充電、40Gbps転送、8K出力対応",
+          "相違点：Ankerは5000回の折り曲げ耐性など耐久性をアピールしており、保証も充実している"
+        ],
+        "differentiators": [
+          "SUMPK USB4 Type-C ケーブル 1mの利点：圧倒的に安い",
+          "Anker 515 USB-C & USB-C ケーブルの利点：大手ブランドの安心感と充実したサポート"
+        ]
+      },
+      {
+        "name": "KHkuahai Thunderbolt 4 ケーブル",
+        "asin": "B0FYYKZDH1",
+        "priceComparison": "対象商品の方が安い。",
+        "featureComparison": [
+          "共通点：240W充電、40Gbps転送、8K出力対応",
+          "相違点：KHkuahaiはナイロン編組ケーブルを採用している可能性がある"
+        ],
+        "differentiators": [
+          "SUMPK USB4 Type-C ケーブル 1mの利点：価格が安い",
+          "KHkuahai Thunderbolt 4 ケーブルの利点：幅広い機器との互換性をアピール"
+        ]
+      },
+      {
+        "name": "Cable Matters 40Gbps USB4 延長ケーブル",
+        "asin": "B0CNY9NJ4B",
+        "priceComparison": "対象商品の方が安いが、こちらは延長用ケーブルであるため用途が異なる。",
+        "featureComparison": [
+          "共通点：240W充電、40Gbps転送対応",
+          "相違点：対象商品はオス-オス、競合はオス-メスの延長ケーブル"
+        ],
+        "differentiators": [
+          "SUMPK USB4 Type-C ケーブル 1mの利点：通常のデバイス間接続に最適で安価",
+          "Cable Matters 40Gbps USB4 延長ケーブルの利点：既存のケーブルを延長できる"
+        ]
+      },
+      {
+        "name": "surola USB-C & USB-C ケーブル 1M",
+        "asin": "B0BKG67652",
+        "priceComparison": "対象商品とほぼ同等の価格帯。",
+        "featureComparison": [
+          "共通点：240W充電、40Gbps転送、8K出力対応",
+          "相違点：surolaは高耐久ナイロン編組を明記している"
+        ],
+        "differentiators": [
+          "SUMPK USB4 Type-C ケーブル 1mの利点：わずかに価格が安い場合がある",
+          "surola USB-C & USB-C ケーブル 1Mの利点：ナイロン編組で耐久性が高い"
+        ]
+      },
+      {
+        "name": "XAOSUN USB4 ケーブル L字",
+        "asin": "B0BF9T8LX1",
+        "priceComparison": "対象商品の方が安い。",
+        "featureComparison": [
+          "共通点：240W充電、40Gbps転送、8K出力対応",
+          "相違点：XAOSUNは片側のコネクタがL字型になっている"
+        ],
+        "differentiators": [
+          "SUMPK USB4 Type-C ケーブル 1mの利点：価格が安い",
+          "XAOSUN USB4 ケーブル L字の利点：L字型コネクタで取り回しが良い"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "コストパフォーマンスを重視するユーザー",
+        "最新スペック(240W/40Gbps)のケーブルを安価に試したいユーザー"
+      ],
+      "pros": [
+        "非常に安価",
+        "最高クラスのスペック（240W充電、40Gbps転送、8K出力）"
+      ],
+      "cons": [
+        "ブランドの知名度が低く、耐久性に懸念が残る"
+      ],
+      "score": 90,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (同スペックの競合製品と比較して圧倒的に価格が安く、コストパフォーマンスが高い)\n[加点: +10] (240W、40Gbps、8K出力という最高クラスの性能を備えている)\n[合計: 90]"
+    },
+    "technicalSpecs": {
+      "length": "1m",
+      "powerDelivery": "最大240W (48V/5A)",
+      "dataTransferSpeed": "最大40Gbps",
+      "videoOutput": "単8K@60Hz / デュアル4K@60Hz",
+      "features": ["E-markerチップ内蔵", "DP Altモード対応"]
+    }
+  }
+}


### PR DESCRIPTION
SUMPK USB4 Type-C ケーブル 1m (B0CZNG4VCL) の調査結果を `data/investigations/B0CZNG4VCL.json` に追加しました。
公式スペックに基づく機能的利点と、コストパフォーマンスの高さを競合製品と比較し評価しています。ハルシネーションルールに従い、信頼できるエビデンスのないユーザーストーリーは除外しています。

---
*PR created automatically by Jules for task [10283394395261792995](https://jules.google.com/task/10283394395261792995) started by @aegisfleet*