### PR TITLE
Add investigation data for Anker Soundcore Nebula P1i (B0FY2XXWPJ)

### DIFF
--- a/data/investigations/B0FY2XXWPJ.json
+++ b/data/investigations/B0FY2XXWPJ.json
@@ -1,0 +1,104 @@
+{
+  "analysis": {
+    "productName": "Anker Soundcore Nebula P1i",
+    "parentAsin": "B0FY2XXWPJ",
+    "productDescription": "フリップ式スピーカーを搭載し、音の向きを自在にコントロールできるGoogle TV搭載ホームプロジェクター。380ANSIルーメンのフルHD画質と最大15°の角度調整が可能なスタンドにより、自由な設置と没入感の高い映像体験を提供します。",
+    "productUsage": [
+      "自宅での映画やドラマの鑑賞",
+      "部屋を移動しての映像再生",
+      "斜めからの投影や限られたスペースでの設置"
+    ],
+    "positivePoints": [
+      "左右90°、上下200°に回転するフリップ式スピーカー（合計20W、Dolby Audio対応）を搭載",
+      "380ANSIルーメンの明るさとフルHDの高解像度によるクリアな映像",
+      "最大15°まで角度調整可能なスタンドと持ち運び用の取り外し可能なハンドルを装備",
+      "Google TV搭載で10,000以上のアプリ（Netflix、YouTube等）に直接アクセス可能",
+      "「IEA 3.0」による垂直・水平の自動台形補正、オートフォーカス、スクリーンフィット、障害物回避機能"
+    ],
+    "negativePoints": [
+      "プロジェクター本体にバッテリーが搭載されていないため、常に電源接続が必要"
+    ],
+    "useCases": [
+      "寝室の壁や天井など、好きな場所に映像を映して寝転がりながら視聴する",
+      "リビングで家族と大画面（最大150インチ）で映画を楽しむ",
+      "スピーカーの向きを調整し、部屋の隅に設置しても自分の方へ音を向ける"
+    ],
+    "userStories": [],
+    "userImpression": "フリップ式スピーカーによる音の指向性コントロールと、Google TV搭載の利便性が高く評価される一方で、バッテリー非搭載のためコンセントがある場所での使用に限定される点が注意されます。しかし、優れた自動補正機能と角度調整スタンドにより、設置の自由度の高さで十分カバーできると考えるユーザーが多いモデルです。",
+    "sources": [],
+    "claims": [
+      {
+        "claim": "世界初フリップ式スピーカー搭載ホームプロジェクター",
+        "category": "comparativeAdvantage",
+        "confidence": "high",
+        "supportingSourceIds": [],
+        "crossChecked": false,
+        "notes": "Anker調べ（2026年1月時点）"
+      }
+    ],
+    "lastInvestigated": "2026-07-22",
+    "competitiveAnalysis": [
+      {
+        "name": "Anker Nebula Capsule 3",
+        "asin": "B0CJDV213W",
+        "priceComparison": "対象商品（49,990円）と比較して約20,000円高価（69,990円）。バッテリー内蔵のモバイル性が追加される分の価格差です。",
+        "featureComparison": [
+          "共通点：Anker製でGoogle TVを搭載し、フルHDの高画質を提供する点",
+          "相違点：対象商品が据え置き・電源必須でフリップ式スピーカーを搭載するのに対し、Capsule 3はバッテリー内蔵のモバイルプロジェクターである点"
+        ],
+        "differentiators": [
+          "Anker Soundcore Nebula P1iの利点：コンセントがある環境で、より迫力ある音響（20Wフリップスピーカー）を楽しみたいならこちら",
+          "Anker Nebula Capsule 3の利点：アウトドアやコンセントがない部屋でも完全ワイヤレスで使いたいならこちら"
+        ]
+      },
+      {
+        "name": "Anker Nebula Capsule Air",
+        "asin": "B0CXY3S1MP",
+        "priceComparison": "対象商品（49,990円）と同等の価格帯。",
+        "featureComparison": [
+          "共通点：Anker製のプロジェクターでGoogle TVを搭載している点",
+          "相違点：対象商品が高音質・据え置き型であるのに対し、Capsule Airは超小型のモバイル性に特化している点"
+        ],
+        "differentiators": [
+          "Anker Soundcore Nebula P1iの利点：自宅内での使用がメインで、音質と設置のしやすさ（自動補正・スタンド）を重視するならこちら",
+          "Anker Nebula Capsule Airの利点：とにかく小さくて持ち運びに便利なサイズ感を最優先するならこちら"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "自宅で映画を見る機会が多く、音質や音の向きにこだわりたいが、本格的な音響システムの構築までは考えていない人",
+        "設置場所が部屋の隅などになりがちで、強力な自動台形補正や障害物回避機能を求める人"
+      ],
+      "pros": [
+        "スピーカーを自分の方へ向けられるため、斜め投影時でも映像と音のズレを感じにくく没入感が高い",
+        "最新のGoogle TV搭載により、外部デバイス不要で豊富なコンテンツをリモコン一つで快適に楽しめる"
+      ],
+      "cons": [
+        "バッテリー非搭載のため、屋外やコンセントから遠い場所での使用には向かない"
+      ],
+      "score": 85,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (フリップ式スピーカーによる音響の自由度)\n[加点: +5] (充実した自動補正機能（IEA 3.0）による設置の容易さ)\n[加点: +5] (5万円を切る価格でGoogle TV・フルHD・380ANSIを実現したコスパの良さ)\n[合計: 85]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "height": "228mm",
+        "width": "204mm",
+        "depth": "183mm"
+      },
+      "weight": "不明",
+      "resolution": "フルHD (1080p)",
+      "brightness": "380 ANSIルーメン",
+      "speaker": "合計20W (フリップ式、Dolby Audio対応)",
+      "os": "Google TV",
+      "connectivity": "Wi-Fi (2.4GHz/5GHz), Bluetooth (2.4GHz)",
+      "correction": "IEA 3.0 (垂直・水平自動台形補正、オートフォーカス、スクリーンフィット、障害物回避)",
+      "battery": "非搭載",
+      "other": [
+        "最大381cm投影可能",
+        "最大15°角度調節可能スタンド",
+        "取り外し可能ハンドル付属"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds investigation file for Anker Soundcore Nebula P1i (B0FY2XXWPJ).
Converts inches to metric units.
Includes score and competitive analysis.

---
*PR created automatically by Jules for task [13933164932562735545](https://jules.google.com/task/13933164932562735545) started by @aegisfleet*