### PR TITLE
Add investigation JSON for B0FG822M7V

### DIFF
--- a/data/investigations/B0FG822M7V.json
+++ b/data/investigations/B0FG822M7V.json
@@ -1,0 +1,178 @@
+{
+  "analysis": {
+    "productName": "CCZ C03 TYPE-C リケーブル",
+    "parentAsin": "B0FHJJ4BT4",
+    "productDescription": "4N銀メッキ無酸素銅ダブル並列アップグレードケーブルを採用し、KT0231 DACデコーダチップを内蔵したType-Cインターフェース用リケーブル。マイク付きでTFZプラグに対応し、快適な装着感と高解像度音質を実現する。",
+    "productUsage": [
+      "Type-C対応のスマートフォンやタブレットでの高音質音楽鑑賞",
+      "TFZプラグ採用イヤホンのアップグレード・交換",
+      "マイク付きケーブルによる通話・オンライン会議・ゲーム"
+    ],
+    "positivePoints": [
+      "4N84芯銀メッキ無酸素銅ダブルパラレルワイヤーによる音のディテールと高周波応答の向上",
+      "KT0231 DACデコードチップ内蔵によりプラグアンドプレイでHIFI音質を提供",
+      "200デニールの繊維で覆われた絡まりにくい設計と、5000回の抜き差しテストをクリアした高耐久性",
+      "マイク付きでType-Cデバイス（Android/PC/タブレット）に直結可能"
+    ],
+    "negativePoints": [
+      "対象機器がType-Cポート搭載デバイス及びTFZピン仕様のイヤホンに限定される",
+      "有線接続のため、完全ワイヤレスを求めるユーザーの用途には合致しない"
+    ],
+    "useCases": [
+      "外出先でスマートフォンから手軽に高解像度の音楽を楽しみたいシーン",
+      "オンライン通話やゲーム時にマイクを使用してクリアな音声を届けたい時",
+      "イヤホンの標準ケーブルが断線した際の交換や、音質向上のためのリケーブル時"
+    ],
+    "userStories": [],
+    "userImpression": "Type-C接続でDACを内蔵しているため、変換アダプタ不要でスマートフォン等に直結でき、手軽に音質向上が図れる点が高く評価できる。また、マイク付きで通話など日常使いにも便利。TFZ端子に限定されるという制約はあるが、対応イヤホンを持つユーザーにとっては、価格と性能のバランスが取れた手堅いアップグレードケーブルと言える。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon商品ページ",
+        "url": "https://www.amazon.co.jp/dp/B0FG822M7V",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-07-21",
+        "author": "KINBOOFI",
+        "conflictOfInterest": "disclosed",
+        "notes": "製品仕様、特徴、価格情報の確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "KT0231 DACデコードチップを内蔵し、プラグアンドプレイでHIFI音質を楽しむことができる",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "メーカーの仕様説明に基づく。Type-C接続においてDAC内蔵は事実であり、設定不要で直結できる利便性がある"
+      },
+      {
+        "claim": "5000回の抜き差しテストに合格しており、耐久性に優れる",
+        "category": "durability",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "メーカーの品質試験データに基づく"
+      }
+    ],
+    "lastInvestigated": "2026-07-21",
+    "competitiveAnalysis": [
+      {
+        "name": "CCZ C03 4N銀メッキ無酸素銅 リケーブル 2pin",
+        "asin": "B0FGD21S8Y",
+        "priceComparison": "本商品は1,999円、当競合品は1,800円と若干安価だがほぼ同等。",
+        "featureComparison": [
+          "共通点：4N銀メッキ無酸素銅ダブル並列ケーブル、KT0231 DACチップ内蔵、Type-C接続、マイク付き",
+          "相違点：本商品はTFZプラグだが、当競合品は2pinプラグを採用"
+        ],
+        "differentiators": [
+          "CCZ C03 TYPE-C リケーブルの利点：TFZ規格のイヤホンを使用しているなら迷わずこちら。",
+          "CCZ C03 4N銀メッキ無酸素銅 リケーブル 2pinの利点：0.78mm 2pin規格のイヤホンを所有しているユーザーに適している。"
+        ]
+      },
+      {
+        "name": "KBEAR P36 Type-Cイヤホン リケーブル",
+        "asin": "B0G3PMGMNZ",
+        "priceComparison": "本商品は1,999円に対し、当競合品は3,780円と高価。",
+        "featureComparison": [
+          "共通点：Type-C接続のアップグレードケーブル",
+          "相違点：当競合品はCX31991チップ（32bit/384kHz対応）と5N2股98芯無酸素銅メッキ銀ケーブルを採用し、より上位のスペックを持つ"
+        ],
+        "differentiators": [
+          "CCZ C03 TYPE-C リケーブルの利点：手頃な価格で手軽にType-C直結とマイク機能を追加したいコスト重視のユーザーに最適。",
+          "KBEAR P36 Type-Cイヤホン リケーブルの利点：より高性能なDACチップと高品質な5Nケーブルによる本格的な音質向上を求めるユーザーに適している。"
+        ]
+      },
+      {
+        "name": "NICEHCK SP4 イヤホンリケーブル 2Pin",
+        "asin": "B0D83DB12M",
+        "priceComparison": "本商品は1,999円に対し、当競合品は3,699円と高価。",
+        "featureComparison": [
+          "共通点：Type-C接続、マイク付き、DACチップ内蔵",
+          "相違点：当競合品はCX31993 DACチップを搭載し、ケーブル材質が4本無酸素銅OFC+銀メッキ無酸素銅OFCのハイブリッド、プラグは0.78mm 2pin"
+        ],
+        "differentiators": [
+          "CCZ C03 TYPE-C リケーブルの利点：TFZプラグ対応でコストパフォーマンスに優れたType-Cケーブルを探している方に。",
+          "NICEHCK SP4 イヤホンリケーブル 2Pinの利点：2pinイヤホンでより上位のDACチップとハイブリッドケーブルの音質を楽しみたい方に。"
+        ]
+      },
+      {
+        "name": "3APLUS HBC13 Type-cケーブル",
+        "asin": "B0G93PGBR5",
+        "priceComparison": "本商品は1,999円、当競合品は2,457円で当競合品がやや高い。",
+        "featureComparison": [
+          "共通点：Type-C接続のイヤホンケーブル、高純度OFC銀メッキ",
+          "相違点：当競合品はSENNHEISER IE100pro等の特定機種専用コネクタを採用している"
+        ],
+        "differentiators": [
+          "CCZ C03 TYPE-C リケーブルの利点：TFZ規格の汎用イヤホンをType-C接続で手軽に使いたい方に。",
+          "3APLUS HBC13 Type-cケーブルの利点：SENNHEISER IEシリーズ（IE100pro等）専用のリケーブルを求めている方に。"
+        ]
+      },
+      {
+        "name": "Yinyoo CCZ C02 2PIN Type-C リケーブル",
+        "asin": "B0FD9XPKFR",
+        "priceComparison": "本商品は1,999円、当競合品は1,899円と価格差はほとんどない。",
+        "featureComparison": [
+          "共通点：4N 84芯無酸素銅ダブル並列ケーブル、KT0231 DACチップ内蔵、Type-C接続、マイク付き",
+          "相違点：本商品はTFZプラグ、当競合品は2pinプラグを採用"
+        ],
+        "differentiators": [
+          "CCZ C03 TYPE-C リケーブルの利点：TFZプラグのイヤホンユーザーならこちらを選択すべき。",
+          "Yinyoo CCZ C02 2PIN Type-C リケーブルの利点：一般的な0.78mm 2pin仕様のイヤホンを使用している方に適している。"
+        ]
+      },
+      {
+        "name": "Yinyoo KBEAR 4994 Type-c リケーブル QDC",
+        "asin": "B0FVWNKNKR",
+        "priceComparison": "本商品は1,999円、当競合品は1,599円と当競合品の方が安価。",
+        "featureComparison": [
+          "共通点：4N 84芯無酸素銅ダブル並列、DAC搭載、Type-C接続",
+          "相違点：本商品はTFZプラグ・マイク付き、当競合品はQDCプラグでマイクなし仕様"
+        ],
+        "differentiators": [
+          "CCZ C03 TYPE-C リケーブルの利点：TFZプラグのイヤホンを使用し、通話やゲーム用にマイク機能が必須な方に最適。",
+          "Yinyoo KBEAR 4994 Type-c リケーブル QDCの利点：QDC仕様のイヤホンを使用し、マイク機能が不要でより低価格なケーブルを求める方に。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "TFZ端子採用のイヤホンを所有し、スマートフォン等のType-Cポートに変換アダプタなしで直接接続したいユーザー",
+        "通話やオンライン会議、ゲーム用途でマイク付きのケーブルを探している人",
+        "上位の高性能DAC搭載ケーブル（3,000円台〜）よりも、コストを抑えつつ基本性能と使い勝手を向上させたいコスト重視のユーザー"
+      ],
+      "pros": [
+        "DACチップ（KT0231）内蔵により、イヤホンジャックがない最近のスマートフォンでもアダプタ不要でそのまま高音質を楽しめる",
+        "絡まりにくい繊維被膜と5000回の耐久テストをクリアした設計で、日常的に持ち歩いてもストレスが少なく長持ちする",
+        "マイク機能が搭載されているため、音楽鑑賞中に電話が来てもそのまま通話でき、リモートワークやゲーム用としても重宝する"
+      ],
+      "cons": [
+        "イヤホン側の端子がTFZ規格に限定されるため、一般的な2pinやMMCXのイヤホンを使用しているユーザーは接続できない",
+        "上位のDACチップ（CX31993等）を搭載したモデルと比べると音質面での限界があるため、究極の音質を追求するオーディオマニアには不向き"
+      ],
+      "score": 80,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (KT0231 DACチップ内蔵で手軽にType-C直結が可能な利便性)\n[加点: +5] (2,000円を切る価格で4N銀メッキOFCとマイク機能を提供するコストパフォーマンス)\n[合計: 80]"
+    },
+    "technicalSpecs": {
+      "cableLength": "1.2m",
+      "weight": "0.0195kg",
+      "material": "4N銀メッキ無酸素銅 (84芯ダブルパラレルワイヤー), 200デニール繊維被覆",
+      "plugType": "Type-C",
+      "connectorType": "TFZ",
+      "dacChip": "KT0231",
+      "features": [
+        "マイク内蔵",
+        "金メッキピン"
+      ],
+      "other": [
+        "5000回抜き差しテスト合格"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the investigation JSON for the CCZ C03 TYPE-C recable (ASIN: B0FG822M7V).

It includes detailed specification, competitive analysis of 6 similar ASINs, proper pros/cons, and calculates a base score of 80 using standard criteria. Metric system measurements were used properly, and an empty user stories array was set due to the lack of evidence of actual user reviews for this particular ASIN.

---
*PR created automatically by Jules for task [12665742493672711002](https://jules.google.com/task/12665742493672711002) started by @aegisfleet*