### PR TITLE
Add investigation data for B0DY7PJYYR

### DIFF
--- a/data/investigations/B0DY7PJYYR.json
+++ b/data/investigations/B0DY7PJYYR.json
@@ -1,0 +1,157 @@
+{
+  "analysis": {
+    "productName": "SwanScout 305G2",
+    "parentAsin": "B0DY7PJYYR",
+    "productDescription": "Pixel Watch 3/2およびFitbit製品に対応した1800mAhの小型モバイルバッテリー型充電器。キーホルダー設計で持ち運びやすく、外出先でのスマートウォッチ充電に適している。",
+    "productUsage": [
+      "外出先や旅行でのPixel Watch/Fitbitの充電",
+      "ケーブル不要での直接充電"
+    ],
+    "positivePoints": [
+      "1800mAhの容量を備え、Pixel Watch 3/2を3～4回フル充電可能",
+      "重さ約80gの軽量設計で、キーチェーンループが付いており携帯性に優れる",
+      "2.5Wの急速充電に対応し、約60分でフル充電が可能"
+    ],
+    "negativePoints": [
+      "Pixel Watch 1および4には非対応",
+      "スマホとの同時充電や大容量出力には対応していない（ウォッチ専用）"
+    ],
+    "useCases": [
+      "旅行・出張時の予備バッテリーとして",
+      "通勤・通学中にバックパックに取り付けて携帯"
+    ],
+    "userStories": [],
+    "userImpression": "1800mAhという十分な容量と約80gの軽量設計により、外出先でのスマートウォッチのバッテリー切れ不安を解消できる点が評価される一方、最新のPixel Watch 4や初代モデルには非対応であるため、自身のデバイスが対応機種に含まれるか事前確認が必要な製品。",
+    "sources": [
+      {
+        "id": "src-amazon",
+        "name": "Amazon.co.jp 製品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0DY7PJYYR",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-07-05",
+        "author": "SwanScout",
+        "conflictOfInterest": "possible",
+        "notes": "製品スペック、対応機種（Pixel Watch 3/2、Fitbit Sense/Versa等）、機能（1800mAh、88g、2.5W急速充電）を確認。"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "わずか60分で0％から100％まで充電可能",
+        "category": "comparativeAdvantage",
+        "confidence": "medium",
+        "supportingSourceIds": [
+          "src-amazon"
+        ],
+        "crossChecked": false,
+        "notes": "メーカーの主張。バッテリー容量や使用状況により変動する可能性がある。"
+      }
+    ],
+    "lastInvestigated": "2026-07-05",
+    "competitiveAnalysis": [
+      {
+        "name": "Miimall ポータブル充電ドック",
+        "asin": "B0H25BJTGC",
+        "priceComparison": "対象商品より高価。対象商品は自立したバッテリーを内蔵しているが、こちらは外部電源（モバイルバッテリーやPCなど）が必要なアダプター型。",
+        "featureComparison": [
+          "共通点：キーホルダーやストラップに対応した持ち運びやすい小型設計",
+          "相違点：対象商品は1800mAhのバッテリーを内蔵しているのに対し、競合商品はバッテリーを内蔵しておらず外部電源との接続が必須。また、競合商品はPixel Watch 4に対応している。"
+        ],
+        "differentiators": [
+          "SwanScout 305G2の利点：外出先で外部電源なしに独立してスマートウォッチを充電したい場合に最適。",
+          "Miimall ポータブル充電ドックの利点：すでにモバイルバッテリーを携帯しており、Pixel Watch 4用のコンパクトな充電アダプターを求めている場合に適している。"
+        ]
+      },
+      {
+        "name": "Ketcflaz Type-C充電変換アダプタ",
+        "asin": "B0FDVHL1C8",
+        "priceComparison": "対象商品より大幅に安価。単なるType-C変換アダプタであり、機能が限られている。",
+        "featureComparison": [
+          "共通点：Pixel Watch 2/3やFitbit Sense 2に対応したコンパクトな充電アイテム",
+          "相違点：対象商品はバッテリー内蔵型。競合商品は手持ちのType-Cケーブルの先端に取り付ける変換アダプタ。"
+        ],
+        "differentiators": [
+          "SwanScout 305G2の利点：ケーブルや電源すら不要で、単体でウォッチを充電したい人に最適。",
+          "Ketcflaz Type-C充電変換アダプタの利点：Type-Cケーブルを常に持ち歩いており、荷物を極限まで減らしたい（変換アダプタのみで済ませたい）人に適している。"
+        ]
+      },
+      {
+        "name": "INIU モバイルバッテリー 5000mAh",
+        "asin": "B0DSWF8PZD",
+        "priceComparison": "対象商品と同等の価格帯。",
+        "featureComparison": [
+          "共通点：スマートウォッチを充電できるモバイルバッテリー",
+          "相違点：対象商品は1800mAhでPixel Watch向け。競合商品は5000mAhでApple Watchおよびスマートフォン（USB-C）の充電に対応。"
+        ],
+        "differentiators": [
+          "SwanScout 305G2の利点：Pixel Watch 2/3ユーザー専用の軽量・コンパクトな充電ソリューションを求める人に適している。",
+          "INIU モバイルバッテリー 5000mAhの利点：Apple Watchやスマートフォンなど、複数のデバイスを同時に充電したいAppleユーザーに適している。"
+        ]
+      },
+      {
+        "name": "RORRY モバイルバッテリー 5000mAh",
+        "asin": "B0BNHQQ2KF",
+        "priceComparison": "対象商品よりやや高価。",
+        "featureComparison": [
+          "共通点：スマートウォッチとスマートフォンを充電できるモバイルバッテリー",
+          "相違点：対象商品はPixel Watch向け。競合商品はApple Watch専用の磁気充電機能と、iPhone/Type-C用のケーブルを内蔵している。"
+        ],
+        "differentiators": [
+          "SwanScout 305G2の利点：Pixel Watchユーザー向け。",
+          "RORRY モバイルバッテリー 5000mAhの利点：Apple WatchとiPhoneを同時に充電でき、ケーブル内蔵の利便性を求める人に適している。"
+        ]
+      },
+      {
+        "name": "Google Pixel Watch 4対応 充電ドック",
+        "asin": "B0GWJS2ZKD",
+        "priceComparison": "対象商品より安価。",
+        "featureComparison": [
+          "共通点：Pixel Watchシリーズの充電アイテム",
+          "相違点：対象商品はバッテリー内蔵でPixel Watch 2/3対応。競合商品は1mのケーブルが付属した標準的な充電ドックで、Pixel Watch 4に対応。"
+        ],
+        "differentiators": [
+          "SwanScout 305G2の利点：コンセントやPCがない外出先での充電を重視する人に最適。",
+          "Google Pixel Watch 4対応 充電ドックの利点：自宅やオフィスなど、固定の場所でPixel Watch 4を充電する基本用途に適している。"
+        ]
+      },
+      {
+        "name": "For Pixel Watch 2 in 1 充電ケーブル",
+        "asin": "B0FPXK34KM",
+        "priceComparison": "対象商品より大幅に安価。",
+        "featureComparison": [
+          "共通点：Pixel Watch 2/3に対応した充電器",
+          "相違点：対象商品はバッテリー内蔵型。競合商品はUSB-C/USB-Aの両方に対応するケーブル一体型の充電器。"
+        ],
+        "differentiators": [
+          "SwanScout 305G2の利点：ケーブル不要で完全に独立したモバイルバッテリーとして活用したい人に最適。",
+          "For Pixel Watch 2 in 1 充電ケーブルの利点：PCのUSB-AやUSB-Cポートなど、様々な給電元に柔軟に接続できるケーブルを安価に求める人に適している。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "Pixel Watch 2/3または対応するFitbitデバイスを使用しており、外出先でケーブルや外部電源に依存せずに充電したい人"
+      ],
+      "pros": [
+        "ケーブルを持ち歩かなくても、キーホルダー感覚で持ち運べるため、外出先でバッテリーが少なくなってもすぐに充電を開始できる"
+      ],
+      "cons": [
+        "Pixel Watch 4や初代モデルには非対応であるため、最新モデルへの買い替えを検討している人や初代ユーザーは使用できない"
+      ],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] ケーブルレスで独立して充電できる1800mAhのバッテリー内蔵という独自性と利便性\n[減点: -5] Pixel Watch 4および1に非対応という汎用性の低さ\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "15mm",
+        "width": "46mm",
+        "depth": "64mm"
+      },
+      "weight": "80g",
+      "capacity": "1800mAh",
+      "compatibility": "Google Pixel Watch 3/2, Fitbit Versa 4/Versa 3, Fitbit Sense 2/Sense, Ace LTE",
+      "incompatibility": "Google Pixel Watch 4, Google Pixel Watch 1",
+      "inputOutput": "2.5W急速充電対応"
+    }
+  }
+}


### PR DESCRIPTION
Adds investigation data for B0DY7PJYYR (SwanScout 305G2 Pixel Watch mobile battery) including competitor analysis, specifications in metric units, scoring, and source information following the required JSON schema.

---
*PR created automatically by Jules for task [11952406911701586607](https://jules.google.com/task/11952406911701586607) started by @aegisfleet*