### PR TITLE
Add investigation data for Haqquio B0H26DMS4G

### DIFF
--- a/data/investigations/B0H26DMS4G.json
+++ b/data/investigations/B0H26DMS4G.json
@@ -1,0 +1,190 @@
+{
+  "analysis": {
+    "productName": "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）",
+    "parentAsin": "B0HDN8JXS5",
+    "productDescription": "充電ケースに高精細タッチスクリーンを搭載し、ケース上で10種類の操作が可能なワイヤレスイヤホン。ANC搭載、片耳3.7gの超軽量設計で、Bluetooth 6.0による安定接続を実現。",
+    "productUsage": [
+      "音楽鑑賞",
+      "ハンズフリー通話",
+      "オンライン会議"
+    ],
+    "positivePoints": [
+      "充電ケースにタッチスクリーンを搭載し、スマホを取り出さずに10種類の機能を操作可能",
+      "4モードのANC（標準、ANC、自動適応、外音取り込み）と5種類のイコライザーを搭載",
+      "充電ケース込みで最大48時間の長時間再生、片耳のみでも8時間使用可能",
+      "片耳わずか3.7gの超軽量設計で長時間の装着でも快適",
+      "最新のBluetooth 6.0を搭載し、開蓋自動接続と低遅延を実現",
+      "14mmの大口径ドライバーと高感度マイクを搭載"
+    ],
+    "negativePoints": [
+      "ケースにディスプレイが搭載されているため、落下時の破損リスクが懸念される"
+    ],
+    "useCases": [
+      "通勤・通学時",
+      "オフィスやカフェでの作業",
+      "オンライン会議",
+      "ジョギングやワークアウト"
+    ],
+    "userStories": [],
+    "userImpression": "ユーザーレビューは確認できなかったが、スペック上は多彩な機能を備えたケースと超軽量イヤホン本体の組み合わせが非常に魅力的。特に最新Bluetooth 6.0や14mm大口径ドライバー、ANCを2,499円という手頃な価格で実現している点は評価できる。",
+    "sources": [
+      {
+        "id": "src-1",
+        "name": "Amazon商品ページ B0H26DMS4G",
+        "url": "https://www.amazon.co.jp/dp/B0H26DMS4G",
+        "tier": "high",
+        "evidenceType": "primary",
+        "publishedAt": "2026-08-11",
+        "author": "Haqquio (Amazon)",
+        "conflictOfInterest": "disclosed",
+        "notes": "製品仕様と公式の宣伝文句を確認"
+      }
+    ],
+    "claims": [
+      {
+        "claim": "充電ケース込みで最大48時間の連続再生",
+        "category": "durability",
+        "confidence": "medium",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "公称値のため実際の再生時間は使用環境（ANCの有無など）により短くなる可能性がある"
+      },
+      {
+        "claim": "Bluetooth 6.0搭載",
+        "category": "quality",
+        "confidence": "high",
+        "supportingSourceIds": [
+          "src-1"
+        ],
+        "crossChecked": false,
+        "notes": "最新規格を採用しているとアピール"
+      }
+    ],
+    "lastInvestigated": "2026-08-11",
+    "competitiveAnalysis": [
+      {
+        "name": "完全ワイヤレスイヤホン Bluetooth 5.4 ANC タッチディスプレイ付き",
+        "asin": "B0D93Q5T5N",
+        "priceComparison": "対象商品は2,499円であるのに対し、競合商品は4,980円であるため、対象商品の方がコストパフォーマンスに優れる。",
+        "featureComparison": [
+          "共通点：タッチディスプレイ搭載ケース、ANC機能",
+          "相違点：対象商品はBluetooth 6.0を搭載しているのに対し、競合商品は5.4。"
+        ],
+        "differentiators": [
+          "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）の利点：最新Bluetooth 6.0と超軽量3.7gを求めるなら迷わずこちら",
+          "完全ワイヤレスイヤホン Bluetooth 5.4 ANC タッチディスプレイ付きの利点：特になし（価格も対象商品より高い）"
+        ]
+      },
+      {
+        "name": "JBL LIVE BUDS 3 スマートタッチディスプレイ搭載",
+        "asin": "B0D6VHFP4H",
+        "priceComparison": "対象商品は2,499円であるのに対し、競合商品は18,480円。対象商品は非常に安価だが、競合商品はJBLの音響技術（LDAC対応など）がある。",
+        "featureComparison": [
+          "共通点：スマートタッチディスプレイ搭載、ノイズキャンセリング",
+          "相違点：競合商品はハイレゾ・LDAC対応で大手オーディオブランドの品質。"
+        ],
+        "differentiators": [
+          "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）の利点：低予算でタッチディスプレイ付きイヤホンを試してみたいならこちら",
+          "JBL LIVE BUDS 3 スマートタッチディスプレイ搭載の利点：音質（ハイレゾ/LDAC）やブランドの信頼性を最優先するなら迷わずこちら"
+        ]
+      },
+      {
+        "name": "ONES MusPlayE イヤホン",
+        "asin": "B0DWDK4K24",
+        "priceComparison": "対象商品は2,499円、競合商品は2,999円で同価格帯。",
+        "featureComparison": [
+          "共通点：多機能タッチスクリーン搭載、ANCノイズキャンセリング",
+          "相違点：競合商品は専用APP連携機能を備えている。"
+        ],
+        "differentiators": [
+          "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）の利点：価格を限界まで抑え、Bluetooth 6.0搭載機種を選びたい場合",
+          "ONES MusPlayE イヤホンの利点：専用アプリによる細かなカスタマイズ機能を利用したい場合"
+        ]
+      },
+      {
+        "name": "TOKATech LUMIPods PRO",
+        "asin": "B0FJXYZ1VL",
+        "priceComparison": "対象商品は2,499円、競合商品は3,999円。",
+        "featureComparison": [
+          "共通点：スマートディスプレイ搭載、ANC機能",
+          "相違点：競合商品はBluetooth 5.4、対象商品はBluetooth 6.0。"
+        ],
+        "differentiators": [
+          "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）の利点：より安価に最新のBluetooth 6.0を試したい場合",
+          "TOKATech LUMIPods PROの利点：デザインや固有の装着感を好む場合"
+        ]
+      },
+      {
+        "name": "明誠 ワイヤレスイヤホン",
+        "asin": "B0DV4BZ11H",
+        "priceComparison": "対象商品は2,499円、競合商品は2,980円で同等の価格帯。",
+        "featureComparison": [
+          "共通点：1.47インチタッチディスプレイ搭載、ANC対応",
+          "相違点：競合商品はBluetooth 5.4。"
+        ],
+        "differentiators": [
+          "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）の利点：最新Bluetooth 6.0の接続安定性を重視する場合",
+          "明誠 ワイヤレスイヤホンの利点：画面サイズ(1.47インチ)が明記されており視認性を求める場合"
+        ]
+      },
+      {
+        "name": "ONES MusPlayE Ai イヤホン",
+        "asin": "B0FM4L5J8L",
+        "priceComparison": "対象商品は2,499円、競合商品は2,999円。",
+        "featureComparison": [
+          "共通点：タッチスクリーン搭載、ANCノイズキャンセリング",
+          "相違点：競合商品はAI通訳などのAI機能やAPP連携に対応。"
+        ],
+        "differentiators": [
+          "イヤホン bluetooth タッチディスプレイ搭載 片耳3.7g 小型軽量（ホワイト）の利点：AI機能などの付加機能が不要で、純粋な音楽再生とシンプルなタッチ操作を求める場合",
+          "ONES MusPlayE Ai イヤホンの利点：AI通訳やAPP連携など、イヤホンの枠を超えたガジェット的機能に魅力を感じる場合"
+        ]
+      }
+    ],
+    "recommendation": {
+      "targetUsers": [
+        "JBL製品などのプレミアムブランドより安価に、話題のタッチスクリーン搭載ケースを試してみたいガジェット好きの人",
+        "長時間の使用でも耳が疲れにくい、超軽量(片耳3.7g)なANCイヤホンを探している人"
+      ],
+      "pros": [
+        "スマホを取り出さずにケース上で音量調整やANCの切り替えなどが完結するため、満員電車や両手が塞がっている時でもストレスフリー",
+        "Bluetooth 6.0と14mm大口径ドライバーの搭載により、2,499円という低価格ながら安定した接続と迫力あるサウンドが期待できる"
+      ],
+      "cons": [
+        "ケースにディスプレイが搭載されている分、落下時や鍵などと一緒にポケットに入れた際の傷・破損には注意が必要"
+      ],
+      "score": 75,
+      "scoreRationale": "[基本点: 70]\n[加点: +5] (2,499円という価格でタッチディスプレイケースとBluetooth 6.0を搭載した抜群のコストパフォーマンス)\n[合計: 75]"
+    },
+    "technicalSpecs": {
+      "color": "ホワイト",
+      "model": "T20",
+      "dimensions": {
+        "height": "60mm",
+        "width": "23mm",
+        "depth": "45mm"
+      },
+      "weight": "片耳約3.7g",
+      "battery": {
+        "capacity": "不明",
+        "charging": "不明"
+      },
+      "os": "非搭載",
+      "cpu": "不明",
+      "ram": "不明",
+      "storage": "不明",
+      "display": {
+        "size": "不明",
+        "resolution": "不明"
+      },
+      "other": [
+        "Bluetooth 6.0",
+        "14mm大口径ドライバー",
+        "ANC（アクティブノイズキャンセリング）対応",
+        "連続再生：最大48時間（ケース込み）、8時間（単体）"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds investigation JSON for ASIN B0H26DMS4G (Haqquio T20). Included competitive analysis of smart screen earbuds. Formatted the output according to strict guidelines including avoiding hallucinations (empty user stories since none exist online) and converting measurements from imperial to metric. Checked constraints via `scripts/validate_artifact.py`.

---
*PR created automatically by Jules for task [12621439011848201674](https://jules.google.com/task/12621439011848201674) started by @aegisfleet*