### PR TITLE
Investigate B0DBHRWRKC (Xiaomi Redmi buds 6 Play)

### DIFF
--- a/data/investigations/B0DBHRWRKC.json
+++ b/data/investigations/B0DBHRWRKC.json
@@ -1,0 +1,242 @@
+{
+  "analysis": {
+    "productName": "Xiaomi Redmi buds 6 Play",
+    "parentAsin": "B0DBHRWRKC",
+    "productDescription": "Xiaomiの安価な完全ワイヤレスイヤホン。10mmの大型ダイナミックドライバーを搭載し、専用アプリでイコライザーなどの設定が可能。最大36時間のバッテリー駆動時間を持つ。",
+    "productUsage": [
+      "音楽やポッドキャストの視聴",
+      "通話用ヘッドセットとして",
+      "低遅延モードを利用したカジュアルなゲームプレイ",
+      "動画鑑賞"
+    ],
+    "positivePoints": [
+      "1,380円という非常に安価な価格でコスパが高い",
+      "10mmドライバーとXiaomi Acoustic Labによるチューニングで、価格以上のバランスの良いサウンドを提供する",
+      "最大36時間の長時間バッテリーを搭載し、10分の充電で3時間再生できる急速充電にも対応",
+      "専用アプリ「Xiaomi Earbuds」に対応し、イコライザーや操作のカスタマイズが可能",
+      "Google Fast Pairに対応し、Androidスマホとの接続が容易",
+      "片耳わずか3.6gの軽量設計で、長時間の使用でも疲れにくい",
+      "AIノイズリダクションにより、通話時の周囲の雑音を効果的に抑え、クリアな音声通話が可能"
+    ],
+    "negativePoints": [
+      "対応コーデックがSBCのみで、AACやより高音質なコーデックには非対応",
+      "ノイズキャンセリングや外音取り込み機能は搭載されていない",
+      "タッチ操作の反応に一瞬の間があり、キビキビとした動作ではないと感じることがある",
+      "ビーンズ型の形状が耳の形によってはフィットしにくい場合がある",
+      "充電用のUSBケーブルが付属していない",
+      "マルチポイント接続には非対応"
+    ],
+    "useCases": [
+      "通勤・通学中や家事中のBGM用途",
+      "手軽な価格なのでサブのイヤホンとして、または寝ホンとして",
+      "Web会議や電話での通話用ヘッドセットとして"
+    ],
+    "userStories": [
+      {
+        "userType": "一般ユーザー",
+        "scenario": "日常的な音楽視聴",
+        "experience": "1,000円台の安価なイヤホンでありながら、音質は全体的にバランスが良く、中高域の粗も少なく刺さらない優しい音で聴きやすい。専用アプリで高域重視に設定するとさらに好みの音になった。",
+        "supportingSourceIds": [
+          "src-2"
+        ],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "Androidユーザー",
+        "scenario": "初期設定と接続",
+        "experience": "Google Fast Pairに対応しているため、ケースを開けるだけでスマホにポップアップが表示され、簡単に接続できたのが非常に便利だった。",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "sentiment": "positive"
+      },
+      {
+        "userType": "ゲーマー",
+        "scenario": "ゲームプレイ",
+        "experience": "専用アプリから低遅延モードをオンにすることで、FPSなどのカジュアルなゲームであればプレイできるレベルに遅延が抑えられたが、音ゲーのようなシビアなゲームには向いていないと感じた。",
+        "supportingSourceIds": [
+          "src-2"
+        ],
+        "sentiment": "mixed"
+      },
+      {
+        "userType": "一般ユーザー",
+        "scenario": "外出先での通話",
+        "experience": "AIノイズリダクションの効果があり、騒がしい場所でも背景のノイズが低減され、相手に声がクリアに伝わった。ダイソーなどの低価格帯のイヤホンと比べてもマイク性能は優秀だった。",
+        "supportingSourceIds": [
+          "src-2"
+        ],
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "1,000円台という超低価格でありながら、音質、バッテリー持ち、アプリ対応、マイク品質など、基本性能がしっかりしており、ダイソーなどの100均イヤホンよりも明らかに優れた「お値段以上」のワイヤレスイヤホンとして高く評価されている。ノイズキャンセリングなどの高度な機能はないものの、初めてのワイヤレスイヤホンやサブ機として非常に満足度が高い。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "こまめブログ / Redmi Buds 6 Playレビュー：1380円の激安ワイヤレスイヤホンの実力は？",
+        "url": "https://komameblog.jp/review/redmi-buds6-play/",
+        "tier": "medium",
+        "evidenceType": "primary",
+        "publishedAt": "2024-08-30",
+        "author": "こまめ",
+        "conflictOfInterest": "none",
+        "notes": "実機レビュー。音質はお値段以上でバランスが良いと評価。専用アプリ対応やGoogle Fast Pairの利便性を紹介。"
+      },
+      {
+        "id": "src-2",
+        "name": "カジェログ / Redmi Buds 6 Lite / Play / Active レビュー",
+        "url": "https://kajetblog.com/redmi-buds-6-lite-play-active/",
+        "tier": "medium",
+        "evidenceType": "primary",
+        "publishedAt": "2025-01-31",
+        "author": "かじかじ",
+        "conflictOfInterest": "none",
+        "notes": "実機レビュー。ダイソーや3COINSのイヤホンとの比較で優位性を主張。音質は刺さり感のない柔らかい音で、イコライザー（高域重視）の推奨や、マイク性能の良さ、低遅延モードについて言及。"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "ダイソーや3COINSの同価格帯のワイヤレスイヤホンと比較して、音質や機能（アプリ対応など）で優位性がある",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "crossChecked": true,
+        "notes": "両方のレビューサイトでダイソー等のイヤホンと比較され、音質や専用アプリ対応の点でRedmi Buds 6 Playが高く評価されている。"
+      },
+      {
+        "claim": "1,380円という価格ながら、専用アプリによるイコライザー調整や操作のカスタマイズが可能",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1",
+          "src-2"
+        ],
+        "crossChecked": true,
+        "notes": "この価格帯で専用アプリに対応している点が共通して高く評価されている。"
+      }
+    ],
+    "lastInvestigated": "2026-07-01",
+    "competitiveAnalysis": [
+      {
+        "name": "Anker Soundcore P31i",
+        "asin": "B0FNRMBR4X",
+        "priceComparison": "対象商品より高いが、ノイズキャンセリングや長いバッテリー寿命があるため妥当",
+        "featureComparison": [
+          "共通点：専用アプリ対応、カナル型、Type-C充電",
+          "相違点：Anker Soundcore P31iはアクティブノイズキャンセリング搭載、マルチポイント接続対応、最大50時間再生に対応している"
+        ],
+        "differentiators": [
+          "Xiaomi Redmi buds 6 Playの利点：圧倒的に安価であり、軽量でコンパクトなデザイン",
+          "Anker Soundcore P31iの利点：ノイズキャンセリング機能やマルチポイント接続が必要な場合、より長いバッテリー駆動時間を求める場合に適している"
+        ]
+      },
+      {
+        "name": "Xiaomi REDMI Buds 8 Active",
+        "asin": "B08N5WP9NP",
+        "priceComparison": "対象商品より少し高く、インナーイヤー型やAAC対応を求めるなら妥当な選択",
+        "featureComparison": [
+          "共通点：Xiaomi製、専用アプリ対応、Google Fast Pair対応、Type-C充電",
+          "相違点：REDMI Buds 8 Activeはインナーイヤー型、AACコーデックに対応、マルチポイント接続に対応している"
+        ],
+        "differentiators": [
+          "Xiaomi Redmi buds 6 Playの利点：カナル型で遮音性が高く、より安価",
+          "Xiaomi REDMI Buds 8 Activeの利点：インナーイヤー型で耳への圧迫感が少ない、AAC対応でより高音質、マルチポイント接続に対応"
+        ]
+      },
+      {
+        "name": "Xiaomi REDMI Buds 8 Lite",
+        "asin": "B0FRSCXWSV",
+        "priceComparison": "対象商品より高いが、強力なノイズキャンセリングを考慮すればコストパフォーマンスは高い",
+        "featureComparison": [
+          "共通点：Xiaomi製、専用アプリ対応、Google Fast Pair対応、カナル型",
+          "相違点：REDMI Buds 8 Liteはアクティブノイズキャンセリング（最大42dB）を搭載し、AACコーデックに対応、スティック型のデザイン"
+        ],
+        "differentiators": [
+          "Xiaomi Redmi buds 6 Playの利点：非常に安価で、コンパクトなビーンズ型デザイン",
+          "Xiaomi REDMI Buds 8 Liteの利点：ノイズキャンセリングが必要な場合、AAC対応による高音質を求める場合に適している"
+        ]
+      },
+      {
+        "name": "Anker Soundcore K20i",
+        "asin": "B0D2RGPTKM",
+        "priceComparison": "対象商品より高く、インナーイヤー型や防水性能に価値を見出す場合に適する",
+        "featureComparison": [
+          "共通点：専用アプリ対応、急速充電対応",
+          "相違点：K20iはインナーイヤー型で、IPX5の防水規格を持つ"
+        ],
+        "differentiators": [
+          "Xiaomi Redmi buds 6 Playの利点：より安価で、カナル型による遮音性がある",
+          "Anker Soundcore K20iの利点：インナーイヤー型で耳への圧迫感が少ない、より高い防水性能が必要な場合"
+        ]
+      },
+      {
+        "name": "SONY WF-C710N",
+        "asin": "B0F3XFNHCW",
+        "priceComparison": "対象商品よりかなり高いが、高性能ノイキャンや高音質コーデック等に対応するハイエンド機",
+        "featureComparison": [
+          "共通点：カナル型ワイヤレスイヤホン",
+          "相違点：SONY WF-C710Nは高性能ノイズキャンセリング、外音取り込み、マルチポイント接続、より高いブランドの音質など機能が豊富"
+        ],
+        "differentiators": [
+          "Xiaomi Redmi buds 6 Playの利点：圧倒的に安価で気軽に購入できる",
+          "SONY WF-C710Nの利点：ノイズキャンセリングや音質など全体的な性能が圧倒的に高く、ハイエンド志向のユーザー向け"
+        ]
+      },
+      {
+        "name": "Nakamichi OP-TW009 Lite",
+        "asin": "B0GWMJN5BZ",
+        "priceComparison": "対象商品より高いが、耳を塞がないオープンイヤー型という全く異なる付加価値がある",
+        "featureComparison": [
+          "共通点：ワイヤレス接続",
+          "相違点：OP-TW009 Liteは耳を塞がないオープンイヤー型で、空間オーディオやマルチポイントに対応"
+        ],
+        "differentiators": [
+          "Xiaomi Redmi buds 6 Playの利点：カナル型で遮音性があり、安価でコンパクト",
+          "Nakamichi OP-TW009 Liteの利点：耳を塞がないため周囲の音が聞こえ、耳への負担が少ないオープンイヤー型であること"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "とにかく予算を抑えてワイヤレスイヤホンを購入したい人",
+        "音質にそこまで強いこだわりがないが、普通に聴けるレベルを求める人",
+        "サブ機や寝ホン用のイヤホンを探している人"
+      ],
+      "pros": [
+        "1,380円という圧倒的なコストパフォーマンス",
+        "価格以上のバランスの取れた音質",
+        "専用アプリでイコライザーやジェスチャー設定が可能",
+        "最大36時間の長時間バッテリーと急速充電"
+      ],
+      "cons": [
+        "ノイズキャンセリング機能は非搭載",
+        "対応コーデックがSBCのみ",
+        "充電ケーブルが付属しない",
+        "ビーンズ型の形状が耳に合わない場合がある"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +15] (圧倒的なコストパフォーマンスと価格に対する音質の良さ)\n[加点: +5] (1000円台でありながら専用アプリでの設定やGoogle Fast Pairに対応する利便性)\n[減点: -5] (対応コーデックがSBCのみであり、ANCなどの高度な機能は非搭載)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "31mm",
+        "width": "100mm",
+        "depth": "100mm"
+      },
+      "weight": "45g",
+      "capacity": "イヤホン単体最大7.5時間、ケース込最大36時間",
+      "material": "プラスチック等",
+      "origin": "中国",
+      "other": [
+        "ドライバー: 10mmダイナミックドライバー",
+        "Bluetoothバージョン: 5.4",
+        "対応コーデック: SBC",
+        "防水性能: IPX4（イヤホンのみ）",
+        "充電端子: USB Type-C"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Generated comprehensive investigation JSON for `B0DBHRWRKC` (Xiaomi Redmi buds 6 Play). The data includes:
- Product info and specs.
- Competitive analysis against 6 competitors (Anker, Xiaomi, SONY, Nakamichi, etc.).
- Target users, pros, cons, and scored recommendation.
- Review-based user stories with positive and mixed sentiments.
- Converted dimensions and weight to metric units (mm and g).
- Validated all URLs and JSON structure.

---
*PR created automatically by Jules for task [8896503692991370351](https://jules.google.com/task/8896503692991370351) started by @aegisfleet*