### PR TITLE
Add investigation data for B0F9WJLW45

### DIFF
--- a/data/investigations/B0F9WJLW45.json
+++ b/data/investigations/B0F9WJLW45.json
@@ -1,0 +1,195 @@
+{
+  "analysis": {
+    "productName": "ASUS TUF Gaming VG259Q5A 24.5インチ ゲーミングモニター",
+    "parentAsin": "B0H7B8LQ4W",
+    "productDescription": "24.5インチのフルHD(1920x1080)解像度で200HzのリフレッシュレートとFast IPSパネルを搭載したゲーミングモニター。0.3ms(最小GTG)の応答速度とELMB技術を備え、滑らかでクリアなゲーム体験を提供する。",
+    "productUsage": [
+      "PCや家庭用ゲーム機でのFPS・TPSなどの競技性の高いゲームプレイ",
+      "滑らかな映像表示を活かした動画視聴や日常的なブラウジング"
+    ],
+    "positivePoints": [
+      "Fast IPSパネル採用により200Hzの高リフレッシュレートと最小0.3ms(GTG)の超高速応答を実現している",
+      "HDMI(v2.0)ポートを2つ、DisplayPort 1.4ポートを1つ備え、複数の機器を同時に接続できる",
+      "ASUS独自の「DisplayWidget Center」により、マウス操作で直感的にモニターの設定変更が可能である",
+      "12,980円という価格設定により、24.5インチ・200Hz・IPSパネルのゲーミングモニターとして非常に高いコストパフォーマンスを持つ"
+    ],
+    "negativePoints": [
+      "高さ調整や左右の首振り(スイーベル)機能がなく、前後の角度調整(チルト)のみの対応となっている",
+      "HDR(High Dynamic Range)機能には非対応であるため、明暗差の激しい映像表現では上位機種に劣る",
+      "内蔵のステレオスピーカーは2W+2Wの出力であり、高音質を求める場合は外部スピーカーやヘッドセットが必要になる"
+    ],
+    "useCases": [
+      "FPS/TPSでフレームレートや応答速度を重視するゲーマーのメインモニターとして",
+      "限られた予算で200HzクラスのIPSモニターを導入したいエントリーからミドル層向けの環境構築"
+    ],
+    "userStories": [
+      {
+        "userType": "FPS/TPSゲーマー",
+        "scenario": "PCでApex LegendsやValorantをプレイする",
+        "experience": "これまで144Hzのモニターを使用していたが、200HzのFast IPSパネルと0.3msの応答速度のおかげで、激しい視点移動時でも残像感が減り敵の動きを追いやすくなった。高さ調整機能がない点はモニターアームを別途用意することで解決した。コストを抑えつつ200Hz環境へアップグレードできたことが一番の決め手である。",
+        "supportingSourceIds": [
+          "src-amazon-reviews"
+        ],
+        "sentiment": "positive"
+      }
+    ],
+    "userImpression": "価格の安さと200Hz/Fast IPSという基本性能の高さに対する評価が非常に高く、特にFPSなどの競技タイトルをプレイするユーザーからの満足度が高い。一方で、スタンドの調整機能がチルト(前後の傾き)のみである点や、内蔵スピーカーの音質については妥協点として挙げられているが、多くのユーザーはモニターアームを使用したりヘッドセットを併用したりすることで許容している。コストパフォーマンスを重視して高リフレッシュレート環境を手に入れたいユーザーにとって、理想的な選択肢となっている。",
+    "sources": [
+      {
+        "id": "src-amazon-reviews",
+        "name": "Amazonカスタマーレビュー",
+        "url": "https://www.amazon.co.jp/dp/B0F9WJLW45",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-06-13",
+        "author": "Amazon購入者",
+        "conflictOfInterest": "none",
+        "notes": "200HzとFast IPSによる残像感の少なさ、価格に対する性能の高さ、スタンドの調整機能がチルトのみである点に関する言及を確認"
+      },
+      {
+        "id": "src-asus-official",
+        "name": "ASUS公式製品ページ VG259Q5A",
+        "url": "https://www.asus.com/jp/displays-desktops/monitors/tuf-gaming/tuf-gaming-vg259q5a/",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-06-13",
+        "author": "ASUS",
+        "conflictOfInterest": "none",
+        "notes": "24.5インチ、Fast IPS、200Hz、0.3ms(GTG)、チルト調整のみなどの基本スペックと製品仕様を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "ASUS Fast IPSディスプレイは、従来のIPSパネルより液晶素子のスイッチングを4倍速にすることで、0.3ms（GTG）の応答速度を実現している",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-asus-official"
+        ],
+        "crossChecked": true,
+        "notes": "ASUS公式サイトの製品特徴ページにて、Fast IPS技術による応答速度向上のメカニズムとして記載されていることを確認"
+      }
+    ],
+    "lastInvestigated": "2026-07-08",
+    "competitiveAnalysis": [
+      {
+        "name": "INNOCN 25G2G",
+        "asin": "B0DNKC8HXP",
+        "priceComparison": "対象商品とほぼ同等（約12,000円台）であり、200Hz・IPSパネルの最安クラスで直接的な競合となる。",
+        "featureComparison": [
+          "共通点：24.5インチのIPSパネルを採用し、200Hzの高リフレッシュレートと1msの応答速度を備える点",
+          "相違点：対象商品は0.3ms(GTG最小)の応答速度とASUS独自のDisplayWidget Center機能を持つ。INNOCN 25G2Gはより低価格だが、ブランドの信頼性や専用のソフトウェア制御機能において対象商品に劣る"
+        ],
+        "differentiators": [
+          "ASUS TUF Gaming VG259Q5Aの利点：PC上からマウス操作で設定変更できる利便性や、ASUSという大手ゲーミングブランドの信頼性、0.3msというより高速な応答速度を重視するなら迷わずこちら",
+          "INNOCN 25G2Gの利点：ブランドにはこだわらず、1円でも安く200Hz・IPSのゲーミングモニターを手に入れたい場合に適している"
+        ]
+      },
+      {
+        "name": "IODATA EX-GD251UH",
+        "asin": "B0FLC2Y42B",
+        "priceComparison": "対象商品より約2,000円高いが、リフレッシュレートが240Hzとなっており、価格差に見合ったスペック向上が見込める。",
+        "featureComparison": [
+          "共通点：24.5インチのパネルを採用し、1msの応答速度を持つフルHDゲーミングモニターである点",
+          "相違点：対象商品は200HzのIPSパネルだが、EX-GD251UHは240Hzのリフレッシュレートを持つAHVA(IPS系)パネルを採用している"
+        ],
+        "differentiators": [
+          "ASUS TUF Gaming VG259Q5Aの利点：200Hzで十分な性能を確保しつつ、13,000円以下という絶対的な安さ・コストパフォーマンスを最優先するならこちら",
+          "IODATA EX-GD251UHの利点：少し予算を追加してでも、200Hzではなく競技向けスタンダードになりつつある240Hzのリフレッシュレート環境を構築したい場合に適している"
+        ]
+      },
+      {
+        "name": "ASUS ROG Strix XG259CS-J",
+        "asin": "B08HYH95Z8",
+        "priceComparison": "対象商品より約4,000円高い。上位ブランドのROGシリーズであり、USB Type-C給電やHDR対応などの付加価値による価格差である。",
+        "featureComparison": [
+          "共通点：ASUS製の24.5インチ・Fast IPSパネルを採用したゲーミングモニターである点",
+          "相違点：対象商品は200Hzで基本機能に絞っているが、XG259CS-Jは180Hzであるものの、USB Type-C(15W給電対応)端子を備え、HDRやより広範なエルゴノミクススタンド(高さ調整・スイーベル対応)を搭載している"
+        ],
+        "differentiators": [
+          "ASUS TUF Gaming VG259Q5Aの利点：スタンドの調整機能やUSB Type-C接続、HDRを必要とせず、純粋に高いリフレッシュレートを低価格で求めるなら迷わずこちら",
+          "ASUS ROG Strix XG259CS-Jの利点：モニターの高さ調整機能が必須な人や、ノートPC等をType-Cで接続して映像出力と給電を同時に行いたい場合に適している"
+        ]
+      },
+      {
+        "name": "KOORUI G2511P",
+        "asin": "B0F4892J8W",
+        "priceComparison": "対象商品より約5,800円高い。スペックは似ているが価格差が大きいため、対象商品のコストパフォーマンスの高さが際立つ。",
+        "featureComparison": [
+          "共通点：24.5インチのIPSパネルで、200Hzのリフレッシュレートと1msの応答速度を持つ点",
+          "相違点：対象商品が12,980円であるのに対し、G2511PはHDR400に対応しているものの価格が18,000円台と割高である"
+        ],
+        "differentiators": [
+          "ASUS TUF Gaming VG259Q5Aの利点：同等の基本スペック(24.5インチ/200Hz/IPS)でありながら大幅に価格が安く、コストパフォーマンスを最優先するなら迷わずこちら",
+          "KOORUI G2511Pの利点：HDR400の認証を受けているため、HDRコンテンツの視聴や対応ゲームでの明暗表現を重視する場合に適している"
+        ]
+      },
+      {
+        "name": "BenQ MOBIUZ EX251",
+        "asin": "B0DT3NLNCC",
+        "priceComparison": "対象商品より約6,800円高い。より高いリフレッシュレートと高音質スピーカー、独自の自動輝度調整機能を搭載しているため妥当な価格差。",
+        "featureComparison": [
+          "共通点：24.5インチのIPSパネルを採用し、1msの応答速度を持つフルHDゲーミングモニターである点",
+          "相違点：対象商品は200Hzで価格を抑えているが、EX251は220Hz、HDR400対応、高音質の2.5W×2スピーカー、周辺の明るさを検知して自動調整するB.I.+ Gen2機能を備える"
+        ],
+        "differentiators": [
+          "ASUS TUF Gaming VG259Q5Aの利点：付加機能よりも圧倒的な低価格を重視し、スピーカーは外部のものを使用する前提の人ならこちら",
+          "BenQ MOBIUZ EX251の利点：内蔵スピーカーだけで十分な高音質を楽しみたい人や、独自のB.I.+機能による目の疲れ軽減効果を重視する人に適している"
+        ]
+      },
+      {
+        "name": "Pixio PX259 Prime",
+        "asin": "B00CWXQIFE",
+        "priceComparison": "対象商品より約7,800円高い。280Hzという非常に高いリフレッシュレートとホワイトカラーのデザインによる価格差である。",
+        "featureComparison": [
+          "共通点：24.5インチのIPSパネルを採用したフルHDゲーミングモニターである点",
+          "相違点：対象商品は200Hzでブラックカラーだが、PX259 Primeは280Hzの超高リフレッシュレートを誇り、筐体がホワイトカラーで統一されている"
+        ],
+        "differentiators": [
+          "ASUS TUF Gaming VG259Q5Aの利点：200Hzで十分な性能と判断でき、予算を1万円台前半に抑えたいなら迷わずこちら",
+          "Pixio PX259 Primeの利点：240Hzを超える280Hzの極めて滑らかな映像を求める人や、デスク周りを白色のデバイスで統一したい場合に適している"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "限られた予算で競技向け(200Hz/IPS)の高性能モニターを導入したいPCゲーマー（より高価な240Hz機や多機能機より安さを優先する人）",
+        "外部スピーカーやモニターアームを使用する前提で、モニター本体のコストを極力抑えたい環境構築者"
+      ],
+      "pros": [
+        "12,980円という破格の安さで、200Hz・Fast IPSによる残像感の少ない滑らかなゲーム映像を体験でき、FPS等でのエイム精度向上が期待できる",
+        "「DisplayWidget Center」対応により、わざわざモニター背面のボタンに手を伸ばさずともマウス操作でサクサクと明るさや色味の調整が完了する"
+      ],
+      "cons": [
+        "スタンドの調整機能が前後の傾き(チルト)のみであるため、適切な画面の高さに調整したい場合はモニターアームや台座を別途用意する必要がある",
+        "HDR機能が省かれているため、映像の明暗表現の豊かさを重視するRPGや映画視聴には特化していない"
+      ],
+      "score": 90,
+      "scoreRationale": "[基本点: 70]\n[加点: +15] (24.5インチ/200Hz/Fast IPSという高い基本スペックに対して12,980円という圧倒的なコストパフォーマンス)\n[加点: +5] (最小0.3msの超高速応答とDisplayWidget Center対応による高い実用性)\n[加点: +5] (ASUSという大手ブランドの高い信頼性と品質保証)\n[減点: -5] (スタンドの調整機能がチルトのみであり、設置の自由度が低い)\n[合計: 90]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "401mm",
+        "width": "559mm",
+        "depth": "174mm"
+      },
+      "weight": "3400g",
+      "displaySize": "24.5インチ",
+      "resolution": "1920x1080 (フルHD)",
+      "panelType": "Fast IPS (アンチグレア)",
+      "refreshRate": "200Hz",
+      "responseTime": "1ms (GTG), 0.3ms (最小GTG)",
+      "contrastRatio": "1,000:1 (Typ)",
+      "brightness": "300cd/m2",
+      "viewingAngle": "水平178° / 垂直178°",
+      "speakers": "2W x 2 ステレオスピーカー",
+      "ports": [
+        "DisplayPort 1.4 x 1",
+        "HDMI(v2.0) x 2",
+        "3.5mmステレオミニジャック"
+      ],
+      "vesaMount": "100mm x 100mm 対応",
+      "powerConsumption": "13.6W未満 (Typ)"
+    }
+  }
+}


### PR DESCRIPTION
Added the required JSON investigation file for the ASUS TUF Gaming VG259Q5A monitor (ASIN: B0F9WJLW45), including specs, user stories, competitive analysis, and score rationale, and verified it using the provided validation script.

---
*PR created automatically by Jules for task [12766700180821979851](https://jules.google.com/task/12766700180821979851) started by @aegisfleet*