### PR TITLE
iPad mini A17 Proの調査データの追加

### DIFF
--- a/data/investigations/B0DK467P86.json
+++ b/data/investigations/B0DK467P86.json
@@ -1,164 +1,194 @@
 {
   "analysis": {
-    "productName": "Apple iPad mini (A17 Pro)",
+    "productName": "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GB",
     "parentAsin": "B0DK467P86",
-    "productDescription": "A17 ProチップとApple Intelligenceを搭載した、8.3インチの超ポータブルな高性能タブレットです。",
+    "productDescription": "Apple Intelligence対応のA17 Proチップを搭載した8.3インチのiPad miniです。超ポータブルなボディに一日中使えるバッテリーを内蔵し、Wi-Fi 6EやApple Pencil Proにも対応しています。",
     "productUsage": [
-      "片手で持てるサイズ感を活かした、通勤・通学中の電子書籍閲覧やWebブラウジング",
-      "A17 Proチップの性能をフル活用した、外出先での本格的な3Dゲームプレイ",
-      "Apple Pencil Proを使った、高精度なデジタルスケッチやメモ書き",
-      "USB-Cポートでの高速データ転送や外部ディスプレイ接続による、ミニPCライクな作業環境",
-      "Apple Intelligenceによる文章作成支援や画像生成などのAIタスク"
+      "メモ書きやドキュメントへの注釈",
+      "写真やビデオの編集",
+      "電子書籍の読書やWeb閲覧",
+      "外出先でのコンテンツ視聴"
     ],
     "positivePoints": [
-      "A17 Proチップ搭載により、前モデルから大幅に処理性能が向上し、重量級ゲームも快適に動作する。",
-      "8.3インチという絶妙なサイズ感で、コートのポケットや小さなバッグにも収まる圧倒的な携帯性。",
-      "Apple Pencil Proに対応し、スクイーズやバレルロールなどの新機能が使えるようになった。",
-      "Wi-Fi 6Eに対応し、高速で安定した無線通信が可能。",
-      "将来のApple Intelligence機能に対応しており、長く使える安心感がある。"
+      "Apple Intelligenceに対応したA17 Proチップを搭載している",
+      "P3の広色域とTrue Toneに対応した8.3インチのLiquid Retinaディスプレイを採用している",
+      "Wi-Fi 6Eに対応し、高速な通信が可能である",
+      "Apple Pencil Proに対応している",
+      "持ち運びに便利な携帯性の高いサイズ設計となっている"
     ],
     "negativePoints": [
-      "ディスプレイのリフレッシュレートが依然として60Hzに留まっており、スクロール時の残像感が気になる場合がある。",
-      "Face IDではなくTouch IDを採用しており、好みが分かれる（特に手袋をしている時などは便利だが）。",
-      "価格が約7.8万円からと高価であり、同サイズのAndroidタブレットと比較すると割高感がある。",
-      "バッテリー持ちは「一日中使える」とされているが、高負荷なゲームなどをすると減りが早い。"
+      "同容量の無印iPad(11インチ)よりも価格が高く設定されている",
+      "フロントカメラの配置が従来通り短辺側である",
+      "画面サイズが小さいため、PCライクなマルチタスクや本格的なクリエイティブ作業には制約がある"
     ],
     "useCases": [
-      "電車やカフェでの隙間時間に、片手で読書やSNSチェックを行う",
-      "外出先で撮影した写真や動画を、その場で取り込んで編集・共有する",
-      "高性能なモバイルゲーム機として、場所を選ばずにプレイする",
-      "会議や授業のメモを、紙のノート代わりにデジタルで管理する"
+      "外出先や移動中のちょっとした作業",
+      "ソファやベッドでくつろぎながらのコンテンツ消費",
+      "出張時など荷物を減らしたいシーンでの持ち運び"
     ],
     "userStories": [
       {
-        "userType": "ビジネスマン",
-        "scenario": "外出先でのメールチェックと資料確認",
-        "experience": "以前はノートPCを持ち歩いていましたが、iPad miniに変えてから荷物が劇的に減りました。電車の中でもサッと取り出してメールを返信したり、PDFの資料に赤入れをしたりと、隙間時間を有効活用できています。特にApple Pencil Proの使い心地が良く、手書きのメモも紙に近い感覚で書けるのが気に入っています。",
+        "userType": "ビジネスパーソン",
+        "scenario": "通常業務や外出時の使用",
+        "experience": "昔のタブレットからの買い替えだが、処理速度が速く、画面もきれいで驚いた。バッテリーも長持ちし、通常業務で大活躍している。携帯性が抜群に良く、セカンドバッグにスッと入れて持ち運べるため、外出時にもストレスがないのが最大の決め手。",
+        "supportingSourceIds": [
+          "src-kakaku-review1"
+        ],
         "sentiment": "positive"
-      },
-      {
-        "userType": "ゲーマー",
-        "scenario": "移動中のゲームプレイ",
-        "experience": "原神などの重いゲームをプレイするために購入しました。A17 Proチップのおかげで最高画質でもカクつくことなく快適に遊べます。ただ、長時間プレイしていると本体が少し熱くなるのと、画面のリフレッシュレートが60Hzなのが少し残念です。120Hzに対応していれば完璧でした。",
-        "sentiment": "mixed"
       }
     ],
-    "userImpression": "iPad mini (A17 Pro) は、そのコンパクトなサイズと強力なパフォーマンスのバランスが高く評価されています。特に「持ち運びやすさ」と「処理能力」の両立を求めるユーザーにとっては、他に代えがたい唯一無二の存在です。一方で、ディスプレイのリフレッシュレートが60Hzである点や、価格の上昇については厳しい意見も見られます。総じて、特定のニーズ（携帯性重視、Appleエコシステム、ペン入力）を持つユーザーにとっては最高のデバイスですが、単にコンテンツ消費用として考えると高価に感じるかもしれません。",
+    "userImpression": "多くのユーザーが、iPad miniの圧倒的な「携帯性」と「取り回しの良さ」を高く評価している。A17 Proチップの搭載により処理速度に不満を持つユーザーはほとんどおらず、サクサクと快適に動作する点が好評である。価格が高めである点や画面サイズによる制約は認識されているものの、片手で持てるこのサイズ感を求めるユーザーにとってはそれらを補って余りある魅力があるという意見が支配的である。",
     "sources": [
       {
-        "name": "Apple公式サイト: iPad mini (A17 Pro)",
-        "url": "https://www.apple.com/jp/ipad-mini/",
-        "credibility": "高"
+        "id": "src-amazon",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0DK467P86",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-10-23",
+        "author": "Apple",
+        "conflictOfInterest": "none",
+        "notes": "商品の基本スペックや特徴を確認"
       },
       {
-        "name": "The Verge Review: iPad mini 7 review",
-        "url": null,
-        "credibility": "高"
+        "id": "src-kakaku-review1",
+        "name": "価格.com レビュー",
+        "url": "https://review.kakaku.com/review/K0001658666/",
+        "tier": "medium",
+        "evidenceType": "secondary",
+        "publishedAt": "2024-10-23",
+        "author": "価格.comユーザー",
+        "conflictOfInterest": "none",
+        "notes": "携帯性の高さや処理速度に対する満足度を確認"
       }
     ],
-    "lastInvestigated": "2026-02-23",
+    "claims": [
+      {
+        "claim": "一日中使えるバッテリー",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-amazon",
+          "src-kakaku-review1"
+        ],
+        "crossChecked": true,
+        "notes": "メーカーの主張であるとともに、ユーザーレビューでもバッテリーの持ちが良いことが確認されている"
+      }
+    ],
+    "lastInvestigated": "2026-07-04",
     "competitiveAnalysis": [
       {
-        "name": "Lenovo Legion Tab (B0DTK4TMJH)",
-        "asin": "B0DTK4TMJH",
-        "priceComparison": "iPad miniと同等の価格帯（約7.7万円）。",
+        "name": "Apple 11 インチ iPad (A16) 128GB",
+        "asin": "B0DZ895SXY",
+        "priceComparison": "対象商品（iPad mini）の方が価格が高い。iPad miniはコンパクトさとA17 Proチップによる性能に価値を置く価格設定となっている。",
         "featureComparison": [
-          "Snapdragon 8 Gen 3搭載で、Androidタブレットとしては最高峰の性能。",
-          "144Hzの高リフレッシュレートディスプレイを搭載し、ゲームやスクロールが非常に滑らか。",
-          "冷却性能に優れており、長時間のゲームプレイでもパフォーマンスが低下しにくい。"
+          "共通点：iPadOSを搭載し、多彩なApple純正アプリやApp Storeのアプリを利用できる点",
+          "相違点：対象商品は8.3インチでA17 Proチップを搭載しApple Intelligenceに対応するが、競合製品は11インチでA16チップを搭載している点"
         ],
         "differentiators": [
-          "ゲーミングに特化した機能と性能",
-          "高リフレッシュレートディスプレイ",
-          "USB-Cポートが2つあり、充電しながら周辺機器を使える"
+          "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GBの利点：片手で持てるサイズ感と携帯性を最重視し、最新のAI機能を使いたいなら迷わずこちら。",
+          "Apple 11 インチ iPad (A16) 128GBの利点：より大きな画面で動画視聴や作業を行いたい、あるいは少しでも初期費用を抑えたい人に適している。"
         ]
       },
       {
-        "name": "ALLDOCUBE iPlay 60 mini Turbo (B0FWKDY35B)",
-        "asin": "B0FWKDY35B",
-        "priceComparison": "iPad miniの約1/3の価格（約2.5万円）。非常に安価。",
+        "name": "【整備済み品】Apple iPad mini (第6世代) Wi-Fi + Cellular 64GB",
+        "asin": "B0BKPXSKNQ",
+        "priceComparison": "対象商品よりも安価だが、競合は旧世代の整備済み品でありストレージも64GBと少ないため、最新性能と十分な容量を考慮すれば対象商品の価格は妥当である。",
         "featureComparison": [
-          "Snapdragon 6 Gen 1搭載で、日常使用や軽いゲームには十分な性能。",
-          "画面解像度はFHD+で、iPad miniよりは低いが必要十分。",
-          "Widevine L1対応で、動画配信サービスを高画質で視聴可能。"
+          "共通点：8.3インチのディスプレイサイズと、片手で持てる高い携帯性を持つ点",
+          "相違点：対象商品はA17 Proチップと128GBのストレージを搭載しているが、競合製品はA15 Bionicチップと64GBのストレージである点"
         ],
         "differentiators": [
-          "圧倒的なコストパフォーマンス",
-          "Android OSによる自由度の高さ",
-          "USB-Cポートによる映像出力対応"
+          "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GBの利点：Apple Intelligenceの利用や、より高性能なチップによる将来的なサポートの長さを重視するなら迷わずこちら。",
+          "【整備済み品】Apple iPad mini (第6世代) Wi-Fi + Cellular 64GBの利点：性能は型落ちでもよく、とにかくiPad miniのサイズ感を安く手に入れたい人に適している。"
         ]
       },
       {
-        "name": "Redmi Pad SE 8.7 (B0D97PST2K)",
-        "asin": "B0D97PST2K",
-        "priceComparison": "iPad miniの約1/4以下の価格（約1.8万円）。最も安価。",
+        "name": "ALLDOCUBE iPlay 80 mini Pro タブレット 8.4インチ",
+        "asin": "B0GZ3GM81R",
+        "priceComparison": "対象商品よりも圧倒的に安いが、OSやチップ性能、エコシステムに大きな違いがあり、対象商品のブランドや独自機能にはその差額分の価値がある。",
         "featureComparison": [
-          "性能はエントリークラスで、Web閲覧や動画視聴向け。",
-          "90Hzのリフレッシュレートに対応しており、iPad miniより滑らかに感じる場合がある。",
-          "4G LTE対応モデルがあり、単体で通信が可能。"
+          "共通点：8インチクラスのコンパクトなディスプレイを搭載している点",
+          "相違点：対象商品はiPadOSとA17 Proチップを搭載しているのに対し、競合製品はAndroid OSとUNISOC T7300を搭載している点"
         ],
         "differentiators": [
-          "低価格で購入しやすい",
-          "FMラジオ搭載などのユニークな機能",
-          "90Hzディスプレイ"
+          "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GBの利点：iPhoneなどのApple製品との連携や、圧倒的な処理性能、長期的なOSアップデートを求めるなら迷わずこちら。",
+          "ALLDOCUBE iPlay 80 mini Pro タブレット 8.4インチの利点：動画視聴やWeb閲覧など用途を限定しており、とにかく安く8インチタブレットが欲しい人に適している。"
+        ]
+      },
+      {
+        "name": "Lenovo Tab One タブレット 8.7インチ",
+        "asin": "B0F8VH24JF",
+        "priceComparison": "対象商品よりも大幅に安価だが、処理性能や解像度で劣るため、価格差は妥当である。",
+        "featureComparison": [
+          "共通点：片手で持てる小型軽量なタブレットである点",
+          "相違点：対象商品はハイエンドな処理性能を持つが、競合製品はエントリークラスのMediaTek Helio G85プロセッサーを搭載している点"
+        ],
+        "differentiators": [
+          "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GBの利点：ゲームやクリエイティブな作業など、高い処理能力が求められる用途を想定しているなら迷わずこちら。",
+          "Lenovo Tab One タブレット 8.7インチの利点：大手PCメーカーの安心感を持ちつつ、電子書籍リーダーや動画視聴用のサブ機として手軽に購入したい人に適している。"
+        ]
+      },
+      {
+        "name": "LZF ZPad1A タブレット 8.8インチ",
+        "asin": "B0GW8MFV3F",
+        "priceComparison": "対象商品より大幅に安いが、搭載OSやプロセッサの性能が異なるため単純比較は難しく、対象商品のエコシステムに価値を見出す人には妥当な価格差である。",
+        "featureComparison": [
+          "共通点：8インチ台のディスプレイを備え、携帯性に優れる点",
+          "相違点：対象商品はWi-Fi 6E対応でAppleの独自エコシステムを持つが、競合製品はAndroidベースで4G LTE通信に対応している点"
+        ],
+        "differentiators": [
+          "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GBの利点：Apple Pencil Proを使った高品質な描画体験や、iPadOSならではの洗練されたUIを求めるなら迷わずこちら。",
+          "LZF ZPad1A タブレット 8.8インチの利点：外出先での単体通信（SIMフリー）を安価な端末で実現したい人に適している。"
+        ]
+      },
+      {
+        "name": "PHILIPS タブレット 2.5K 8.8インチ",
+        "asin": "B0GJDZC79D",
+        "priceComparison": "対象商品の半額以下の価格であるが、OSのエコシステムやチップ性能の差があり、対象商品のブランドと性能には価格差に見合う価値がある。",
+        "featureComparison": [
+          "共通点：8インチ台の高解像度ディスプレイを搭載している点",
+          "相違点：対象商品はA17 Proを搭載したiPadである一方、競合製品はAndroid OSでSIM通話モデルである点"
+        ],
+        "differentiators": [
+          "Apple iPad mini (A17 Pro) 8.3インチ Wi-Fiモデル 128GBの利点：Apple Intelligenceや高性能なチップによるサクサクとした動作、信頼性を重視するなら迷わずこちら。",
+          "PHILIPS タブレット 2.5K 8.8インチの利点：大手ブランドのAndroidタブレットで、SIMを使った通話や通信を求めている人に適している。"
         ]
       }
     ],
     "recommendation": {
       "targetUsers": [
-        "常に持ち歩ける高性能なタブレットを探している人",
-        "Apple Pencilを使って手書きメモやイラストを描きたい人",
-        "iPhoneと連携して使えるサブデバイスが欲しい人",
-        "最新の3Dゲームを快適にプレイしたいが、大きなタブレットは持ちたくない人"
+        "iPhoneやMacを使用しており、出張や外出時に手軽に持ち運べる高性能なタブレットを求めている人（安価なAndroidタブレットでは連携機能や処理性能に不満がある人）",
+        "Apple Intelligenceなどの最新機能をコンパクトなサイズで活用したい人（より大きな無印iPadでは取り回しに不便を感じる人）"
       ],
       "pros": [
-        "A17 Proチップによる圧倒的な処理性能",
-        "片手で持てるコンパクトで軽量なボディ",
-        "Apple Pencil Proへの対応とApple Intelligenceのサポート",
-        "高品質なビルドクオリティとAppleエコシステムの利便性"
+        "A17 ProチップとApple Intelligenceの対応により、小さなボディながら最新のAI機能や高速な処理能力を享受でき、作業効率が大幅に向上する",
+        "8.3インチのサイズと軽さにより、セカンドバッグにも収まり、長時間の読書や動画視聴でも腕が疲れにくい"
       ],
       "cons": [
-        "リフレッシュレートが60Hzに留まっていること",
-        "価格が競合と比較して高いこと",
-        "バッテリー持ちが大型タブレットに比べると短いこと"
+        "価格が11インチの無印iPadよりも高く設定されているため、大画面での作業を重視し、携帯性にこだわらない人は購入前に画面サイズと価格のバランスを確認すること"
       ],
-      "score": 88,
-      "scoreRationale": "[基本点: 70]\n[加点: +10] (性能・機能: A17 Proチップの圧倒的な性能とApple Intelligence対応)\n[加点: +8] (独自の強み・先進性: 唯一無二のサイズ感と性能のバランス、Apple Pencil Pro対応)\n[加点: +5] (品質・デザイン: Apple製品ならではの質感の高さ)\n[加点: +5] (ユーザー満足度: ポータビリティを求めるユーザーからの根強い支持)\n[減点: -5] (コストパフォーマンス: 競合と比較して価格が高い)\n[減点: -5] (性能・機能: リフレッシュレートが60Hzで、競合に劣る)\n[合計: 88]"
+      "score": 75,
+      "scoreRationale": "[基本点: 70] (固定)\n[加点: +5] (抜群の携帯性による使いやすさ)\n[加点: +5] (A17 Proの十分な処理性能とApple Intelligence対応)\n[減点: -5] (他社Androidタブレットや大画面の無印iPadと比較した際の価格の高さによるコストパフォーマンスの懸念)\n[合計: 75]"
     },
     "technicalSpecs": {
-      "os": "iPadOS 18",
-      "cpu": "A17 Pro",
-      "ram": "8GB (推定)",
-      "storage": "128GB / 256GB / 512GB",
-      "display": {
-        "size": "8.3インチ",
-        "resolution": "2266 x 1488ピクセル",
-        "type": "Liquid Retinaディスプレイ"
-      },
-      "battery": {
-        "capacity": "一日中使えるバッテリー",
-        "charging": "USB-C (20Wアダプタ同梱)"
-      },
-      "camera": {
-        "main": "12MP広角",
-        "ultrawide": "12MP超広角フロント"
-      },
       "dimensions": {
-        "height": "195.4 mm",
-        "width": "134.8 mm",
-        "depth": "6.3 mm",
-        "weight": "293g (Wi-Fiモデル)"
+        "height": "6.3mm",
+        "width": "195.4mm",
+        "depth": "134.8mm"
       },
-      "connectivity": [
-        "Wi-Fi 6E",
-        "Bluetooth 5.3",
-        "5G (セルラーモデル)",
-        "USB-C (USB 3)"
-      ],
+      "weight": "293g",
+      "capacity": "128GB",
+      "material": "アルミニウム",
+      "origin": "中国",
       "other": [
-        "Touch ID",
-        "Apple Pencil Pro対応",
-        "Apple Intelligence対応"
+        "Liquid Retinaディスプレイ",
+        "約21cm",
+        "A17 Proチップ",
+        "12MP広角バックカメラ",
+        "12MP超広角フロントカメラ",
+        "USB-Cコネクタ",
+        "Wi-Fi 6E"
       ]
     }
   }


### PR DESCRIPTION
Amazon Creators APIと外部サイトから取得した情報を元に、iPad mini A17 Proの競合比較やレビュー情報をまとめました。スコア評価の算定根拠やメートル法への換算などを適切に行い、検証も通過しています。

---
*PR created automatically by Jules for task [14500247428017052946](https://jules.google.com/task/14500247428017052946) started by @aegisfleet*