### PR TITLE
Investigate YAMAHA PSR-E283 (B0D1PRWS49)

### DIFF
--- a/data/investigations/B0D1PRWS49.json
+++ b/data/investigations/B0D1PRWS49.json
@@ -1,0 +1,131 @@
+{
+  "analysis": {
+    "productName": "ヤマハ キーボード PSR-E283",
+    "parentAsin": "B0D1PRWS49",
+    "productDescription": "多彩な410音色と自動伴奏機能、楽しいクイズモードを備え、初心者でも楽しく演奏できる61鍵盤のエントリーモデルキーボード。",
+    "productUsage": [
+      "初めてのキーボード練習",
+      "クイズモードで遊びながらの音感育成",
+      "家族でのアンサンブル（デュオモード）"
+    ],
+    "positivePoints": [
+      "410種類の多彩な音色を内蔵",
+      "指1本で自動的に豪華な伴奏が鳴るスマートコード機能",
+      "音当てクイズなど遊びながら学べる機能搭載",
+      "右手、左手、両手別に練習できる3ステップレッスン",
+      "電池駆動に対応し、場所を選ばず演奏可能",
+      "重さ4.0kgと軽量設計"
+    ],
+    "negativePoints": [
+      "タッチレスポンス（鍵盤を弾く強さによる音量変化）非搭載",
+      "USB TO HOSTなどの外部接続端子が少なく、MIDIキーボードとしては使いにくい",
+      "スピーカー出力が2.5W+2.5Wで、本格的な演奏には物足りない"
+    ],
+    "useCases": [
+      "子どもへの初めての鍵盤楽器プレゼント",
+      "大人の趣味としての気軽な楽器演奏",
+      "リビングや子供部屋でのキーボード練習"
+    ],
+    "userStories": [],
+    "userImpression": "初心者が『弾く楽しさ』を味わうことに特化したモデル。クイズやレッスン機能が充実しており、特に子供の初めての楽器として評価が高い。一方でタッチレスポンスがないため、ピアノの本格的な代用にはならない点に注意が必要。",
+    "sources": [
+      {
+        "id": "src-yamaha-official",
+        "name": "YAMAHA公式製品ページ PSR-E283",
+        "url": "https://jp.yamaha.com/products/musical_instruments/keyboards/portable_keyboards/psr-e283/index.html",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-05-30",
+        "author": "YAMAHA",
+        "conflictOfInterest": "possible",
+        "notes": "仕様、機能詳細（クイズ、スマートコード、レッスン等）を確認"
+      },
+      {
+        "id": "src-yamaha-official-specs",
+        "name": "YAMAHA公式製品ページ PSR-E283 仕様",
+        "url": "https://jp.yamaha.com/products/musical_instruments/keyboards/portable_keyboards/psr-e283/specs.html",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2024-05-30",
+        "author": "YAMAHA",
+        "conflictOfInterest": "possible",
+        "notes": "詳細スペック（サイズ、重量、端子など）を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "遊びながら音を聞き分ける力をつけられる（音当てクイズなど）",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-yamaha-official"
+        ],
+        "crossChecked": false,
+        "notes": "公式の機能説明通り"
+      }
+    ],
+    "lastInvestigated": "2026-07-29",
+    "competitiveAnalysis": [
+      {
+        "name": "CASIO Casiotone CT-S195",
+        "asin": "B08YMZ27H4",
+        "priceComparison": "同価格帯（CT-S195が微高）",
+        "featureComparison": [
+          "共通点：61鍵盤、タッチレスポンスなし、軽量で電池駆動対応",
+          "相違点：PSR-E283はクイズやレッスンなどの機能が充実しているのに対し、CT-S195はよりシンプルで直感的な操作と持ち運びやすいグリップ付きデザインが特徴。"
+        ],
+        "differentiators": [
+          "ヤマハ キーボード PSR-E283の利点：機能を使って遊びながら楽しく上達したい人や、スマートコードで自動伴奏を楽しみたい人に最適。",
+          "CASIO Casiotone CT-S195の利点：機能がシンプルで、部屋間の持ち運びやすさや直感的な操作性を重視する人に適している。"
+        ]
+      },
+      {
+        "name": "ヤマハ キーボード PSR-E383",
+        "asin": "B0D1Q73669",
+        "priceComparison": "PSR-E283より上位モデルで価格が高い",
+        "featureComparison": [
+          "共通点：61鍵盤、ヤマハのレッスン機能や自動伴奏を搭載",
+          "相違点：PSR-E383はタッチレスポンスを搭載し、音色数（650）やスピーカー出力も優れている。"
+        ],
+        "differentiators": [
+          "ヤマハ キーボード PSR-E283の利点：価格を抑えてまずは気軽に楽器に触れたい、タッチレスポンスは不要という初心者向け。",
+          "ヤマハ キーボード PSR-E383の利点：ピアノ本来の強弱表現（タッチレスポンス）を学びたい人や、将来的にピアノへのステップアップを考えている人向け。"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "初めて鍵盤楽器に触れる子供や、遊び感覚で音感を身につけさせたい親",
+        "ピアノの本格的な練習ではなく、手軽に自動伴奏などで音楽を楽しみたい大人"
+      ],
+      "pros": [
+        "多彩な音色や楽しいクイズ機能で、練習が飽きにくい",
+        "スマートコード機能により、初心者でもすぐに豪華な伴奏付きの演奏が楽しめる",
+        "電池駆動と軽量設計で、出し入れや片付けが苦にならない"
+      ],
+      "cons": [
+        "タッチレスポンスがないため、ピアノ教室に通う前提の練習用としては不十分",
+        "本格的なMIDI入力用キーボードとしては拡張性が低い"
+      ],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +10] (初心者が楽しめるレッスン機能やクイズ機能の充実)\n[減点: -5] (タッチレスポンス非搭載による用途の制限)\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "dimensions": {
+        "width": "940mm",
+        "height": "104mm",
+        "depth": "317mm"
+      },
+      "weight": "4.0kg（乾電池除く）",
+      "keyboard": "61鍵盤",
+      "polyphony": "最大32音",
+      "voices": "410音色",
+      "styles": "150スタイル",
+      "songs": "122曲（リズムスタディ、コードスタディ含む）",
+      "amplifiers": "2.5W + 2.5W",
+      "speakers": "12cm x 2",
+      "connections": "ヘッドホン/OUTPUT兼用（ステレオ標準フォーン）、サステインペダル、AUX IN（ステレオミニ）",
+      "powerSupply": "電源アダプター（PA-130C等）、単3電池×6本（別売）"
+    }
+  }
+}


### PR DESCRIPTION
ヤマハのポータブル・アレンジャーキーボード「PSR-E283」に関する調査を行い、情報を指定されたJSONフォーマットにまとめて出力しました。
サイズの単位をメートル法に変換し、検索結果から確認された競合商品（CASIO CT-S195、YAMAHA PSR-E383）との比較を行っています。
レビューソースが不足していたため、架空のuserStoriesは含めていません。

---
*PR created automatically by Jules for task [9980376274650912641](https://jules.google.com/task/9980376274650912641) started by @aegisfleet*