### PR TITLE
Add investigation data for B0002E1O3G

### DIFF
--- a/data/investigations/B0002E1O3G.json
+++ b/data/investigations/B0002E1O3G.json
@@ -1,0 +1,176 @@
+{
+  "analysis": {
+    "productName": "Elixir エレキギター弦 NANOWEB Light .010-.046",
+    "parentAsin": "B0002E1O3G",
+    "productDescription": "特殊なポリマーコーティングにより汗や汚れから弦を守り、長寿命と高音質を実現するコーティング弦。",
+    "productUsage": [
+      "エレキギターの弦交換",
+      "ライブやレコーディングでの使用"
+    ],
+    "positivePoints": [
+      "特殊コーティングにより錆びにくく、長寿命",
+      "張り替え直後のブライトで迫力あるサウンドが長続きする",
+      "フィンガーノイズが抑えられており弾きやすい"
+    ],
+    "negativePoints": [
+      "コーティング無しの弦と比較すると価格が高い",
+      "指先の感触がコーティング弦特有のツルツル感がある"
+    ],
+    "useCases": [
+      "弦交換の頻度を減らしたい方",
+      "手汗をかきやすく弦が錆びやすい方",
+      "長期間安定したサウンドを求める方"
+    ],
+    "userStories": [],
+    "userImpression": "価格はやや高めですが、圧倒的な長寿命により結果的にコストパフォーマンスが高く、張りたてのサウンドが長続きすることで多くのギタリストから支持されています。",
+    "sources": [
+      {
+        "id": "src-amazon",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0002E1O3G",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-05-20",
+        "author": "Amazon",
+        "conflictOfInterest": "none",
+        "notes": "商品スペック、特徴、価格情報を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "特殊ポリマーコーティングにより腐食を防ぎ、寿命が長い",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon"
+        ],
+        "crossChecked": true,
+        "notes": "商品仕様および一般的なコーティング弦の特徴として一致"
+      },
+      {
+        "claim": "フィンガーノイズが抑えられる",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon"
+        ],
+        "crossChecked": true,
+        "notes": "商品仕様に明記"
+      }
+    ],
+    "lastInvestigated": "2026-07-04",
+    "competitiveAnalysis": [
+      {
+        "name": "D'Addario XL Nickel .010-.046 EXL110",
+        "asin": "B0002F7K7Y",
+        "priceComparison": "対象商品より安価で、ノンコーティング弦の定番。",
+        "featureComparison": [
+          "共通点：ゲージが.010-.046のライトゲージであること",
+          "相違点：対象商品はコーティング弦で長寿命。競合はノンコーティングで本来のブライトな音色。"
+        ],
+        "differentiators": [
+          "Elixir NANOWEBの利点：長寿命で弦交換の頻度を減らせる。張りたての音が長く続く。",
+          "D'Addario EXL110の利点：価格が安く、コーティングがないため自然なタッチとブライトな音色。"
+        ]
+      },
+      {
+        "name": "ERNIE BALL Regular Slinky 10-46 2221",
+        "asin": "B0767JBBXH",
+        "priceComparison": "対象商品より安価で、定番のノンコーティング弦。",
+        "featureComparison": [
+          "共通点：ゲージが.010-.046のライトゲージであること",
+          "相違点：対象商品はコーティング弦。競合はノンコーティングで、独特のきらびやかな音色。"
+        ],
+        "differentiators": [
+          "Elixir NANOWEBの利点：錆びにくく長持ちするため、結果的なコスパが良い。",
+          "ERNIE BALL 2221の利点：安価で手に入りやすく、多くのギタリストに愛される定番サウンド。"
+        ]
+      },
+      {
+        "name": "SIT Power Wound ニッケル 09-46 S946",
+        "asin": "B01I5CEPCS",
+        "priceComparison": "対象商品より安価。ゲージが異なる。",
+        "featureComparison": [
+          "共通点：エレキギター用の弦であること",
+          "相違点：対象商品はコーティング弦で10-46ゲージ。競合はノンコーティングでチューニングの安定性に定評があり、ゲージは09-46。"
+        ],
+        "differentiators": [
+          "Elixir NANOWEBの利点：圧倒的な長寿命と、10-46の標準的なテンション感。",
+          "SIT S946の利点：チューニングが狂いにくく、低音弦は太く高音弦は細いハイブリッドゲージで弾きやすい。"
+        ]
+      },
+      {
+        "name": "GHS Boomers 10-46 GBL",
+        "asin": "B0018MA3MO",
+        "priceComparison": "対象商品より安価でパワフルなサウンドの定番弦。",
+        "featureComparison": [
+          "共通点：ゲージが.010-.046のライトゲージであること",
+          "相違点：対象商品はコーティング弦。競合はノンコーティングで、パンチのあるミッドレンジが特徴。"
+        ],
+        "differentiators": [
+          "Elixir NANOWEBの利点：長寿命と安定したトーン。",
+          "GHS GBLの利点：パワフルで抜けの良いサウンドと低価格。"
+        ]
+      },
+      {
+        "name": "DR Strings DIMEBAG DARRELL 10-46 DBG-10",
+        "asin": "B0009QTQ3M",
+        "priceComparison": "対象商品と近い価格帯。特殊な弦。",
+        "featureComparison": [
+          "共通点：ゲージが.010-.046のライトゲージであること",
+          "相違点：対象商品は寿命を重視したコーティング弦。競合はダイムバッグ・ダレルのシグネチャーモデルで、激しいアーミング等に対応。"
+        ],
+        "differentiators": [
+          "Elixir NANOWEBの利点：全体的な長寿命と弾きやすさ。",
+          "DR DBG-10の利点：特定のアーティストのサウンドや、激しいプレイへの耐久性。"
+        ]
+      },
+      {
+        "name": "D'Addario XS コーティング弦 .010-.046 XSE1046",
+        "asin": "B0BCXD1DW5",
+        "priceComparison": "対象商品よりやや高価(3セット入り比較時等)、同等のコーティング弦。",
+        "featureComparison": [
+          "共通点：極薄コーティングが施された10-46の長寿命弦",
+          "相違点：対象商品はコーティング弦の老舗。競合は最新技術の極薄フィルムとポリマーでより自然な触り心地を追求。"
+        ],
+        "differentiators": [
+          "Elixir NANOWEBの利点：長年の実績と独自の滑らかな触り心地。",
+          "D'Addario XSE1046の利点：ノンコーティングに近い自然な感触と強力なピッチ安定性。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "弦交換の手間を減らしたい方",
+        "手汗が多く弦が錆びやすい方",
+        "長期間安定した音質を保ちたい方"
+      ],
+      "pros": [
+        "圧倒的な長寿命",
+        "張りたての高音質が長続きする",
+        "フィンガーノイズが少ない"
+      ],
+      "cons": [
+        "単価が高い",
+        "コーティング特有の滑りやすさに慣れが必要"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (圧倒的な長寿命と安定した品質)\n[加点: +10] (フィンガーノイズの軽減と弾きやすさ)\n[減点: -5] (ノンコーティング弦と比較して価格が高い)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "15.2mm",
+        "width": "119.4mm",
+        "depth": "104.1mm"
+      },
+      "weight": "0.1g",
+      "capacity": "1セット(6本入り)",
+      "material": "ニッケルワウンド、特殊ポリマーコーティング(NANOWEB)",
+      "gauge": "Light .010-.046 (.010, .013, .017, .026, .036, .046)",
+      "other": [
+        "国内正規品",
+        "超極薄ナノウェブコーティング"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added the product investigation data for B0002E1O3G (Elixir NANOWEB Light .010-.046 guitar strings), converting all non-metric measurements and omitting unverified user stories.

---
*PR created automatically by Jules for task [12498489672097861039](https://jules.google.com/task/12498489672097861039) started by @aegisfleet*