### PR TITLE
Add investigation data for B0FJ1JTL44

### DIFF
--- a/data/investigations/B0FJ1JTL44.json
+++ b/data/investigations/B0FJ1JTL44.json
@@ -1,0 +1,180 @@
+{
+  "analysis": {
+    "productName": "シャープ 除加湿空気清浄機 KI-TD50-W",
+    "parentAsin": "B0FJ1JTL44",
+    "productDescription": "衣類乾燥、除湿、加湿、空気清浄の4役を1台でこなすシャープのプラズマクラスター25000搭載除加湿空気清浄機。",
+    "productUsage": [
+      "部屋の空気清浄",
+      "梅雨時期の除湿・部屋干し",
+      "冬場の加湿"
+    ],
+    "positivePoints": [
+      "除湿・加湿・空気清浄・衣類乾燥の4役を1台でこなせる",
+      "プラズマクラスター25000搭載で高い空気浄化能力",
+      "スイングルーバー搭載で衣類乾燥にも効果的",
+      "キャスター付きで移動が容易"
+    ],
+    "negativePoints": [
+      "多機能な分、本体サイズがやや大きく重い可能性がある"
+    ],
+    "useCases": [
+      "梅雨時の部屋干しと除湿",
+      "冬の乾燥対策としての加湿",
+      "花粉・PM2.5対策としての空気清浄"
+    ],
+    "userStories": [],
+    "userImpression": "1台4役の多機能性とプラズマクラスター25000による高い空気浄化能力が特徴。一年中出しっぱなしで使える点が評価できる。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon B0FJ1JTL44 商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0FJ1JTL44",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-06-21",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "製品仕様、価格、機能を確認"
+      },
+      {
+        "id": "src-2",
+        "name": "価格.com シャープ KI-TD50-W",
+        "url": "https://search.kakaku.com/KI-TD50-W/",
+        "tier": "medium",
+        "evidenceType": "secondary",
+        "publishedAt": "2026-06-21",
+        "author": "価格.com",
+        "conflictOfInterest": "none",
+        "notes": "市場価格帯（約37,760円～56,870円）や取り扱い店舗数を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "除湿・加湿・空気清浄の多機能モデル",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": true,
+        "notes": "Amazonの公式スペック情報から確認"
+      }
+    ],
+    "lastInvestigated": "2026-06-21",
+    "competitiveAnalysis": [
+      {
+        "name": "シャープ KI-SD50-W",
+        "asin": "B0D8KJ4PVQ",
+        "priceComparison": "対象商品と同等かやや安い価格帯",
+        "featureComparison": [
+          "共通点：除加湿空気清浄機としての基本性能、プラズマクラスター25000搭載",
+          "相違点：KI-SD50-Wは前年モデル。基本機能はほぼ同等"
+        ],
+        "differentiators": [
+          "KI-TD50-Wの利点：最新モデルとしての安心感",
+          "KI-SD50-Wの利点：型落ちによる価格的メリットがある場合がある"
+        ]
+      },
+      {
+        "name": "シャープ KI-PD50-W",
+        "asin": "B0B2L3DBQY",
+        "priceComparison": "対象商品よりやや高い価格帯（Amazon内比較）",
+        "featureComparison": [
+          "共通点：プラズマクラスター25000搭載、空気清浄21畳対応",
+          "相違点：発売年が異なる"
+        ],
+        "differentiators": [
+          "KI-TD50-Wの利点：最新モデルで価格も手頃",
+          "KI-PD50-Wの利点：過去モデルで実績がある"
+        ]
+      },
+      {
+        "name": "ダイキン MCZ706A-T",
+        "asin": "B0FLWK72DR",
+        "priceComparison": "対象商品よりかなり高価（19万円台）",
+        "featureComparison": [
+          "共通点：除加湿機能付き空気清浄機",
+          "相違点：ダイキンは適用床面積が32畳と広く、ツインストリーマ搭載などのプレミアム機能を持つ"
+        ],
+        "differentiators": [
+          "KI-TD50-Wの利点：コストパフォーマンスに優れ、手軽に導入できる",
+          "ダイキン MCZ706A-Tの利点：広い部屋に対応し、より高度な清浄機能・連動機能を求める場合に適している"
+        ]
+      },
+      {
+        "name": "シャープ KI-RD50-W",
+        "asin": "B0D1K2KRL1",
+        "priceComparison": "対象商品とほぼ同等の価格帯",
+        "featureComparison": [
+          "共通点：除加湿空気清浄機、プラズマクラスター25000搭載",
+          "相違点：発売年次によるモデル違い"
+        ],
+        "differentiators": [
+          "KI-TD50-Wの利点：最新モデルのメリット",
+          "KI-RD50-Wの利点：機能的に大きな差はなく、セール時などに安価であれば狙い目"
+        ]
+      },
+      {
+        "name": "シャープ KI-LD50-W",
+        "asin": "B0876MZ6RY",
+        "priceComparison": "対象商品よりやや高い（Amazon内比較）",
+        "featureComparison": [
+          "共通点：プラズマクラスター25000搭載、除加湿対応",
+          "相違点：旧モデルである"
+        ],
+        "differentiators": [
+          "KI-TD50-Wの利点：新モデルでありながら価格が抑えられている",
+          "KI-LD50-Wの利点：特になし（新モデルのKI-TD50の方が安価であるため）"
+        ]
+      },
+      {
+        "name": "シャープ KI-ND50-W",
+        "asin": "B092J2B1XB",
+        "priceComparison": "対象商品よりやや高い（Amazon内比較）",
+        "featureComparison": [
+          "共通点：プラズマクラスター25000搭載、除湿5L・空気清浄21畳",
+          "相違点：旧モデル"
+        ],
+        "differentiators": [
+          "KI-TD50-Wの利点：新モデルで価格競争力がある",
+          "KI-ND50-Wの利点：機能差は少なく、在庫処分などで安ければ選択肢となる"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "1台で除湿・加湿・空気清浄を済ませたい方",
+        "部屋干しをよくする方"
+      ],
+      "pros": [
+        "1台4役の多機能性",
+        "プラズマクラスター25000搭載",
+        "キャスター付きで移動がラク"
+      ],
+      "cons": [
+        "機能が多い分、手入れ箇所が多い可能性がある",
+        "単機能モデルに比べて本体サイズが大きめ"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (1台で除湿・加湿・空気清浄・衣類乾燥が可能な高い実用性)\n[加点: +5] (プラズマクラスター25000による空気浄化機能)\n[加点: +5] (楽天など他サイトと比較してもAmazon価格が3万円台とコストパフォーマンスが良好)\n[減点: -5] (多機能ゆえに手入れの手間が想定される点)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "// 注意": "調査で判明した仕様情報をここに網羅的に記載する（サイズはメートル法のみ、インチ不要）",
+      "dimensions": {
+        "height": "656mm",
+        "width": "350mm",
+        "depth": "285mm"
+      },
+      "weight": "約13kg",
+      "capacity": "除湿量: 5.0/5.6L/日(50/60Hz), 加湿量: 最大400mL/h",
+      "material": "不明",
+      "origin": "不明",
+      "other": [
+        "おすすめ畳数（プラズマクラスター）: ～10畳",
+        "空気清浄適用床面積: ～21畳",
+        "運転音: 23～54dB",
+        "除湿方式: コンプレッサー方式"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added the analysis data for B0FJ1JTL44 including competitive analysis and scoring in `data/investigations/B0FJ1JTL44.json`.

---
*PR created automatically by Jules for task [366343757164699567](https://jules.google.com/task/366343757164699567) started by @aegisfleet*